### PR TITLE
[PAPI-223] Add token endpoint

### DIFF
--- a/src/Opdex.Platform.Application.Abstractions/EntryCommands/Tokens/CreateAddTokenCommand.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryCommands/Tokens/CreateAddTokenCommand.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Opdex.Platform.Application.Abstractions.Models.Tokens;
+using Opdex.Platform.Common.Models;
+using System;
+
+namespace Opdex.Platform.Application.Abstractions.EntryCommands.Tokens
+{
+    /// <summary>
+    /// Command to add a new token to the database and return the token details.
+    /// </summary>
+    public class CreateAddTokenCommand : IRequest<TokenDto>
+    {
+        /// <summary>
+        /// Creates a command to add and validate a token and return the token details.
+        /// </summary>
+        /// <param name="token">The address of the token.</param>
+        public CreateAddTokenCommand(Address token)
+        {
+            if (token == Address.Empty)
+            {
+                throw new ArgumentNullException(nameof(token), "Token address must be provided.");
+            }
+
+            Token = token;
+        }
+
+        public Address Token { get; }
+    }
+}

--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateAddTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateAddTokenCommandHandler.cs
@@ -1,0 +1,61 @@
+using AutoMapper;
+using MediatR;
+using Opdex.Platform.Application.Abstractions.Commands.Tokens;
+using Opdex.Platform.Application.Abstractions.EntryCommands.Tokens;
+using Opdex.Platform.Application.Abstractions.EntryQueries.Blocks;
+using Opdex.Platform.Application.Abstractions.Models.Tokens;
+using Opdex.Platform.Application.Abstractions.Queries.Tokens;
+using Opdex.Platform.Application.Exceptions;
+using Opdex.Platform.Common.Exceptions;
+using Opdex.Platform.Domain.Models.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.Tokens;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opdex.Platform.Application.EntryHandlers.Tokens
+{
+    public class CreateAddTokenCommandHandler : IRequestHandler<CreateAddTokenCommand, TokenDto>
+    {
+        private readonly IMapper _mapper;
+        private readonly IMediator _mediator;
+
+        public CreateAddTokenCommandHandler(IMapper mapper, IMediator mediator)
+        {
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        }
+
+        public async Task<TokenDto> Handle(CreateAddTokenCommand request, CancellationToken cancellationToken)
+        {
+            var token = await _mediator.Send(new RetrieveTokenByAddressQuery(request.Token, findOrThrow: false));
+            if (!(token is null))
+            {
+                throw new TokenAlreadyIndexedException(request.Token);
+            }
+
+            var latestBlock = await _mediator.Send(new GetBestBlockReceiptQuery());
+
+            StandardTokenContractSummary summary;
+            try
+            {
+                summary = await _mediator.Send(new CallCirrusGetStandardTokenContractSummaryQuery(request.Token,
+                                                                                                  latestBlock.Height,
+                                                                                                  includeBaseProperties: true,
+                                                                                                  includeTotalSupply: true));
+            }
+            catch (Exception)
+            {
+                throw new InvalidDataException("tokenAddress", "Unable to validate SRC token.");
+            }
+
+            token = new Token(request.Token, summary.IsLpt.Value, summary.Name, summary.Symbol, (int)summary.Decimals.Value, summary.Sats.Value,
+                              summary.TotalSupply.Value, latestBlock.Height);
+
+            var tokenId = await _mediator.Send(new MakeTokenCommand(token, latestBlock.Height));
+            if (tokenId == 0) throw new Exception("Something went wrong when indexing the token.");
+
+            return _mapper.Map<TokenDto>(token);
+        }
+    }
+}

--- a/src/Opdex.Platform.Application/Exceptions/TokenAlreadyIndexedException.cs
+++ b/src/Opdex.Platform.Application/Exceptions/TokenAlreadyIndexedException.cs
@@ -1,0 +1,15 @@
+using Opdex.Platform.Common.Models;
+using System;
+
+namespace Opdex.Platform.Application.Exceptions
+{
+    public class TokenAlreadyIndexedException : Exception
+    {
+        public TokenAlreadyIndexedException(Address token)
+        {
+            Token = token;
+        }
+
+        public Address Token { get; }
+    }
+}

--- a/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
@@ -330,6 +330,7 @@ namespace Opdex.Platform.Application
             services.AddTransient<IRequestHandler<CreateRewindStakingPositionsCommand, bool>, CreateRewindStakingPositionsCommandHandler>();
             services.AddTransient<IRequestHandler<CreateAddressBalanceCommand, ulong>, CreateAddressBalanceCommandHandler>();
             services.AddTransient<IRequestHandler<CreateTokenCommand, ulong>, CreateTokenCommandHandler>();
+            services.AddTransient<IRequestHandler<CreateAddTokenCommand, TokenDto>, CreateAddTokenCommandHandler>();
             services.AddTransient<IRequestHandler<CreateRewindTokenDailySnapshotCommand, bool>, CreateRewindTokenDailySnapshotCommandHandler>();
             services.AddTransient<IRequestHandler<CreateSwapTransactionQuoteCommand, TransactionQuoteDto>, CreateSwapTransactionQuoteCommandHandler>();
 

--- a/src/Opdex.Platform.WebApi/Controllers/TokensController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/TokensController.cs
@@ -7,12 +7,14 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Opdex.Platform.Application.Abstractions.EntryCommands.Tokens;
 using Opdex.Platform.Application.Abstractions.EntryCommands.Tokens.Quotes;
 using Opdex.Platform.Application.Abstractions.EntryQueries.Tokens;
 using Opdex.Platform.Application.Abstractions.EntryQueries.Tokens.Snapshots;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.WebApi.Models;
+using Opdex.Platform.WebApi.Models.Requests.Tokens;
 using Opdex.Platform.WebApi.Models.Requests.WalletTransactions;
 using Opdex.Platform.WebApi.Models.Responses.Tokens;
 using Opdex.Platform.WebApi.Models.Responses.Transactions;
@@ -62,6 +64,29 @@ namespace Opdex.Platform.WebApi.Controllers
             var response = _mapper.Map<IEnumerable<TokenResponseModel>>(result);
 
             return Ok(response);
+        }
+
+        /// <summary>
+        /// Add Token
+        /// </summary>
+        /// <remarks>Adds an SRC token to the Opdex indexer that can be tracked and used within markets.</remarks>
+        /// <param name="request">Token details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Token details.</returns>
+        /// <response code="201">The token was added to indexed tokens.</response>
+        /// <response code="303">Token is already indexed.</response>
+        /// <response code="422">The address provided was not a valid token.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(TokenResponseModel), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status303SeeOther)]
+        [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+        public async Task<IActionResult> AddToken([FromBody] AddTokenRequest request, CancellationToken cancellationToken)
+        {
+            var result = await _mediator.Send(new CreateAddTokenCommand(request.TokenAddress), cancellationToken);
+
+            var response = _mapper.Map<TokenResponseModel>(result);
+
+            return Created($"/tokens/{request.TokenAddress}", response);
         }
 
         /// <summary>Get Token</summary>

--- a/src/Opdex.Platform.WebApi/Middleware/ConfigurationValidationStartupFilter.cs
+++ b/src/Opdex.Platform.WebApi/Middleware/ConfigurationValidationStartupFilter.cs
@@ -9,6 +9,7 @@ namespace Opdex.Platform.WebApi.Middleware
     public class ConfigurationValidationStartupFilter : IStartupFilter
     {
         readonly IEnumerable<IValidatable> _validatableObjects;
+
         public ConfigurationValidationStartupFilter(IEnumerable<IValidatable> validatableObjects)
         {
             _validatableObjects = validatableObjects;

--- a/src/Opdex.Platform.WebApi/Middleware/RedirectToResourceMiddleware.cs
+++ b/src/Opdex.Platform.WebApi/Middleware/RedirectToResourceMiddleware.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Opdex.Platform.Application.Exceptions;
+using System;
+using System.Threading.Tasks;
+
+namespace Opdex.Platform.WebApi.Middleware
+{
+    /// <summary>
+    /// Provides middleware for returning redirect responses based on exceptions thrown.
+    /// </summary>
+    public class RedirectToResourceMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public RedirectToResourceMiddleware(RequestDelegate next)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            try
+            {
+                await _next(httpContext);
+            }
+            catch (TokenAlreadyIndexedException e)
+            {
+                httpContext.Response.Headers.Add(HeaderNames.Location, $"/tokens/{e.Token}");
+                httpContext.Response.StatusCode = StatusCodes.Status303SeeOther;
+                await httpContext.Response.CompleteAsync();
+            }
+        }
+    }
+}

--- a/src/Opdex.Platform.WebApi/Models/Requests/Tokens/AddTokenRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Tokens/AddTokenRequest.cs
@@ -1,0 +1,15 @@
+using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace Opdex.Platform.WebApi.Models.Requests.Tokens
+{
+    /// <summary>
+    /// Request body to add a token.
+    /// </summary>
+    public class AddTokenRequest
+    {
+        /// <summary>The address of the SRC token.</summary>
+        [Required]
+        public Address TokenAddress { get; set; }
+    }
+}

--- a/src/Opdex.Platform.WebApi/Startup.cs
+++ b/src/Opdex.Platform.WebApi/Startup.cs
@@ -216,6 +216,7 @@ namespace Opdex.Platform.WebApi
             }
 
             app.UseProblemDetails();
+            app.UseMiddleware<RedirectToResourceMiddleware>();
             app.UseCors(options => options
                             .SetIsOriginAllowed(host => true)
                             .AllowAnyHeader()

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/CreateAddTokenCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/CreateAddTokenCommandHandlerTests.cs
@@ -1,0 +1,202 @@
+using AutoMapper;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Opdex.Platform.Application.Abstractions.Commands.Tokens;
+using Opdex.Platform.Application.Abstractions.EntryCommands.Tokens;
+using Opdex.Platform.Application.Abstractions.EntryQueries.Blocks;
+using Opdex.Platform.Application.Abstractions.Models.Tokens;
+using Opdex.Platform.Application.Abstractions.Queries.Tokens;
+using Opdex.Platform.Application.EntryHandlers.Tokens;
+using Opdex.Platform.Application.Exceptions;
+using Opdex.Platform.Common.Exceptions;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Domain.Models.Blocks;
+using Opdex.Platform.Domain.Models.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.Tokens;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.Application.Tests.EntryHandlers.Tokens
+{
+    public class CreateAddTokenCommandHandlerTests
+    {
+        private readonly Mock<IMapper> _mockMapper;
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly CreateAddTokenCommandHandler _handler;
+
+        public CreateAddTokenCommandHandlerTests()
+        {
+            _mockMapper = new Mock<IMapper>();
+            _mockMediator = new Mock<IMediator>();
+            _handler = new CreateAddTokenCommandHandler(_mockMapper.Object, _mockMediator.Object);
+        }
+
+        [Fact]
+        public async Task Handle_TokenAlreadyIndexed_ThrowTokenAlreadyIndexedException()
+        {
+            // Arrange
+            Address tokenAddress = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            var token = new Token(1, tokenAddress, false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
+
+            // Act
+            Task Act() => _handler.Handle(new CreateAddTokenCommand(tokenAddress), CancellationToken.None);
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<TokenAlreadyIndexedException>(Act);
+            exception.Token.Should().Be(tokenAddress);
+        }
+
+        [Fact]
+        public async Task Handle_GetBestBlockReceiptQuery_Send()
+        {
+            // Arrange
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync((Token)null);
+
+            // Act
+            try
+            {
+                await _handler.Handle(new CreateAddTokenCommand("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV"), CancellationToken.None);
+            }
+            catch (Exception) { }
+
+            // Assert
+            _mockMediator.Verify(callTo => callTo.Send(It.IsAny<GetBestBlockReceiptQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_CallCirrusGetStandardTokenContractSummaryQuery_Send()
+        {
+            // Arrange
+            Address tokenAddress = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            var blockReceipt = new BlockReceipt("59218de9ed9bc1df4400fdf4b968ec6ca42baccbdb7f25c923345ba84d5eb5b3", 5000, DateTime.Now, DateTime.Now,
+                                                "bec4d5e4f8d01f8741ccd268504d8b9a1086273ad2fca90eed55096da9bc910b",
+                                                "4d35ea70ce77c42fad7852045694c3c0ec30a7aa069e9cec769f344f14d3d9f9",
+                                                "ad0bea2255c37ec43daa5446f2599b9f23bd36ec79ab52c2323470d0e08b718d", Enumerable.Empty<string>());
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync((Token)null);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<GetBestBlockReceiptQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockReceipt);
+
+            // Act
+            try
+            {
+                await _handler.Handle(new CreateAddTokenCommand(tokenAddress), CancellationToken.None);
+            }
+            catch (Exception) { }
+
+            // Assert
+            _mockMediator.Verify(callTo => callTo.Send(It.Is<CallCirrusGetStandardTokenContractSummaryQuery>(query => query.Token == tokenAddress
+                                                                                                                   && query.BlockHeight == blockReceipt.Height
+                                                                                                                   && query.IncludeBaseProperties
+                                                                                                                   && query.IncludeTotalSupply), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_CallCirrusGetStandardTokenContractSummaryQueryFails_ThrowInvalidDataException()
+        {
+            // Arrange
+            var blockReceipt = new BlockReceipt("59218de9ed9bc1df4400fdf4b968ec6ca42baccbdb7f25c923345ba84d5eb5b3", 5000, DateTime.Now, DateTime.Now,
+                                                "bec4d5e4f8d01f8741ccd268504d8b9a1086273ad2fca90eed55096da9bc910b",
+                                                "4d35ea70ce77c42fad7852045694c3c0ec30a7aa069e9cec769f344f14d3d9f9",
+                                                "ad0bea2255c37ec43daa5446f2599b9f23bd36ec79ab52c2323470d0e08b718d", Enumerable.Empty<string>());
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync((Token)null);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<GetBestBlockReceiptQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockReceipt);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<CallCirrusGetStandardTokenContractSummaryQuery>(), It.IsAny<CancellationToken>()))
+                         .ThrowsAsync(new Exception("Call to Cirrus failed"));
+
+            // Act
+            Task Act() => _handler.Handle(new CreateAddTokenCommand("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV"), CancellationToken.None);
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(Act);
+            exception.Message.Should().Be("Unable to validate SRC token.");
+        }
+
+        [Fact]
+        public async Task Handle_MakeTokenCommand_Send()
+        {
+            // Arrange
+            Address tokenAddress = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            var blockReceipt = new BlockReceipt("59218de9ed9bc1df4400fdf4b968ec6ca42baccbdb7f25c923345ba84d5eb5b3", 5000, DateTime.Now, DateTime.Now,
+                                                "bec4d5e4f8d01f8741ccd268504d8b9a1086273ad2fca90eed55096da9bc910b",
+                                                "4d35ea70ce77c42fad7852045694c3c0ec30a7aa069e9cec769f344f14d3d9f9",
+                                                "ad0bea2255c37ec43daa5446f2599b9f23bd36ec79ab52c2323470d0e08b718d", Enumerable.Empty<string>());
+            var tokenSummary = new StandardTokenContractSummary(blockReceipt.Height);
+            tokenSummary.SetBaseProperties("Bitcoin (Wrapped)", "xBTC", 8);
+            tokenSummary.SetTotalSupply(2100000000000000);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync((Token)null);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<GetBestBlockReceiptQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockReceipt);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<CallCirrusGetStandardTokenContractSummaryQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(tokenSummary);
+
+            // Act
+            try
+            {
+                await _handler.Handle(new CreateAddTokenCommand(tokenAddress), CancellationToken.None);
+            }
+            catch (Exception) { }
+
+            // Assert
+            _mockMediator.Verify(callTo => callTo.Send(It.Is<MakeTokenCommand>(query => query.Token.Address == tokenAddress && query.BlockHeight == blockReceipt.Height),
+                                                       It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_MakeTokenCommandFails_ThrowException()
+        {
+            // Arrange
+            Address tokenAddress = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            var blockReceipt = new BlockReceipt("59218de9ed9bc1df4400fdf4b968ec6ca42baccbdb7f25c923345ba84d5eb5b3", 5000, DateTime.Now, DateTime.Now,
+                                                "bec4d5e4f8d01f8741ccd268504d8b9a1086273ad2fca90eed55096da9bc910b",
+                                                "4d35ea70ce77c42fad7852045694c3c0ec30a7aa069e9cec769f344f14d3d9f9",
+                                                "ad0bea2255c37ec43daa5446f2599b9f23bd36ec79ab52c2323470d0e08b718d", Enumerable.Empty<string>());
+            var tokenSummary = new StandardTokenContractSummary(blockReceipt.Height);
+            tokenSummary.SetBaseProperties("Bitcoin (Wrapped)", "xBTC", 8);
+            tokenSummary.SetTotalSupply(2100000000000000);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync((Token)null);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<GetBestBlockReceiptQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockReceipt);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<CallCirrusGetStandardTokenContractSummaryQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(tokenSummary);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<MakeTokenCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(0UL);
+
+            // Act
+            Task Act() => _handler.Handle(new CreateAddTokenCommand(tokenAddress), CancellationToken.None);
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<Exception>(Act);
+            exception.Message.Should().Be("Something went wrong when indexing the token.");
+        }
+
+        [Fact]
+        public async Task Handle_Token_MapResponse()
+        {
+            // Arrange
+            Address tokenAddress = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            var blockReceipt = new BlockReceipt("59218de9ed9bc1df4400fdf4b968ec6ca42baccbdb7f25c923345ba84d5eb5b3", 5000, DateTime.Now, DateTime.Now,
+                                                "bec4d5e4f8d01f8741ccd268504d8b9a1086273ad2fca90eed55096da9bc910b",
+                                                "4d35ea70ce77c42fad7852045694c3c0ec30a7aa069e9cec769f344f14d3d9f9",
+                                                "ad0bea2255c37ec43daa5446f2599b9f23bd36ec79ab52c2323470d0e08b718d", Enumerable.Empty<string>());
+            var tokenSummary = new StandardTokenContractSummary(blockReceipt.Height);
+            tokenSummary.SetBaseProperties("Bitcoin (Wrapped)", "xBTC", 8);
+            tokenSummary.SetTotalSupply(2100000000000000);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync((Token)null);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<GetBestBlockReceiptQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockReceipt);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<CallCirrusGetStandardTokenContractSummaryQuery>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(tokenSummary);
+            _mockMediator.Setup(callTo => callTo.Send(It.IsAny<MakeTokenCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(1UL);
+
+            // Act
+            try
+            {
+                await _handler.Handle(new CreateAddTokenCommand(tokenAddress), CancellationToken.None);
+            }
+            catch (Exception) { }
+
+            // Assert
+            _mockMapper.Verify(callTo => callTo.Map<TokenDto>(It.Is<Token>(token => token.Address == tokenAddress)));
+        }
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Controllers/TokensControllerTests/AddTokenTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Controllers/TokensControllerTests/AddTokenTests.cs
@@ -1,0 +1,58 @@
+using AutoMapper;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Opdex.Platform.Application.Abstractions.EntryCommands.Tokens;
+using Opdex.Platform.Application.Abstractions.Models.Tokens;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Controllers;
+using Opdex.Platform.WebApi.Models;
+using Opdex.Platform.WebApi.Models.Requests.Tokens;
+using Opdex.Platform.WebApi.Models.Responses.Tokens;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Controllers.TokensControllerTests
+{
+    public class AddTokenTests
+    {
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly Mock<IApplicationContext> _contextMock;
+        private readonly TokensController _controller;
+
+        public AddTokenTests()
+        {
+            _mapperMock = new Mock<IMapper>();
+            _mediatorMock = new Mock<IMediator>();
+            _contextMock = new Mock<IApplicationContext>();
+
+            _controller = new TokensController(_mediatorMock.Object, _mapperMock.Object, _contextMock.Object);
+        }
+
+        [Fact]
+        public async Task AddToken_Succeess_ReturnCreated()
+        {
+            // Arrange
+            Address token = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDda3";
+
+            var request = new AddTokenRequest { TokenAddress = token };
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            var responseBody = new TokenResponseModel();
+
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<CreateAddTokenCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(new TokenDto());
+            _mapperMock.Setup(callTo => callTo.Map<TokenResponseModel>(It.IsAny<TokenDto>())).Returns(responseBody);
+
+            // Act
+            var response = await _controller.AddToken(request, cancellationToken);
+
+            // Act
+            response.Should().BeOfType<CreatedResult>();
+            ((CreatedResult)response).Value.Should().Be(responseBody);
+            ((CreatedResult)response).Location.Should().Be("/tokens/PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDda3");
+        }
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Middleware/RedirectToResourceMiddlewareTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Middleware/RedirectToResourceMiddlewareTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Opdex.Platform.Application.Exceptions;
+using Opdex.Platform.WebApi.Middleware;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Middleware
+{
+    public class RedirectToResourceMiddlewareTests
+    {
+        [Fact]
+        public async Task Invoke_RegularException_Next()
+        {
+            // Arrange
+            using var host = await CreateHost();
+
+            // Act
+            HttpResponseMessage response = null;
+            try
+            {
+                response = await host.GetTestClient().GetAsync("/generic-exception");
+            }
+            catch (Exception) { }
+
+            // Assert
+            response?.StatusCode.Should().NotBe(StatusCodes.Status303SeeOther);
+        }
+
+        [Fact]
+        public async Task Invoke_TokenAlreadyIndexedException_Intercept()
+        {
+            // Arrange
+            using var host = await CreateHost();
+
+            // Act
+            var response = await host.GetTestClient().GetAsync("/token-already-indexed-exception");
+
+            // Assert
+            response.StatusCode.Should().Be(StatusCodes.Status303SeeOther);
+        }
+
+        private async Task<IHost> CreateHost()
+        {
+            return await new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder
+                        .UseTestServer()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddRouting();
+                        })
+                        .Configure(app =>
+                        {
+                            app.UseMiddleware<RedirectToResourceMiddleware>();
+                            app.UseRouting();
+                            app.UseEndpoints(builder =>
+                            {
+                                builder.MapGet("/token-already-indexed-exception", context =>
+                                {
+                                    throw new TokenAlreadyIndexedException("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+                                });
+                                builder.MapGet("/generic-exception", context =>
+                                {
+                                    throw new Exception("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+                                });
+                            });
+
+                        });
+                })
+                .StartAsync();
+        }
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Opdex.Platform.WebApi.Tests.csproj
+++ b/test/Opdex.Platform.WebApi.Tests/Opdex.Platform.WebApi.Tests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.19" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
* Adds a `/POST tokens` endpoint to be able to validate and index a token
* Middleware for responding with redirects (303 See Other), which is done when a user tries to add a token that already exists

From the [RFC7231 HTTP spec](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.3),
>   If the result of processing a POST would be equivalent to a
   representation of an existing resource, an origin server MAY redirect
   the user agent to that resource by sending a 303 (See Other) response
   with the existing resource's identifier in the Location field.