### PR TITLE
Various Small Bugs

### DIFF
--- a/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/GetLiquidityPoolAddLiquidityAmountInQuoteQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/GetLiquidityPoolAddLiquidityAmountInQuoteQuery.cs
@@ -4,9 +4,9 @@ using System;
 
 namespace Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools
 {
-    public class GetLiquidityPoolAddLiquidityQuoteQuery : IRequest<FixedDecimal>
+    public class GetLiquidityPoolAddLiquidityAmountInQuoteQuery : IRequest<FixedDecimal>
     {
-        public GetLiquidityPoolAddLiquidityQuoteQuery(FixedDecimal amountIn, Address tokenIn, Address pool, Address market)
+        public GetLiquidityPoolAddLiquidityAmountInQuoteQuery(FixedDecimal amountIn, Address tokenIn, Address pool, Address market)
         {
             if (tokenIn == Address.Empty)
             {

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
@@ -8,6 +8,7 @@ namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools
     {
         public ulong Id { get; set; }
         public Address Address { get; set; }
+        public decimal TransactionFee { get; set; }
         public bool StakingEnabled { get; set; }
         public MiningPoolDto MiningPool { get; set; }
         public TokenDto SrcToken { get; set; }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/StakingDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/StakingDto.cs
@@ -9,6 +9,7 @@ namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools
         public UInt256 Weight { get; set; }
         public decimal Usd { get; set; }
         public decimal? WeightDailyChange { get; set; }
+        public bool IsNominated { get; set; }
 
         public void SetDailyChange(UInt256 previousWeight)
         {

--- a/src/Opdex.Platform.Application.Abstractions/Queries/LiquidityPools/RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Queries/LiquidityPools/RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Opdex.Platform.Application.Abstractions.Queries.LiquidityPools
 {
-    public class RetrieveLiquidityPoolAddLiquidityQuoteQuery : IRequest<UInt256>
+    public class RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery : IRequest<UInt256>
     {
-        public RetrieveLiquidityPoolAddLiquidityQuoteQuery(UInt256 amountIn, Address tokenIn, Address pool, Address router)
+        public RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery(UInt256 amountIn, Address tokenIn, Address pool, Address router)
         {
             if (tokenIn == Address.Empty)
             {

--- a/src/Opdex.Platform.Application/EntryHandlers/LiquidityPools/GetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/LiquidityPools/GetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler.cs
@@ -3,7 +3,6 @@ using Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools;
 using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
 using Opdex.Platform.Application.Abstractions.Queries.Markets;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
-using Opdex.Platform.Common.Constants;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using System;
@@ -12,16 +11,16 @@ using System.Threading.Tasks;
 
 namespace Opdex.Platform.Application.EntryHandlers.LiquidityPools
 {
-    public class GetLiquidityPoolAddLiquidityQuoteQueryHandler : IRequestHandler<GetLiquidityPoolAddLiquidityQuoteQuery, FixedDecimal>
+    public class GetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler : IRequestHandler<GetLiquidityPoolAddLiquidityAmountInQuoteQuery, FixedDecimal>
     {
         private readonly IMediator _mediator;
 
-        public GetLiquidityPoolAddLiquidityQuoteQueryHandler(IMediator mediator)
+        public GetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler(IMediator mediator)
         {
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         }
 
-        public async Task<FixedDecimal> Handle(GetLiquidityPoolAddLiquidityQuoteQuery request, CancellationToken cancellationToken)
+        public async Task<FixedDecimal> Handle(GetLiquidityPoolAddLiquidityAmountInQuoteQuery request, CancellationToken cancellationToken)
         {
             var tokenInIsCrs = request.TokenIn == Address.Cirrus;
             var tokenIn = await _mediator.Send(new RetrieveTokenByAddressQuery(request.TokenIn), cancellationToken);
@@ -35,8 +34,8 @@ namespace Opdex.Platform.Application.EntryHandlers.LiquidityPools
 
             var amountIn = request.AmountIn.ToSatoshis(tokenIn.Decimals);
 
-            var quote = await _mediator.Send(new RetrieveLiquidityPoolAddLiquidityQuoteQuery(amountIn, request.TokenIn,
-                                                                                             request.Pool, router.Address), cancellationToken);
+            var quote = await _mediator.Send(new RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery(amountIn, request.TokenIn,
+                                                                                                     request.Pool, router.Address), cancellationToken);
 
             return quote.ToDecimal(tokenOut.Decimals);
         }

--- a/src/Opdex.Platform.Application/Handlers/LiquidityPools/RetrieveLiquidityPoolAddLiquidityQuoteQueryHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/LiquidityPools/RetrieveLiquidityPoolAddLiquidityQuoteQueryHandler.cs
@@ -10,16 +10,16 @@ using System.Threading.Tasks;
 
 namespace Opdex.Platform.Application.Handlers.LiquidityPools
 {
-    public class RetrieveLiquidityPoolAddLiquidityQuoteQueryHandler : IRequestHandler<RetrieveLiquidityPoolAddLiquidityQuoteQuery, UInt256>
+    public class RetrieveLiquidityPoolAddLiquidityAmountInQuoteQueryHandler : IRequestHandler<RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery, UInt256>
     {
         private readonly IMediator _mediator;
 
-        public RetrieveLiquidityPoolAddLiquidityQuoteQueryHandler(IMediator mediator)
+        public RetrieveLiquidityPoolAddLiquidityAmountInQuoteQueryHandler(IMediator mediator)
         {
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         }
 
-        public async Task<UInt256> Handle(RetrieveLiquidityPoolAddLiquidityQuoteQuery request, CancellationToken cancellationToken)
+        public async Task<UInt256> Handle(RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery request, CancellationToken cancellationToken)
         {
             var reserves = await _mediator.Send(new CallCirrusGetOpdexLiquidityPoolReservesQuery(request.Pool), cancellationToken);
 
@@ -28,7 +28,7 @@ namespace Opdex.Platform.Application.Handlers.LiquidityPools
             var reserveIn = request.TokenIn == Address.Cirrus ? reservesCrs : reservesSrc;
             var reserveOut = request.TokenIn == Address.Cirrus ? reservesSrc : reservesCrs;
 
-            return await _mediator.Send(new CallCirrusGetAddLiquidityQuoteQuery(request.AmountIn, reserveIn, reserveOut, request.Router), cancellationToken);
+            return await _mediator.Send(new CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery(request.AmountIn, reserveIn, reserveOut, request.Router), cancellationToken);
         }
     }
 }

--- a/src/Opdex.Platform.Application/Handlers/Transactions/MakeNotifyUserOfTransactionBroadcastCommandHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Transactions/MakeNotifyUserOfTransactionBroadcastCommandHandler.cs
@@ -12,6 +12,9 @@ namespace Opdex.Platform.Application.Handlers.Transactions
     {
         private readonly IMediator _mediator;
 
+        private const int MaxRetries = 3; // Retry mempool times
+        private const int Backoff = 5; // seconds prior to retry
+
         public MakeNotifyUserOfTransactionBroadcastCommandHandler(IMediator mediator)
         {
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
@@ -19,10 +22,33 @@ namespace Opdex.Platform.Application.Handlers.Transactions
 
         public async Task<bool> Handle(MakeNotifyUserOfTransactionBroadcastCommand request, CancellationToken cancellationToken)
         {
-            var existsInMempool = await _mediator.Send(new CallCirrusGetExistsInMempoolQuery(request.TransactionHash), cancellationToken);
+            int attempt = 0;
+            bool existsInMempool = false;
+
+            // Retry up to MaxRetries times with the configured Backoff in seconds in between attempts
+            while (++attempt <= MaxRetries)
+            {
+                try
+                {
+                    if (attempt > 1) await Task.Delay(TimeSpan.FromSeconds(Backoff));
+
+                    existsInMempool = await _mediator.Send(new CallCirrusGetExistsInMempoolQuery(request.TransactionHash), cancellationToken);
+
+                    if (!existsInMempool) continue;
+
+                    break;
+                }
+                catch
+                {
+                    existsInMempool = false;
+                }
+            }
+
+            // Do not notify if we never found the transaction in the mempool
             if (!existsInMempool) return false;
 
             await _mediator.Send(new NotifyUserOfBroadcastTransactionCommand(request.User, request.TransactionHash), cancellationToken);
+
             return true;
         }
     }

--- a/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
@@ -204,7 +204,7 @@ namespace Opdex.Platform.Application
             // Liquidity Pools
             services.AddTransient<IRequestHandler<GetLiquidityPoolsWithFilterQuery, IEnumerable<LiquidityPoolDto>>, GetLiquidityPoolsWithFilterQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityPoolSwapQuoteQuery, FixedDecimal>, GetLiquidityPoolSwapQuoteQueryHandler>();
-            services.AddTransient<IRequestHandler<GetLiquidityPoolAddLiquidityQuoteQuery, FixedDecimal>, GetLiquidityPoolAddLiquidityQuoteQueryHandler>();
+            services.AddTransient<IRequestHandler<GetLiquidityPoolAddLiquidityAmountInQuoteQuery, FixedDecimal>, GetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityPoolSnapshotsWithFilterQuery, IEnumerable<LiquidityPoolSnapshotDto>>, GetLiquidityPoolSnapshotsWithFilterQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityPoolByAddressQuery, LiquidityPoolDto>, GetLiquidityPoolByAddressQueryHandler>();
 
@@ -404,7 +404,7 @@ namespace Opdex.Platform.Application
             services.AddTransient<IRequestHandler<RetrieveLiquidityPoolSnapshotsWithFilterQuery, IEnumerable<LiquidityPoolSnapshot>>, RetrieveLiquidityPoolSnapshotsWithFilterQueryHandler>();
             services.AddTransient<IRequestHandler<RetrieveLiquidityPoolSnapshotWithFilterQuery, LiquidityPoolSnapshot>, RetrieveLiquidityPoolSnapshotWithFilterQueryHandler>();
             services.AddTransient<IRequestHandler<RetrieveLiquidityPoolSwapQuoteQuery, UInt256>, RetrieveLiquidityPoolSwapQuoteQueryHandler>();
-            services.AddTransient<IRequestHandler<RetrieveLiquidityPoolAddLiquidityQuoteQuery, UInt256>, RetrieveLiquidityPoolAddLiquidityQuoteQueryHandler>();
+            services.AddTransient<IRequestHandler<RetrieveLiquidityPoolAddLiquidityAmountInQuoteQuery, UInt256>, RetrieveLiquidityPoolAddLiquidityAmountInQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<RetrieveLiquidityPoolByLpTokenIdQuery, LiquidityPool>, RetrieveLiquidityPoolByLpTokenIdQueryHandler>();
             services.AddTransient<IRequestHandler<RetrieveLiquidityPoolByIdQuery, LiquidityPool>, RetrieveLiquidityPoolByIdQueryHandler>();
             services.AddTransient<IRequestHandler<RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQuery, LiquidityPool>, RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler>();

--- a/src/Opdex.Platform.Domain/Models/Transactions/Transaction.cs
+++ b/src/Opdex.Platform.Domain/Models/Transactions/Transaction.cs
@@ -111,11 +111,12 @@ namespace Opdex.Platform.Domain.Models.Transactions
 
         public void ValidateLogTypeEligibility()
         {
+            // Todo: Failed transactions won't have logs.
             // No logs is most likely ineligible
             if (!Logs.Any())
             {
-                // Only transactions without logs could be new contract deployments in which we'll validate.
-                EligibilityStatus = NewContractAddress == Address.Empty
+                // Only transactions without logs could be new contract deployments or errored transactions in which we'll validate.
+                EligibilityStatus = NewContractAddress == Address.Empty || !Success
                     ? TransactionEligibilityType.Ineligible
                     : TransactionEligibilityType.PendingContractValidation;
 

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Queries/LiquidityPools/LiquidityQuotes/CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Queries/LiquidityPools/LiquidityQuotes/CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.LiquidityPools.LiquidityQuotes
 {
-    public class CallCirrusGetAddLiquidityQuoteQuery : IRequest<UInt256>
+    public class CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery : IRequest<UInt256>
     {
-        public CallCirrusGetAddLiquidityQuoteQuery(UInt256 amountA, UInt256 reserveA, UInt256 reserveB, Address market)
+        public CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery(UInt256 amountA, UInt256 reserveA, UInt256 reserveB, Address market)
         {
             if (market == Address.Empty)
             {

--- a/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Handlers/LiquidityPools/LiquidityQuotes/CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Handlers/LiquidityPools/LiquidityQuotes/CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler.cs
@@ -9,16 +9,16 @@ using System.Threading.Tasks;
 
 namespace Opdex.Platform.Infrastructure.Clients.CirrusFullNodeApi.Handlers.LiquidityPools.LiquidityQuotes
 {
-    public class CallCirrusGetAddLiquidityQuoteQueryHandler : IRequestHandler<CallCirrusGetAddLiquidityQuoteQuery, UInt256>
+    public class CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler : IRequestHandler<CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery, UInt256>
     {
         private readonly ISmartContractsModule _smartContractsModule;
 
-        public CallCirrusGetAddLiquidityQuoteQueryHandler(ISmartContractsModule smartContractsModule)
+        public CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler(ISmartContractsModule smartContractsModule)
         {
             _smartContractsModule = smartContractsModule ?? throw new ArgumentNullException(nameof(smartContractsModule));
         }
 
-        public async Task<UInt256> Handle(CallCirrusGetAddLiquidityQuoteQuery request, CancellationToken cancellationToken)
+        public async Task<UInt256> Handle(CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery request, CancellationToken cancellationToken)
         {
             var quoteParams = new[] { $"12#{request.AmountA}", $"12#{request.ReserveA}", $"12#{request.ReserveB}" };
             var localCall = new LocalCallRequestDto(request.Market, request.Market, "GetLiquidityQuote", quoteParams);

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureServiceCollectionExtensions.cs
@@ -322,7 +322,7 @@ namespace Opdex.Platform.Infrastructure
             services.AddTransient<IRequestHandler<CallCirrusGetAmountInStandardQuoteQuery, UInt256>, CallCirrusGetAmountInStandardQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<CallCirrusGetAmountOutMultiHopQuoteQuery, UInt256>, CallCirrusGetAmountOutMultiHopQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<CallCirrusGetAmountInMultiHopQuoteQuery, UInt256>, CallCirrusGetAmountInMultiHopQuoteQueryHandler>();
-            services.AddTransient<IRequestHandler<CallCirrusGetAddLiquidityQuoteQuery, UInt256>, CallCirrusGetAddLiquidityQuoteQueryHandler>();
+            services.AddTransient<IRequestHandler<CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQuery, UInt256>, CallCirrusGetLiquidityPoolAddLiquidityAmountInQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<CallCirrusGetBlockHashByHeightQuery, string>, CallCirrusGetBlockHashByHeightQueryHandler>();
             services.AddTransient<IRequestHandler<CallCirrusGetSrcTokenBalanceQuery, UInt256>, CallCirrusGetSrcTokenBalanceQueryHandler>();
             services.AddTransient<IRequestHandler<CallCirrusGetGovernanceNominationsSummaryQuery, IEnumerable<GovernanceContractNominationSummary>>, CallCirrusGetGovernanceNominationsSummaryQueryHandler>();

--- a/src/Opdex.Platform.WebApi/Controllers/LiquidityPoolsController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/LiquidityPoolsController.cs
@@ -18,6 +18,8 @@ using Opdex.Platform.WebApi.Models.Responses.Pools;
 using Opdex.Platform.WebApi.Models.Responses.Transactions;
 using System.Linq;
 using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.Quotes;
+using System.Net;
 
 namespace Opdex.Platform.WebApi.Controllers
 {
@@ -168,6 +170,26 @@ namespace Opdex.Platform.WebApi.Controllers
             var quote = _mapper.Map<TransactionQuoteResponseModel>(response);
 
             return Ok(quote);
+        }
+
+        /// <summary>Add Liquidity Amount In Quote</summary>
+        /// <remarks>Providing an amount of tokenA in a liquidity pool, returns an equal amount of tokenB for liquidity provisioning.</remarks>
+        /// <param name="address">The liquidity pool address.</param>
+        /// <param name="request">Request model detailing how many of which tokens are desired to be deposited.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <returns>The quoted number of tokens to be deposited.</returns>
+        [HttpPost("{address}/add/amount-in")]
+        [ProducesResponseType(typeof(AddLiquidityAmountInQuoteResponseModel), (int)HttpStatusCode.OK)]
+        public async Task<ActionResult<AddLiquidityAmountInQuoteResponseModel>> AddLiquidityAmountInQuote([FromRoute] Address address,
+                                                                                                          [FromBody] AddLiquidityQuoteRequestModel request,
+                                                                                                          CancellationToken cancellationToken)
+        {
+            var result = await _mediator.Send(new GetLiquidityPoolAddLiquidityAmountInQuoteQuery(request.AmountIn, request.TokenIn,
+                                                                                                 address, _context.Market), cancellationToken);
+
+            var response = new AddLiquidityAmountInQuoteResponseModel { AmountIn = result };
+
+            return Ok(response);
         }
 
         /// <summary>Remove Liquidity Quote</summary>

--- a/src/Opdex.Platform.WebApi/Controllers/QuoteController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/QuoteController.cs
@@ -52,22 +52,5 @@ namespace Opdex.Platform.WebApi.Controllers
 
             return Ok(result);
         }
-
-        /// <summary>Add Liquidity Amount</summary>
-        /// <remarks>
-        /// Gets a quote for how many tokens are required to be input given the other token in a pool's desired input amount.
-        /// </remarks>
-        /// <param name="request">Request model detailing how many of which tokens are desired to be deposited.</param>
-        /// <param name="cancellationToken">Cancellation Token</param>
-        /// <returns>The number of tokens to match the desired input amount of tokens.</returns>
-        [HttpPost("add-liquidity")]
-        [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
-        public async Task<IActionResult> CreateAddLiquidityQuote(AddLiquidityQuoteRequestModel request, CancellationToken cancellationToken)
-        {
-            var result = await _mediator.Send(new GetLiquidityPoolAddLiquidityQuoteQuery(request.AmountIn, request.TokenIn,
-                request.Pool, _context.Market), cancellationToken);
-
-            return Ok(result);
-        }
     }
 }

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -19,7 +19,6 @@ using Opdex.Platform.Application.Abstractions.Models.Transactions;
 using Opdex.Platform.Application.Abstractions.Models.Vaults;
 using Opdex.Platform.Common.Constants;
 using Opdex.Platform.Common.Extensions;
-using Opdex.Platform.WebApi.Models;
 using Opdex.Platform.WebApi.Models.Responses;
 using Opdex.Platform.WebApi.Models.Responses.Blocks;
 using Opdex.Platform.WebApi.Models.Responses.Governances;
@@ -70,6 +69,7 @@ namespace Opdex.Platform.WebApi.Mappers
 
             CreateMap<LiquidityPoolDto, LiquidityPoolResponseModel>()
                 .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
+                .ForMember(dest => dest.TransactionFee, opt => opt.MapFrom(src => src.TransactionFee))
                 .ForMember(dest => dest.Token, opt => opt.MapFrom(src => src))
                 .ForMember(dest => dest.TransactionCount, opt => opt.MapFrom(src => src.Summary.TransactionCount))
                 .ForMember(dest => dest.Reserves, opt => opt.MapFrom(src => MapReserves(src.Summary.Reserves, src.SrcToken.Decimals)))
@@ -493,7 +493,8 @@ namespace Opdex.Platform.WebApi.Mappers
                 Weight = stakingDto.Weight.ToDecimal(TokenConstants.Opdex.Decimals),
                 Usd = stakingDto.Usd,
                 WeightDailyChange = stakingDto.WeightDailyChange,
-                IsActive = stakingEnabled
+                IsActive = stakingEnabled,
+                IsNominated = stakingDto.IsNominated,
             };
         }
 

--- a/src/Opdex.Platform.WebApi/Models/Requests/Quotes/AddLiquidityQuoteRequestModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Quotes/AddLiquidityQuoteRequestModel.cs
@@ -1,4 +1,5 @@
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Requests.Quotes
 {
@@ -7,16 +8,13 @@ namespace Opdex.Platform.WebApi.Models.Requests.Quotes
         /// <summary>
         /// Decimal number as string of the amount of tokens to be deposited into a pool.
         /// </summary>
+        [Required]
         public FixedDecimal AmountIn { get; set; }
 
         /// <summary>
         /// The smart contract address of the deposited token or "CRS" for Cirrus token.
         /// </summary>
+        [Required]
         public Address TokenIn { get; set; }
-
-        /// <summary>
-        /// The address of the liquidity pool to get a quote for.
-        /// </summary>
-        public Address Pool { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/AddLiquidityAmountInQuoteResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/AddLiquidityAmountInQuoteResponseModel.cs
@@ -1,0 +1,14 @@
+using NJsonSchema.Annotations;
+using Opdex.Platform.Common.Models;
+
+namespace Opdex.Platform.WebApi.Models.Responses.Pools
+{
+    public class AddLiquidityAmountInQuoteResponseModel
+    {
+        /// <summary>
+        /// The quoted amount of tokens to provide to match the requested amount.
+        /// </summary>
+        [NotNull]
+        public FixedDecimal AmountIn { get; set; }
+    }
+}

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolResponseModel.cs
@@ -6,6 +6,7 @@ namespace Opdex.Platform.WebApi.Models.Responses.Pools
     public class LiquidityPoolResponseModel : LiquidityPoolSummaryResponseModel
     {
         public Address Address { get; set; }
+        public decimal TransactionFee { get; set; }
         public LiquidityPoolTokenGroupResponseModel Token { get; set; }
         public MiningPoolResponseModel Mining { get; set; }
         public IEnumerable<LiquidityPoolSnapshotResponseModel> SnapshotHistory { get; set; }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSummaryResponseModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public abstract class LiquidityPoolSummaryResponseModel {

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/StakingResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/StakingResponseModel.cs
@@ -8,5 +8,6 @@ namespace Opdex.Platform.WebApi.Models.Responses.Pools
         public decimal Usd { get; set; }
         public decimal? WeightDailyChange { get; set; }
         public bool? IsActive { get; set; }
+        public bool? IsNominated { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Program.cs
+++ b/src/Opdex.Platform.WebApi/Program.cs
@@ -63,6 +63,8 @@ namespace Opdex.Platform.WebApi
                 .ConfigureServices(services =>
                 {
                     services.AddHostedService<IndexerBackgroundService>();
+                    services.Configure<HostOptions>(
+                        opts => opts.ShutdownTimeout = TimeSpan.FromSeconds(30));
                 });
     }
 }

--- a/test/Opdex.Platform.Application.Tests/Handlers/Transactions/MakeNotifyUserOfTransactionBroadcastCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Transactions/MakeNotifyUserOfTransactionBroadcastCommandHandlerTests.cs
@@ -29,13 +29,14 @@ namespace Opdex.Platform.Application.Tests.Handlers.Transactions
             var transactionHash = "87ff7bf5dccd3683ef2925ff2ce9148766eb1c0cb97594d612d7b74e8214ba80";
             var request = new MakeNotifyUserOfTransactionBroadcastCommand("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", transactionHash);
             var cancellationToken = new CancellationTokenSource().Token;
+            const int maxRetries = 3;
 
             // Act
             await _handler.Handle(request, cancellationToken);
 
             // Assert
             _mediator.Verify(callTo => callTo.Send(It.Is<CallCirrusGetExistsInMempoolQuery>(query => query.TransactionHash == transactionHash), cancellationToken),
-                             Times.Once);
+                             Times.AtMost(maxRetries));
         }
 
         [Fact]


### PR DESCRIPTION
- Moved Liquidity Pool Add Liquidity Amount In from quotes controller to liquidity pools [PAPI-123]
- HostedService (BackgroundIndexer) will wait 30 seconds on shutdown (hopefully prevent locked indexer instances) [PAPI-229]
- Return `IsNominated` on liquidity pool
- Return `TransactionFee` on liquidity pool
- NotifyTransaction - attempts mempool request up to 3 times with 5 second delays
     - Note: Getting the mempool up to 3 times for n Transactions at a time can be optimized potentially. Only need to get it once, ever so often. 


[PAPI-123]: https://opdex.atlassian.net/browse/PAPI-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAPI-229]: https://opdex.atlassian.net/browse/PAPI-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ