### PR TITLE
[PAPI-108] Instance Identifiers

### DIFF
--- a/src/Opdex.Platform.Application/Handlers/Indexer/MakeIndexerUnlockCommandHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Indexer/MakeIndexerUnlockCommandHandler.cs
@@ -21,8 +21,6 @@ namespace Opdex.Platform.Application.Handlers.Indexer
 
         public async Task<Unit> Handle(MakeIndexerUnlockCommand request, CancellationToken cancellationToken)
         {
-            // Todo: Calling this command can overwrite another instance that locked indexing.
-            // Considering using an identifier per instance to authorize who can persist the unlock flag
             var unlocked = await _mediator.Send(new PersistIndexerUnlockCommand());
             if (!unlocked)
             {

--- a/src/Opdex.Platform.Common/Configurations/OpdexConfiguration.cs
+++ b/src/Opdex.Platform.Common/Configurations/OpdexConfiguration.cs
@@ -1,5 +1,4 @@
 using Opdex.Platform.Common.Enums;
-using Opdex.Platform.Common.Extensions;
 using System;
 
 namespace Opdex.Platform.Common.Configurations
@@ -8,6 +7,8 @@ namespace Opdex.Platform.Common.Configurations
     {
         public string ConnectionString { get; set; }
         public NetworkType Network { get; set; }
+
+        public string InstanceId { get; } = Guid.NewGuid().ToString();
 
         public void Validate()
         {

--- a/src/Opdex.Platform.Domain/Models/IndexLock.cs
+++ b/src/Opdex.Platform.Domain/Models/IndexLock.cs
@@ -4,15 +4,17 @@ namespace Opdex.Platform.Domain.Models
 {
     public class IndexLock
     {
-        public IndexLock(bool available, bool locked, DateTime modifiedDate)
+        public IndexLock(bool available, bool locked, string instanceId, DateTime modifiedDate)
         {
             Available = available;
             Locked = locked;
             ModifiedDate = modifiedDate;
+            InstanceId = instanceId;
         }
 
         public bool Available { get; }
         public bool Locked { get; }
         public DateTime ModifiedDate { get; }
+        public string InstanceId { get; }
     }
 }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/IndexLockEntity.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/IndexLockEntity.cs
@@ -7,5 +7,6 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Models
         public bool Available { get; set; }
         public bool Locked { get; set; }
         public DateTime ModifiedDate { get; set; }
+        public string InstanceId { get; set; }
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/PersistIndexerLockCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/PersistIndexerLockCommandHandler.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Indexer;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
@@ -14,19 +15,22 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Indexer
             @$"UPDATE index_lock
                SET
                     {nameof(IndexLockEntity.Locked)} = 1,
-                    {nameof(IndexLockEntity.ModifiedDate)} = UTC_TIMESTAMP()
+                    {nameof(IndexLockEntity.ModifiedDate)} = UTC_TIMESTAMP(),
+                    {nameof(IndexLockEntity.InstanceId)} = @{nameof(IndexLockEntity.InstanceId)}
                 WHERE {nameof(IndexLockEntity.Locked)} = 0;";
 
         private readonly IDbContext _context;
+        private readonly string _instanceId;
 
-        public PersistIndexerLockCommandHandler(IDbContext context)
+        public PersistIndexerLockCommandHandler(IDbContext context, OpdexConfiguration opdexConfiguration)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
+            _instanceId = opdexConfiguration?.InstanceId ?? throw new ArgumentNullException(nameof(context));
         }
 
         public async Task<bool> Handle(PersistIndexerLockCommand request, CancellationToken cancellationToken)
         {
-            var command = DatabaseQuery.Create(SqlQuery);
+            var command = DatabaseQuery.Create(SqlQuery, new { InstanceId = _instanceId });
             var result = await _context.ExecuteCommandAsync(command);
             return result == 1;
         }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/PersistIndexerUnlockCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/PersistIndexerUnlockCommandHandler.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Indexer;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
@@ -13,18 +14,22 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Indexer
         private static readonly string SqlQuery =
             $@"UPDATE index_lock SET
                 {nameof(IndexLockEntity.Locked)} = 0,
-                {nameof(IndexLockEntity.ModifiedDate)} = UTC_TIMESTAMP();";
+                {nameof(IndexLockEntity.ModifiedDate)} = UTC_TIMESTAMP(),
+                {nameof(IndexLockEntity.InstanceId)} = NULL
+               WHERE {nameof(IndexLockEntity.InstanceId)} = @{nameof(IndexLockEntity.InstanceId)};";
 
         private readonly IDbContext _context;
+        private readonly string _instanceId;
 
-        public PersistIndexerUnlockCommandHandler(IDbContext context)
+        public PersistIndexerUnlockCommandHandler(IDbContext context, OpdexConfiguration opdexConfiguration)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
+            _instanceId = opdexConfiguration?.InstanceId ?? throw new ArgumentNullException(nameof(context));
         }
 
         public async Task<bool> Handle(PersistIndexerUnlockCommand request, CancellationToken cancellationToken)
         {
-            var command = DatabaseQuery.Create(SqlQuery);
+            var command = DatabaseQuery.Create(SqlQuery, new { InstanceId = _instanceId });
             var result = await _context.ExecuteCommandAsync(command);
             return result == 1;
         }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/SelectIndexerLockQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/SelectIndexerLockQueryHandler.cs
@@ -1,4 +1,3 @@
-using AutoMapper;
 using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models;
@@ -17,17 +16,16 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Indexer
             @$"SELECT
                 {nameof(IndexLockEntity.Available)},
                 {nameof(IndexLockEntity.Locked)},
+                {nameof(IndexLockEntity.InstanceId)},
                 {nameof(IndexLockEntity.ModifiedDate)}
             FROM index_lock
             LIMIT 1;";
 
         private readonly IDbContext _context;
-        private readonly IMapper _mapper;
 
-        public SelectIndexerLockQueryHandler(IDbContext context, IMapper mapper)
+        public SelectIndexerLockQueryHandler(IDbContext context)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
-            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         }
 
         public async Task<IndexLock> Handle(SelectIndexerLockQuery request, CancellationToken cancellationToken)
@@ -41,7 +39,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Indexer
                 throw new NotFoundException($"{nameof(IndexLock)} not found.");
             }
 
-            return new IndexLock(result.Available, result.Locked, result.ModifiedDate);
+            return new IndexLock(result.Available, result.Locked, result.InstanceId, result.ModifiedDate);
         }
     }
 }

--- a/src/Opdex.Platform.WebApi/Controllers/IndexController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/IndexController.cs
@@ -13,6 +13,7 @@ using Opdex.Platform.Application.Abstractions.Queries.Markets;
 using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Common.Enums;
 using Opdex.Platform.WebApi.Models.Requests.Index;
+using Opdex.Platform.WebApi.Models.Responses.Indexer;
 using System.Linq;
 
 namespace Opdex.Platform.WebApi.Controllers
@@ -23,11 +24,13 @@ namespace Opdex.Platform.WebApi.Controllers
     {
         private readonly IMediator _mediator;
         private readonly NetworkType _network;
+        private readonly string _instanceId;
 
         public IndexController(IMediator mediator, OpdexConfiguration opdexConfiguration)
         {
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
             _network = opdexConfiguration?.Network ?? throw new ArgumentNullException(nameof(opdexConfiguration));
+            _instanceId = opdexConfiguration?.InstanceId ?? throw new ArgumentNullException(nameof(opdexConfiguration));
         }
 
 
@@ -43,6 +46,18 @@ namespace Opdex.Platform.WebApi.Controllers
             // Todo: Get Query with ResponseModel
             var latestSyncedBlock = await _mediator.Send(new RetrieveLatestBlockQuery(), cancellationToken);
             return Ok(latestSyncedBlock);
+        }
+
+        /// <summary>
+        /// Retrieve the identifier of this specific host instance.
+        /// </summary>
+        /// <returns>GUID as string identifier</returns>
+        [HttpGet("instance-identity")]
+        [Authorize]
+        [ProducesResponseType(typeof(InstanceIdentityResponseModel), StatusCodes.Status200OK)]
+        public ActionResult<InstanceIdentityResponseModel> InstanceIdentity()
+        {
+            return Ok(new InstanceIdentityResponseModel { Identity = _instanceId });
         }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Indexer/InstanceIdentityResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Indexer/InstanceIdentityResponseModel.cs
@@ -1,0 +1,7 @@
+namespace Opdex.Platform.WebApi.Models.Responses.Indexer
+{
+    public class InstanceIdentityResponseModel
+    {
+        public string Identity { get; set; }
+    }
+}

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Indexer/PersistIndexerLockCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Indexer/PersistIndexerLockCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Moq;
+using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Indexer;
 using Opdex.Platform.Infrastructure.Data.Handlers.Indexer;
@@ -17,7 +18,10 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Indexer
         public PersistIndexerLockCommandHandlerTests()
         {
             _dbContext = new Mock<IDbContext>();
-            _handler = new PersistIndexerLockCommandHandler(_dbContext.Object);
+
+            var opdexConfiguration = new OpdexConfiguration();
+
+            _handler = new PersistIndexerLockCommandHandler(_dbContext.Object, opdexConfiguration);
         }
 
         [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Indexer/PersistIndexerUnlockCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Indexer/PersistIndexerUnlockCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Moq;
+using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Indexer;
 using Opdex.Platform.Infrastructure.Data.Handlers.Indexer;
@@ -17,7 +18,8 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Indexer
         public PersistIndexerUnlockCommandHandlerTests()
         {
             _dbContext = new Mock<IDbContext>();
-            _handler = new PersistIndexerUnlockCommandHandler(_dbContext.Object);
+            var opdexConfiguration = new OpdexConfiguration();
+            _handler = new PersistIndexerUnlockCommandHandler(_dbContext.Object, opdexConfiguration);
         }
 
         [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Indexer/SelectIndexerLockQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Indexer/SelectIndexerLockQueryHandlerTests.cs
@@ -21,10 +21,8 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Indexer
 
         public SelectIndexerLockQueryHandlerTests()
         {
-            var mapper = new MapperConfiguration(config => config.AddProfile(new PlatformInfrastructureMapperProfile())).CreateMapper();
-
             _dbContext = new Mock<IDbContext>();
-            _handler = new SelectIndexerLockQueryHandler(_dbContext.Object, mapper);
+            _handler = new SelectIndexerLockQueryHandler(_dbContext.Object);
         }
 
         [Fact]


### PR DESCRIPTION
- Creates an InstanceId (GUID as string) during startup in the OpdexConfiguration class. 
- Index_Lock table takes an InstanceId column that is persisted when the table is locked, cleared when unlocked
- When the host is shutdown, the indexer background service will unlock the table 