### PR TITLE
[PAPI-86] Refactor Liquidity Pool Filtering and Pagination

### DIFF
--- a/src/Opdex.Platform.Application.Abstractions/EntryCommands/Markets/Snapshots/ProcessMarketSnapshotsCommand.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryCommands/Markets/Snapshots/ProcessMarketSnapshotsCommand.cs
@@ -8,7 +8,7 @@ namespace Opdex.Platform.Application.Abstractions.EntryCommands.Markets.Snapshot
     {
         public ProcessMarketSnapshotsCommand(Market market, DateTime blockTime)
         {
-            Market = market ?? throw new ArgumentNullException(nameof(market), $"Market must be provided.");
+            Market = market ?? throw new ArgumentNullException(nameof(market), "Market must be provided.");
             BlockTime = blockTime;
         }
 

--- a/src/Opdex.Platform.Application.Abstractions/EntryCommands/Markets/Snapshots/ProcessMarketSnapshotsCommand.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryCommands/Markets/Snapshots/ProcessMarketSnapshotsCommand.cs
@@ -1,22 +1,18 @@
 using MediatR;
+using Opdex.Platform.Domain.Models.Markets;
 using System;
 
 namespace Opdex.Platform.Application.Abstractions.EntryCommands.Markets.Snapshots
 {
     public class ProcessMarketSnapshotsCommand : IRequest<Unit>
     {
-        public ProcessMarketSnapshotsCommand(ulong marketId, DateTime blockTime)
+        public ProcessMarketSnapshotsCommand(Market market, DateTime blockTime)
         {
-            if (marketId < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(marketId), $"{nameof(marketId)} must be greater than 0.");
-            }
-
-            MarketId = marketId;
+            Market = market ?? throw new ArgumentNullException(nameof(market), $"Market must be provided.");
             BlockTime = blockTime;
         }
 
-        public ulong MarketId { get; }
+        public Market Market { get; }
         public DateTime BlockTime { get; }
     }
 }

--- a/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/GetLiquidityPoolsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/GetLiquidityPoolsWithFilterQuery.cs
@@ -1,40 +1,24 @@
 using MediatR;
 using Opdex.Platform.Application.Abstractions.Models.LiquidityPools;
-using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using System;
-using System.Collections.Generic;
 
 namespace Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools
 {
-    public class GetLiquidityPoolsWithFilterQuery : IRequest<IEnumerable<LiquidityPoolDto>>
+    /// <summary>
+    /// Get liquidity pools with filtering and pagination.
+    /// </summary>
+    public class GetLiquidityPoolsWithFilterQuery : IRequest<LiquidityPoolsDto>
     {
-        public GetLiquidityPoolsWithFilterQuery(Address marketAddress, bool? stakingEnabled, bool? miningEnabled, bool? nominated,
-                                               uint skip, uint take, string sortBy, string orderBy, IEnumerable<Address> pools)
+        /// <summary>
+        /// Constructor to build a get liquidity pools with filter query.
+        /// </summary>
+        /// <param name="cursor">The liquidity pools cursor to filter by.</param>
+        public GetLiquidityPoolsWithFilterQuery(LiquidityPoolsCursor cursor)
         {
-            if (marketAddress == Address.Empty)
-            {
-                throw new ArgumentNullException(nameof(marketAddress));
-            }
-
-            MarketAddress = marketAddress;
-            Staking = stakingEnabled;
-            Mining = miningEnabled;
-            Nominated = nominated;
-            Skip = skip;
-            Take = take;
-            SortBy = sortBy;
-            OrderBy = orderBy;
-            Pools = pools;
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor), "Liquidity pools cursor must be set.");
         }
 
-        public Address MarketAddress { get; }
-        public bool? Staking { get; }
-        public bool? Mining { get; }
-        public bool? Nominated { get; }
-        public uint Skip { get; }
-        public uint Take { get; }
-        public string SortBy { get; }
-        public string OrderBy { get; }
-        public IEnumerable<Address> Pools { get; }
+        public LiquidityPoolsCursor Cursor { get; }
     }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
@@ -7,6 +7,7 @@ namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools
     public class LiquidityPoolDto
     {
         public ulong Id { get; set; }
+        public string Name { get; set; }
         public Address Address { get; set; }
         public decimal TransactionFee { get; set; }
         public bool StakingEnabled { get; set; }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolsDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolsDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools
+{
+    public class LiquidityPoolsDto
+    {
+        public IEnumerable<LiquidityPoolDto> LiquidityPools { get; set; }
+        public CursorDto Cursor { get; set; }
+    }
+}

--- a/src/Opdex.Platform.Application.Abstractions/Queries/LiquidityPools/RetrieveLiquidityPoolsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Queries/LiquidityPools/RetrieveLiquidityPoolsWithFilterQuery.cs
@@ -1,41 +1,25 @@
 using MediatR;
-using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.LiquidityPools;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Opdex.Platform.Application.Abstractions.Queries.LiquidityPools
 {
+    /// <summary>
+    /// Retrieve liquidity pools with filtering.
+    /// </summary>
     public class RetrieveLiquidityPoolsWithFilterQuery : IRequest<IEnumerable<LiquidityPool>>
     {
-        public RetrieveLiquidityPoolsWithFilterQuery(ulong marketId, bool? stakingEnabled = null, bool? miningEnabled = null, bool? nominated = null,
-                                                     uint skip = 0, uint take = 0, string sortBy = null, string orderBy = null, IEnumerable<Address> pools = null)
+        /// <summary>
+        /// Constructor to build a retrieve liquidity pools with filter query.
+        /// </summary>
+        /// <param name="cursor">The liquidity pools cursor to filter by.</param>
+        public RetrieveLiquidityPoolsWithFilterQuery(LiquidityPoolsCursor cursor)
         {
-            if (marketId < 1)
-            {
-                throw new ArgumentNullException(nameof(marketId), $"{nameof(marketId)} must be greater than 0.");
-            }
-
-            MarketId = marketId;
-            Staking = stakingEnabled;
-            Mining = miningEnabled;
-            Nominated = nominated;
-            Skip = skip;
-            Take = take;
-            SortBy = sortBy;
-            OrderBy = orderBy;
-            Pools = pools ?? Enumerable.Empty<Address>();
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor), "Liquidity pools cursor must be set.");
         }
 
-        public ulong MarketId { get; }
-        public bool? Staking { get; }
-        public bool? Mining { get; }
-        public bool? Nominated { get; }
-        public uint Skip { get; }
-        public uint Take { get; }
-        public string SortBy { get; }
-        public string OrderBy { get; }
-        public IEnumerable<Address> Pools { get; }
+        public LiquidityPoolsCursor Cursor { get; }
     }
 }

--- a/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
@@ -63,7 +63,7 @@ namespace Opdex.Platform.Application.Assemblers
             poolDto.CrsToken = await AssembleToken(Address.Cirrus);
 
             // Assemble staking token details when required
-            var stakingTokenDto = market.StakingTokenId > 0 ? await AssembleMarketToken(market.StakingTokenId.Value, market) : null;
+            var stakingTokenDto = market.IsStakingMarket ? await AssembleMarketToken(market.StakingTokenId, market) : null;
 
             // Assemble SRC Token
             poolDto.SrcToken = await AssembleMarketToken(pool.SrcTokenId, market);

--- a/src/Opdex.Platform.Application/Assemblers/MarketDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/MarketDtoAssembler.cs
@@ -43,7 +43,7 @@ namespace Opdex.Platform.Application.Assemblers
 
             // get staking token if necessary
             var stakingToken = market.IsStakingMarket
-                ? await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId.GetValueOrDefault()))
+                ? await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId))
                 : null;
 
             // Get yesterday and today's snapshots

--- a/src/Opdex.Platform.Application/Assemblers/StakingPositionDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/StakingPositionDtoAssembler.cs
@@ -23,7 +23,7 @@ namespace Opdex.Platform.Application.Assemblers
         {
             var liquidityPool = await _mediator.Send(new RetrieveLiquidityPoolByIdQuery(source.LiquidityPoolId, findOrThrow: true));
             var market = await _mediator.Send(new RetrieveMarketByIdQuery(liquidityPool.MarketId, findOrThrow: true));
-            var token = await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId.Value, findOrThrow: true));
+            var token = await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId, findOrThrow: true));
 
             return new StakingPositionDto
             {

--- a/src/Opdex.Platform.Application/EntryHandlers/Addresses/Staking/GetStakingPositionByPoolQueryHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Addresses/Staking/GetStakingPositionByPoolQueryHandler.cs
@@ -24,11 +24,9 @@ namespace Opdex.Platform.Application.EntryHandlers.Addresses.Staking
         public async Task<StakingPositionDto> Handle(GetStakingPositionByPoolQuery request, CancellationToken cancellationToken)
         {
             var liquidityPool = await _mediator.Send(new RetrieveLiquidityPoolByAddressQuery(request.LiquidityPoolAddress, findOrThrow: true), cancellationToken);
-            var addressStaking = await _mediator.Send(new RetrieveAddressStakingByLiquidityPoolIdAndOwnerQuery(liquidityPool.Id,
-                                                                                                               request.Address,
-                                                                                                               findOrThrow: true), cancellationToken);
+            var addressStaking = await _mediator.Send(new RetrieveAddressStakingByLiquidityPoolIdAndOwnerQuery(liquidityPool.Id, request.Address, findOrThrow: true), cancellationToken);
             var market = await _mediator.Send(new RetrieveMarketByIdQuery(liquidityPool.MarketId, findOrThrow: true), cancellationToken);
-            var token = await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId.Value, findOrThrow: true), cancellationToken);
+            var token = await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId, findOrThrow: true), cancellationToken);
 
             return new StakingPositionDto
             {

--- a/src/Opdex.Platform.Application/EntryHandlers/Blocks/ProcessLatestBlocksCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Blocks/ProcessLatestBlocksCommandHandler.cs
@@ -104,7 +104,7 @@ namespace Opdex.Platform.Application.EntryHandlers.Blocks
 
                         foreach (var market in markets)
                         {
-                            await _mediator.Send(new ProcessMarketSnapshotsCommand(market.Id, currentBlock.MedianTime));
+                            await _mediator.Send(new ProcessMarketSnapshotsCommand(market, currentBlock.MedianTime));
                         }
                     }
 

--- a/src/Opdex.Platform.Application/EntryHandlers/CreateRewindSnapshotsCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/CreateRewindSnapshotsCommandHandler.cs
@@ -14,6 +14,7 @@ using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using Opdex.Platform.Domain.Models.Markets;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Transactions;
 using System;
 using System.Collections.Generic;
@@ -74,7 +75,7 @@ namespace Opdex.Platform.Application.EntryHandlers
             foreach (var market in marketList)
             {
                 // Get All Pools
-                var pools = await _mediator.Send(new RetrieveLiquidityPoolsWithFilterQuery(market.Id));
+                var pools = await _mediator.Send(new RetrieveLiquidityPoolsWithFilterQuery(new LiquidityPoolsCursor(market.Address)));
                 var poolsList = pools.ToList();
 
                 _logger.LogDebug($"Found {poolsList.Count} stale liquidity pool daily snapshots.");
@@ -180,7 +181,7 @@ namespace Opdex.Platform.Application.EntryHandlers
             {
                 try
                 {
-                    await _mediator.Send(new ProcessMarketSnapshotsCommand(market.Id, startOfDay));
+                    await _mediator.Send(new ProcessMarketSnapshotsCommand(market, startOfDay));
                 }
                 catch (Exception)
                 {

--- a/src/Opdex.Platform.Application/EntryHandlers/LiquidityPools/GetLiquidityPoolsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/LiquidityPools/GetLiquidityPoolsWithFilterQueryHandler.cs
@@ -37,8 +37,7 @@ namespace Opdex.Platform.Application.EntryHandlers.LiquidityPools
                 {
                     LiquidityPoolOrderByType.Liquidity => (result.Summary.Reserves.Usd.ToString(), result.Id),
                     LiquidityPoolOrderByType.Volume => (result.Summary.Volume.Usd.ToString(), result.Id),
-                    // Todo: when pool DTOs are changed, result.Summary should be our pool_liquidity_summary and snapshot or "details" should be what the current summary is.
-                    LiquidityPoolOrderByType.StakingWeight => (result.Summary?.Staking?.Weight.ToString(), result.Id),
+                    LiquidityPoolOrderByType.StakingWeight => (result.Summary.Staking?.Weight.ToString(), result.Id),
                     LiquidityPoolOrderByType.Name => (result.Name, result.Id),
                     _ => (string.Empty, result.Id)
                 };

--- a/src/Opdex.Platform.Application/EntryHandlers/LiquidityPools/Snapshots/ProcessLiquidityPoolSnapshotsByTransactionCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/LiquidityPools/Snapshots/ProcessLiquidityPoolSnapshotsByTransactionCommandHandler.cs
@@ -59,15 +59,13 @@ namespace Opdex.Platform.Application.EntryHandlers.LiquidityPools.Snapshots
 
                 if (market.IsStakingMarket)
                 {
-                    var stakingTokenId = market.StakingTokenId.GetValueOrDefault();
-
-                    var stakingTokenSnapshot = await _mediator.Send(new RetrieveTokenSnapshotWithFilterQuery(stakingTokenId, liquidityPool.MarketId,
+                    var stakingTokenSnapshot = await _mediator.Send(new RetrieveTokenSnapshotWithFilterQuery(market.StakingTokenId, liquidityPool.MarketId,
                                                                                                              blockTime, SnapshotType.Hourly));
 
                     // Update a stale snapshot if it is older than what was requested
                     if (stakingTokenSnapshot.EndDate < blockTime)
                     {
-                        var stakingTokenPool = await _mediator.Send(new RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQuery(stakingTokenId, market.Id));
+                        var stakingTokenPool = await _mediator.Send(new RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQuery(market.StakingTokenId, market.Id));
 
                         var stakingTokenPoolSnapshot = await _mediator.Send(new RetrieveLiquidityPoolSnapshotWithFilterQuery(stakingTokenPool.Id,
                                                                                                                              stakingTokenSnapshot.EndDate,

--- a/src/Opdex.Platform.Application/EntryHandlers/Markets/Snapshots/ProcessMarketSnapshotsCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Markets/Snapshots/ProcessMarketSnapshotsCommandHandler.cs
@@ -5,6 +5,7 @@ using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
 using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools.Snapshots;
 using Opdex.Platform.Application.Abstractions.Queries.Markets.Snapshots;
 using Opdex.Platform.Common.Enums;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,8 +24,8 @@ namespace Opdex.Platform.Application.EntryHandlers.Markets.Snapshots
 
         public async Task<Unit> Handle(ProcessMarketSnapshotsCommand request, CancellationToken cancellationToken)
         {
-            var marketPools = await _mediator.Send(new RetrieveLiquidityPoolsWithFilterQuery(request.MarketId));
-            var marketSnapshot = await _mediator.Send(new RetrieveMarketSnapshotWithFilterQuery(request.MarketId, request.BlockTime, SnapshotType));
+            var marketPools = await _mediator.Send(new RetrieveLiquidityPoolsWithFilterQuery(new LiquidityPoolsCursor(request.Market.Address)));
+            var marketSnapshot = await _mediator.Send(new RetrieveMarketSnapshotWithFilterQuery(request.Market.Id, request.BlockTime, SnapshotType));
 
             // Reset stale snapshot if its old
             if (marketSnapshot.EndDate < request.BlockTime)

--- a/src/Opdex.Platform.Application/EntryHandlers/ProcessDailySnapshotRefreshCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/ProcessDailySnapshotRefreshCommandHandler.cs
@@ -13,6 +13,7 @@ using Opdex.Platform.Application.Abstractions.Queries.Tokens;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens.Snapshots;
 using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Extensions;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 
 namespace Opdex.Platform.Application.EntryHandlers
 {
@@ -34,13 +35,13 @@ namespace Opdex.Platform.Application.EntryHandlers
 
             foreach (var market in markets)
             {
-                var marketPools = await _mediator.Send(new RetrieveLiquidityPoolsWithFilterQuery(market.Id));
+                var marketPools = await _mediator.Send(new RetrieveLiquidityPoolsWithFilterQuery(new LiquidityPoolsCursor(market.Address)));
                 var stakingTokenUsd = 0m;
 
                 // Process staking tokens and their liquidity pools first
                 if (market.IsStakingMarket)
                 {
-                    var stakingToken = await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId.GetValueOrDefault(), findOrThrow: false));
+                    var stakingToken = await _mediator.Send(new RetrieveTokenByIdQuery(market.StakingTokenId, findOrThrow: false));
 
                     if (stakingToken == null) continue;
 
@@ -79,7 +80,7 @@ namespace Opdex.Platform.Application.EntryHandlers
                 }
 
                 // Process market snapshot
-                await _mediator.Send(new ProcessMarketSnapshotsCommand(market.Id, blockTime));
+                await _mediator.Send(new ProcessMarketSnapshotsCommand(market, blockTime));
             }
 
             return Unit.Value;

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/Markets/ProcessCreateLiquidityPoolLogCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/Markets/ProcessCreateLiquidityPoolLogCommandHandler.cs
@@ -50,7 +50,7 @@ namespace Opdex.Platform.Application.EntryHandlers.Transactions.TransactionLogs.
                 var lpTokenId = await _mediator.Send(new CreateTokenCommand(request.Log.Pool, request.BlockHeight));
 
                 var networkPrefix = _config.Network.NetworkTokenPrefix();
-                var name = $"{srcToken.Name}-{networkPrefix}CRS";
+                var name = $"{srcToken.Symbol}-{networkPrefix}CRS";
 
                 var liquidityPool = await _mediator.Send(new RetrieveLiquidityPoolByAddressQuery(request.Log.Pool, findOrThrow: false)) ??
                                     new LiquidityPool(request.Log.Pool, name, srcTokenId, lpTokenId, market.Id, request.BlockHeight);

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/Markets/ProcessCreateLiquidityPoolLogCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/Markets/ProcessCreateLiquidityPoolLogCommandHandler.cs
@@ -11,7 +11,9 @@ using Opdex.Platform.Application.Abstractions.Queries.Blocks;
 using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
 using Opdex.Platform.Application.Abstractions.Queries.Markets;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
+using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Common.Enums;
+using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using Opdex.Platform.Domain.Models.LiquidityPools.Snapshots;
 using Opdex.Platform.Domain.Models.TransactionLogs.Markets;
@@ -20,11 +22,14 @@ namespace Opdex.Platform.Application.EntryHandlers.Transactions.TransactionLogs.
 {
     public class ProcessCreateLiquidityPoolLogCommandHandler : IRequestHandler<ProcessCreateLiquidityPoolLogCommand, bool>
     {
+        private readonly OpdexConfiguration _config;
         private readonly IMediator _mediator;
         private readonly ILogger<ProcessCreateLiquidityPoolLogCommandHandler> _logger;
 
-        public ProcessCreateLiquidityPoolLogCommandHandler(IMediator mediator, ILogger<ProcessCreateLiquidityPoolLogCommandHandler> logger)
+        public ProcessCreateLiquidityPoolLogCommandHandler(OpdexConfiguration config, IMediator mediator,
+                                                           ILogger<ProcessCreateLiquidityPoolLogCommandHandler> logger)
         {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -44,8 +49,11 @@ namespace Opdex.Platform.Application.EntryHandlers.Transactions.TransactionLogs.
 
                 var lpTokenId = await _mediator.Send(new CreateTokenCommand(request.Log.Pool, request.BlockHeight));
 
+                var networkPrefix = _config.Network.NetworkTokenPrefix();
+                var name = $"{srcToken.Name}-{networkPrefix}CRS";
+
                 var liquidityPool = await _mediator.Send(new RetrieveLiquidityPoolByAddressQuery(request.Log.Pool, findOrThrow: false)) ??
-                                    new LiquidityPool(request.Log.Pool, srcTokenId, lpTokenId, market.Id, request.BlockHeight);
+                                    new LiquidityPool(request.Log.Pool, name, srcTokenId, lpTokenId, market.Id, request.BlockHeight);
 
                 ulong liquidityPoolId = liquidityPool.Id;
                 var isNewLiquidityPool = liquidityPoolId == 0;

--- a/src/Opdex.Platform.Application/Handlers/LiquidityPools/RetrieveLiquidityPoolsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/LiquidityPools/RetrieveLiquidityPoolsWithFilterQueryHandler.cs
@@ -1,4 +1,3 @@
-using AutoMapper;
 using MediatR;
 using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
 using Opdex.Platform.Domain.Models.LiquidityPools;
@@ -19,12 +18,9 @@ namespace Opdex.Platform.Application.Handlers.LiquidityPools
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         }
 
-        public async Task<IEnumerable<LiquidityPool>> Handle(RetrieveLiquidityPoolsWithFilterQuery request, CancellationToken cancellationToken)
+        public Task<IEnumerable<LiquidityPool>> Handle(RetrieveLiquidityPoolsWithFilterQuery request, CancellationToken cancellationToken)
         {
-            var query = new SelectLiquidityPoolsWithFilterQuery(request.MarketId, request.Staking, request.Mining, request.Nominated,
-                                                                request.Skip, request.Take, request.SortBy, request.OrderBy, request.Pools);
-
-            return await _mediator.Send(query, cancellationToken);
+            return _mediator.Send(new SelectLiquidityPoolsWithFilterQuery(request.Cursor), cancellationToken);
         }
     }
 }

--- a/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
@@ -97,6 +97,7 @@ namespace Opdex.Platform.Application
             CreateMap<LiquidityPool, LiquidityPoolDto>()
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
                 .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<Block, BlockDto>()
@@ -104,11 +105,6 @@ namespace Opdex.Platform.Application
                 .ForMember(dest => dest.Hash, opt => opt.MapFrom(src => src.Hash))
                 .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.Time))
                 .ForMember(dest => dest.MedianTime, opt => opt.MapFrom(src => src.MedianTime))
-                .ForAllOtherMembers(opt => opt.Ignore());
-
-            CreateMap<LiquidityPool, LiquidityPoolDto>()
-                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
-                .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<LiquidityPoolSnapshot, LiquidityPoolSnapshotDto>()

--- a/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
@@ -203,7 +203,7 @@ namespace Opdex.Platform.Application
             services.AddTransient<IRequestHandler<GetMarketSnapshotsWithFilterQuery, IEnumerable<MarketSnapshotDto>>, GetMarketSnapshotsWithFilterQueryHandler>();
 
             // Liquidity Pools
-            services.AddTransient<IRequestHandler<GetLiquidityPoolsWithFilterQuery, IEnumerable<LiquidityPoolDto>>, GetLiquidityPoolsWithFilterQueryHandler>();
+            services.AddTransient<IRequestHandler<GetLiquidityPoolsWithFilterQuery, LiquidityPoolsDto>, GetLiquidityPoolsWithFilterQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityPoolSwapQuoteQuery, FixedDecimal>, GetLiquidityPoolSwapQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityAmountInQuoteQuery, FixedDecimal>, GetLiquidityAmountInQuoteQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityPoolSnapshotsWithFilterQuery, IEnumerable<LiquidityPoolSnapshotDto>>, GetLiquidityPoolSnapshotsWithFilterQueryHandler>();

--- a/src/Opdex.Platform.Common/Extensions/NetworkTypeExtensions.cs
+++ b/src/Opdex.Platform.Common/Extensions/NetworkTypeExtensions.cs
@@ -1,0 +1,14 @@
+using Opdex.Platform.Common.Enums;
+
+namespace Opdex.Platform.Common.Extensions
+{
+    public static class NetworkTypeExtensions
+    {
+        public static string NetworkTokenPrefix(this NetworkType network)
+        {
+            if (network == NetworkType.MAINNET) return string.Empty;
+
+            return network == NetworkType.TESTNET ? "T" : "D";
+        }
+    }
+}

--- a/src/Opdex.Platform.Domain/Models/LiquidityPools/LiquidityPool.cs
+++ b/src/Opdex.Platform.Domain/Models/LiquidityPools/LiquidityPool.cs
@@ -1,3 +1,4 @@
+using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Blocks;
 using System;
@@ -6,11 +7,16 @@ namespace Opdex.Platform.Domain.Models.LiquidityPools
 {
     public class LiquidityPool : BlockAudit
     {
-        public LiquidityPool(Address address, ulong srcTokenId, ulong lpTokenId, ulong marketId, ulong createdBlock) : base(createdBlock)
+        public LiquidityPool(Address address, string name, ulong srcTokenId, ulong lpTokenId, ulong marketId, ulong createdBlock) : base(createdBlock)
         {
             if (address == Address.Empty)
             {
                 throw new ArgumentNullException(nameof(address), "Liquidity pool address must be provided");
+            }
+
+            if (!name.HasValue())
+            {
+                throw new ArgumentNullException(nameof(name), "Name must be provided.");
             }
 
             if (srcTokenId < 1)
@@ -28,16 +34,18 @@ namespace Opdex.Platform.Domain.Models.LiquidityPools
                 throw new ArgumentOutOfRangeException(nameof(marketId), "Market id must be greater than zero.");
             }
 
+            Name = name;
             Address = address;
             SrcTokenId = srcTokenId;
             LpTokenId = lpTokenId;
             MarketId = marketId;
         }
 
-        public LiquidityPool(ulong id, Address address, ulong srcTokenId, ulong lpTokenId, ulong marketId, ulong createdBlock, ulong modifiedBlock)
+        public LiquidityPool(ulong id, Address address, string name, ulong srcTokenId, ulong lpTokenId, ulong marketId, ulong createdBlock, ulong modifiedBlock)
             : base(createdBlock, modifiedBlock)
         {
             Id = id;
+            Name = name;
             Address = address;
             SrcTokenId = srcTokenId;
             LpTokenId = lpTokenId;
@@ -45,6 +53,7 @@ namespace Opdex.Platform.Domain.Models.LiquidityPools
         }
 
         public ulong Id { get; }
+        public string Name { get; }
         public Address Address { get; }
         public ulong SrcTokenId { get; }
         public ulong LpTokenId { get; }

--- a/src/Opdex.Platform.Domain/Models/Markets/Market.cs
+++ b/src/Opdex.Platform.Domain/Models/Markets/Market.cs
@@ -7,7 +7,7 @@ namespace Opdex.Platform.Domain.Models.Markets
 {
     public class Market : BlockAudit
     {
-        public Market(Address address, ulong deployerId, ulong? stakingTokenId, Address owner, bool authPoolCreators, bool authProviders,
+        public Market(Address address, ulong deployerId, ulong stakingTokenId, Address owner, bool authPoolCreators, bool authProviders,
             bool authTraders, uint transactionFee, bool marketFeeEnabled, ulong createdBlock) : base(createdBlock)
         {
             if (address == Address.Empty)
@@ -41,7 +41,7 @@ namespace Opdex.Platform.Domain.Models.Markets
             MarketFeeEnabled = marketFeeEnabled;
         }
 
-        public Market(ulong id, Address address, ulong deployerId, ulong? stakingTokenId, Address pendingOwner, Address owner, bool authPoolCreators, bool authProviders,
+        public Market(ulong id, Address address, ulong deployerId, ulong stakingTokenId, Address pendingOwner, Address owner, bool authPoolCreators, bool authProviders,
             bool authTraders, uint transactionFee, bool marketFeeEnabled, ulong createdBlock, ulong modifiedBlock) : base(createdBlock, modifiedBlock)
         {
             Id = id;
@@ -60,7 +60,7 @@ namespace Opdex.Platform.Domain.Models.Markets
         public ulong Id { get; }
         public Address Address { get; }
         public ulong DeployerId { get; }
-        public ulong? StakingTokenId { get; }
+        public ulong StakingTokenId { get; }
         public Address PendingOwner { get; private set; }
         public Address Owner { get; private set; }
         public bool AuthPoolCreators { get; }
@@ -68,7 +68,7 @@ namespace Opdex.Platform.Domain.Models.Markets
         public bool AuthTraders { get; }
         public uint TransactionFee { get; }
         public bool MarketFeeEnabled { get; }
-        public bool IsStakingMarket => StakingTokenId.GetValueOrDefault() > 0;
+        public bool IsStakingMarket => StakingTokenId > 0;
 
         public void SetPendingOwnership(SetPendingMarketOwnershipLog log, ulong block)
         {

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/LiquidityPools/LiquidityPoolEntity.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/LiquidityPools/LiquidityPoolEntity.cs
@@ -5,6 +5,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools
     public class LiquidityPoolEntity : AuditEntity
     {
         public ulong Id { get; set; }
+        public string Name { get; set; }
         public Address Address { get; set; }
         public ulong SrcTokenId { get; set; }
         public ulong LpTokenId { get; set; }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/Markets/MarketEntity.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/Markets/MarketEntity.cs
@@ -7,7 +7,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets
         public ulong Id { get; set; }
         public Address Address { get; set; }
         public ulong DeployerId { get; set; }
-        public ulong? StakingTokenId { get; set; }
+        public ulong StakingTokenId { get; set; }
         public Address PendingOwner { get; set; }
         public Address Owner { get; set; }
         public bool AuthPoolCreators { get; set; }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
@@ -54,7 +54,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
         public IEnumerable<Address> Markets { get; }
 
         /// <summary>
-        /// LiquidityPools to filter specifically for.
+        /// Liquidity pools to filter specifically for.
         /// </summary>
         public IEnumerable<Address> LiquidityPools { get; }
 

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
@@ -10,6 +10,9 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
 {
     public class LiquidityPoolsCursor : Cursor<(string, ulong)>
     {
+        // Todo: This has to be handled better before we hit 10k, optional pagination in Retrieve may be key
+        private const int MaxInternalLimit = 1_000;
+
         public LiquidityPoolsCursor(string keyword, IEnumerable<Address> markets, IEnumerable<Address> pools, IEnumerable<Address> tokens, LiquidityPoolStakingStatusFilter stakingFilter,
                                     LiquidityPoolNominationStatusFilter nominationFilter, LiquidityPoolMiningStatusFilter miningFilter,
                                     LiquidityPoolOrderByType orderBy, SortDirectionType sortDirection, uint limit, PagingDirection pagingDirection,
@@ -36,7 +39,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
         /// </remarks>
         /// <param name="market">The market to select all liquidity pools for.</param>
         public LiquidityPoolsCursor(Address market)
-            : base(SortDirectionType.ASC, uint.MaxValue, PagingDirection.Forward, default, uint.MaxValue, uint.MaxValue)
+            : base(SortDirectionType.ASC, MaxInternalLimit, PagingDirection.Forward, default, MaxInternalLimit, MaxInternalLimit)
         {
             Markets = new List<Address> { market };
             LiquidityPools = Enumerable.Empty<Address>();

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
@@ -91,9 +91,9 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
 
             var sb = new StringBuilder();
             sb.AppendFormat("direction:{0};limit:{1};paging:{2};", SortDirection, Limit, PagingDirection);
-            foreach (var pool in LiquidityPools) sb.AppendFormat("pools:{0};", pool);
+            foreach (var pool in LiquidityPools) sb.AppendFormat("liquidityPools:{0};", pool);
             foreach (var token in Tokens) sb.AppendFormat("tokens:{0};", token);
-            foreach (var market in Tokens) sb.AppendFormat("markets:{0};", market);
+            foreach (var market in Markets) sb.AppendFormat("markets:{0};", market);
             sb.AppendFormat("keyword:{0};", Keyword);
             sb.AppendFormat("stakingFilter:{0};", StakingFilter);
             sb.AppendFormat("nominationFilter:{0};", NominationFilter);
@@ -135,7 +135,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
 
             TryGetCursorProperties<Address>(values, "tokens", out var tokens);
 
-            TryGetCursorProperties<Address>(values, "pools", out var pools);
+            TryGetCursorProperties<Address>(values, "liquidityPools", out var pools);
 
             TryGetCursorProperty<LiquidityPoolStakingStatusFilter>(values, "stakingFilter", out var stakingFilter);
 
@@ -187,12 +187,15 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
         }
     }
 
+    /// <summary>
+    /// Options to filter liquidity pools by according to their mining status.
+    /// </summary>
     public enum LiquidityPoolMiningStatusFilter
     {
         /// <summary>
-        /// Default status is ignored in filter.
+        /// Retrieve any liquidity pool not determined by mining status.
         /// </summary>
-        Default = 0,
+        Any = 0,
 
         /// <summary>
         /// Mining enabled filter.
@@ -205,12 +208,15 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
         Disabled = 2
     }
 
+    /// <summary>
+    /// Options to filter liquidity pools by according to their nomination status.
+    /// </summary>
     public enum LiquidityPoolNominationStatusFilter
     {
         /// <summary>
-        /// Default status is ignored in filter.
+        /// Retrieve any liquidity pool not determined by nomination status.
         /// </summary>
-        Default = 0,
+        Any = 0,
 
         /// <summary>
         /// Nominated for liquidity mining filter.
@@ -223,12 +229,15 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
         NonNominated = 2
     }
 
+    /// <summary>
+    /// Options to filter liquidity pools by according to their staking status.
+    /// </summary>
     public enum LiquidityPoolStakingStatusFilter
     {
         /// <summary>
-        /// Default status is ignored in filter.
+        /// Retrieve any liquidity pool not determined by staking status.
         /// </summary>
-        Default = 0,
+        Any = 0,
 
         /// <summary>
         /// Staking enabled filter.
@@ -241,12 +250,15 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
         Disabled = 2
     }
 
+    /// <summary>
+    /// The order in which to return liquidity pool records by.
+    /// </summary>
     public enum LiquidityPoolOrderByType
     {
         /// <summary>
-        /// Default orders results based on when they were added to Opdex.
+        /// The default status of any is ignored in filter.
         /// </summary>
-        Default = 0,
+        Any = 0,
 
         /// <summary>
         /// Order results by liquidity locked amounts.

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/LiquidityPoolsCursor.cs
@@ -1,0 +1,271 @@
+using Opdex.Platform.Common.Enums;
+using Opdex.Platform.Common.Extensions;
+using Opdex.Platform.Common.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
+{
+    public class LiquidityPoolsCursor : Cursor<(string, ulong)>
+    {
+        public LiquidityPoolsCursor(string keyword, IEnumerable<Address> markets, IEnumerable<Address> pools, IEnumerable<Address> tokens, LiquidityPoolStakingStatusFilter stakingFilter,
+                                    LiquidityPoolNominationStatusFilter nominationFilter, LiquidityPoolMiningStatusFilter miningFilter,
+                                    LiquidityPoolOrderByType orderBy, SortDirectionType sortDirection, uint limit, PagingDirection pagingDirection,
+                                    (string, ulong) pointer)
+            : base(sortDirection, limit, pagingDirection, pointer)
+        {
+            Keyword = keyword;
+            Markets = markets ?? Enumerable.Empty<Address>();
+            LiquidityPools = pools ?? Enumerable.Empty<Address>();
+            Tokens = tokens ?? Enumerable.Empty<Address>();
+            StakingFilter = stakingFilter;
+            NominationFilter = nominationFilter;
+            MiningFilter = miningFilter;
+            OrderBy = orderBy;
+        }
+
+        /// <summary>
+        /// Constructor specifically for queries where all market pools are needed
+        /// </summary>
+        /// <remarks>
+        /// This is to fill existing snapshot functionality. Improvements can be made to include pagination
+        /// rather than select all, however, current pagination is done after assemblers use resources to build DTO models
+        /// and may be counter productive at the moment without further refactoring.
+        /// </remarks>
+        /// <param name="market">The market to select all liquidity pools for.</param>
+        public LiquidityPoolsCursor(Address market)
+            : base(SortDirectionType.ASC, uint.MaxValue, PagingDirection.Forward, default, uint.MaxValue, uint.MaxValue)
+        {
+            Markets = new List<Address> { market };
+            LiquidityPools = Enumerable.Empty<Address>();
+            Tokens = Enumerable.Empty<Address>();
+        }
+
+        /// <summary>
+        /// A generic keyword search against liquidity pool addresses and names.
+        /// </summary>
+        public string Keyword { get; }
+
+        /// <summary>
+        /// Markets to search liquidity pools within.
+        /// </summary>
+        public IEnumerable<Address> Markets { get; }
+
+        /// <summary>
+        /// LiquidityPools to filter specifically for.
+        /// </summary>
+        public IEnumerable<Address> LiquidityPools { get; }
+
+        /// <summary>
+        /// Tokens to filter specifically for.
+        /// </summary>
+        public IEnumerable<Address> Tokens { get; }
+
+        /// <summary>
+        /// Staking status filter, default ignores filter.
+        /// </summary>
+        public LiquidityPoolStakingStatusFilter StakingFilter { get; }
+
+        /// <summary>
+        /// Nomination status filter, default ignores filter.
+        /// </summary>
+        public LiquidityPoolNominationStatusFilter NominationFilter { get; }
+
+        /// <summary>
+        /// Mining status filter, default ignores filter.
+        /// </summary>
+        public LiquidityPoolMiningStatusFilter MiningFilter { get; }
+
+        /// <summary>
+        /// The order to sort records by.
+        /// </summary>
+        public LiquidityPoolOrderByType OrderBy { get; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var pointerBytes = Encoding.UTF8.GetBytes(Pointer.ToString());
+            var encodedPointer = Convert.ToBase64String(pointerBytes);
+
+            var sb = new StringBuilder();
+            sb.AppendFormat("direction:{0};limit:{1};paging:{2};", SortDirection, Limit, PagingDirection);
+            foreach (var pool in LiquidityPools) sb.AppendFormat("pools:{0};", pool);
+            foreach (var token in Tokens) sb.AppendFormat("tokens:{0};", token);
+            foreach (var market in Tokens) sb.AppendFormat("markets:{0};", market);
+            sb.AppendFormat("keyword:{0};", Keyword);
+            sb.AppendFormat("stakingFilter:{0};", StakingFilter);
+            sb.AppendFormat("nominationFilter:{0};", NominationFilter);
+            sb.AppendFormat("miningFilter:{0};", MiningFilter);
+            sb.AppendFormat("orderBy:{0};", OrderBy);
+            sb.AppendFormat("pointer:{0};", encodedPointer);
+            return sb.ToString();
+        }
+
+        /// <inheritdoc />
+        public override Cursor<(string, ulong)> Turn(PagingDirection direction, (string, ulong) pointer)
+        {
+            if (!direction.IsValid()) throw new ArgumentOutOfRangeException(nameof(direction), "Invalid paging direction.");
+            if (pointer == Pointer) throw new ArgumentOutOfRangeException(nameof(pointer), "Cannot paginate with an identical pointer.");
+
+            return new LiquidityPoolsCursor(Keyword, Markets, LiquidityPools, Tokens, StakingFilter, NominationFilter, MiningFilter,
+                                            OrderBy, SortDirection, Limit, direction, pointer);
+        }
+
+        /// <summary>
+        /// Parses a stringified version of the cursor
+        /// </summary>
+        /// <param name="raw">Stringified cursor</param>
+        /// <param name="cursor">Parsed cursor</param>
+        /// <returns>True if the value could be parsed, otherwise false</returns>
+        public static bool TryParse(string raw, out LiquidityPoolsCursor cursor)
+        {
+            cursor = null;
+
+            if (raw is null) return false;
+
+            var values = ToDictionary(raw);
+
+            TryGetCursorProperty<string>(values, "keyword", out var keyword);
+
+            TryGetCursorProperties<Address>(values, "markets", out var markets);
+
+            TryGetCursorProperty<LiquidityPoolOrderByType>(values, "orderBy", out var orderBy);
+
+            TryGetCursorProperties<Address>(values, "tokens", out var tokens);
+
+            TryGetCursorProperties<Address>(values, "pools", out var pools);
+
+            TryGetCursorProperty<LiquidityPoolStakingStatusFilter>(values, "stakingFilter", out var stakingFilter);
+
+            TryGetCursorProperty<LiquidityPoolNominationStatusFilter>(values, "nominationFilter", out var nominationFilter);
+
+            TryGetCursorProperty<LiquidityPoolMiningStatusFilter>(values, "miningFilter", out var miningFilter);
+
+            if (!TryGetCursorProperty<SortDirectionType>(values, "direction", out var direction)) return false;
+
+            if (!TryGetCursorProperty<uint>(values, "limit", out var limit)) return false;
+
+            if (!TryGetCursorProperty<string>(values, "pointer", out var pointerEncoded)) return false;
+
+            if (!pointerEncoded.HasValue()) return false;
+
+            if (!TryDecodePointer(pointerEncoded, out var pointer)) return false;
+
+            if (!TryGetCursorProperty<PagingDirection>(values, "paging", out var paging)) return false;
+
+            try
+            {
+                cursor = new LiquidityPoolsCursor(keyword, markets, pools, tokens, stakingFilter, nominationFilter, miningFilter,
+                                                  orderBy, direction, limit, paging, pointer);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryDecodePointer(string encoded, out (string, ulong) pointer)
+        {
+            pointer = (string.Empty, 0);
+
+            if (!encoded.TryBase64Decode(out var decoded)) return false;
+
+            var tupleParts = decoded.Replace("(", "").Replace(")", "").Split(',');
+
+            if (tupleParts.Length != 2 || !ulong.TryParse(tupleParts[1], out var ulongValue))
+            {
+                return false;
+            }
+
+            pointer = (tupleParts[0], ulongValue);
+
+            return true;
+        }
+    }
+
+    public enum LiquidityPoolMiningStatusFilter
+    {
+        /// <summary>
+        /// Default status is ignored in filter.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Mining enabled filter.
+        /// </summary>
+        Enabled = 1,
+
+        /// <summary>
+        /// Mining disabled filter.
+        /// </summary>
+        Disabled = 2
+    }
+
+    public enum LiquidityPoolNominationStatusFilter
+    {
+        /// <summary>
+        /// Default status is ignored in filter.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Nominated for liquidity mining filter.
+        /// </summary>
+        Nominated = 1,
+
+        /// <summary>
+        /// Not nominated for liquidity mining filter.
+        /// </summary>
+        NonNominated = 2
+    }
+
+    public enum LiquidityPoolStakingStatusFilter
+    {
+        /// <summary>
+        /// Default status is ignored in filter.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Staking enabled filter.
+        /// </summary>
+        Enabled = 1,
+
+        /// <summary>
+        /// Staking disabled filter.
+        /// </summary>
+        Disabled = 2
+    }
+
+    public enum LiquidityPoolOrderByType
+    {
+        /// <summary>
+        /// Default orders results based on when they were added to Opdex.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Order results by liquidity locked amounts.
+        /// </summary>
+        Liquidity = 1,
+
+        /// <summary>
+        /// Order results by daily volume.
+        /// </summary>
+        Volume = 2,
+
+        /// <summary>
+        /// Order results by locked staking weight.
+        /// </summary>
+        StakingWeight = 3,
+
+        /// <summary>
+        /// Order results alphabetically by name.
+        /// </summary>
+        Name = 4
+    }
+}

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/SelectLiquidityPoolsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/SelectLiquidityPoolsWithFilterQuery.cs
@@ -11,7 +11,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
     public class SelectLiquidityPoolsWithFilterQuery : IRequest<IEnumerable<LiquidityPool>>
     {
         /// <summary>
-        /// Constructor to build a retrieve liquidity pools with filter query.
+        /// Constructor to build a select liquidity pools with filter query.
         /// </summary>
         /// <param name="cursor">The liquidity pools cursor to filter by.</param>
         public SelectLiquidityPoolsWithFilterQuery(LiquidityPoolsCursor cursor)

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/SelectLiquidityPoolsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/SelectLiquidityPoolsWithFilterQuery.cs
@@ -1,41 +1,24 @@
 using MediatR;
-using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools
 {
+    /// <summary>
+    /// Select liquidity pools with filtering.
+    /// </summary>
     public class SelectLiquidityPoolsWithFilterQuery : IRequest<IEnumerable<LiquidityPool>>
     {
-        public SelectLiquidityPoolsWithFilterQuery(ulong marketId, bool? stakingEnabled = null, bool? miningEnabled = null, bool? nominated = null,
-                                                   uint skip = 0, uint take = 0, string sortBy = null, string orderBy = null, IEnumerable<Address> pools = null)
+        /// <summary>
+        /// Constructor to build a retrieve liquidity pools with filter query.
+        /// </summary>
+        /// <param name="cursor">The liquidity pools cursor to filter by.</param>
+        public SelectLiquidityPoolsWithFilterQuery(LiquidityPoolsCursor cursor)
         {
-            if (marketId < 1)
-            {
-                throw new ArgumentNullException(nameof(marketId), $"{nameof(marketId)} must be greater than 0.");
-            }
-
-            MarketId = marketId;
-            Staking = stakingEnabled;
-            Mining = miningEnabled;
-            Nominated = nominated;
-            Skip = skip;
-            Take = take;
-            SortBy = sortBy;
-            OrderBy = orderBy;
-            Pools = pools ?? Enumerable.Empty<Address>();
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor), "Liquidity pools cursor must be set.");
         }
 
-        public ulong MarketId { get; }
-        public bool? Staking { get; }
-        public bool? Mining { get; }
-        public bool? Nominated { get; }
-        public uint Skip { get; }
-        public uint Take { get; }
-        public string SortBy { get; }
-        public string OrderBy { get; }
-        public IEnumerable<Address> Pools { get; }
+        public LiquidityPoolsCursor Cursor { get; }
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/PersistLiquidityPoolCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/PersistLiquidityPoolCommandHandler.cs
@@ -15,6 +15,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
         private static readonly string SqlCommand =
             $@"INSERT INTO pool_liquidity (
                 {nameof(LiquidityPoolEntity.Address)},
+                {nameof(LiquidityPoolEntity.Name)},
                 {nameof(LiquidityPoolEntity.SrcTokenId)},
                 {nameof(LiquidityPoolEntity.LpTokenId)},
                 {nameof(LiquidityPoolEntity.MarketId)},
@@ -22,6 +23,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
                 {nameof(LiquidityPoolEntity.ModifiedBlock)}
               ) VALUES (
                 @{nameof(LiquidityPoolEntity.Address)},
+                @{nameof(LiquidityPoolEntity.Name)},
                 @{nameof(LiquidityPoolEntity.SrcTokenId)},
                 @{nameof(LiquidityPoolEntity.LpTokenId)},
                 @{nameof(LiquidityPoolEntity.MarketId)},

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByAddressQueryHandler.cs
@@ -17,6 +17,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
         private static readonly string SqlQuery =
             @$"SELECT
                 {nameof(LiquidityPoolEntity.Id)},
+                {nameof(LiquidityPoolEntity.Name)},
                 {nameof(LiquidityPoolEntity.Address)},
                 {nameof(LiquidityPoolEntity.SrcTokenId)},
                 {nameof(LiquidityPoolEntity.LpTokenId)},

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByIdQueryHandler.cs
@@ -16,6 +16,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
         private static readonly string SqlQuery =
             @$"SELECT
                 {nameof(LiquidityPoolEntity.Id)},
+                {nameof(LiquidityPoolEntity.Name)},
                 {nameof(LiquidityPoolEntity.Address)},
                 {nameof(LiquidityPoolEntity.SrcTokenId)},
                 {nameof(LiquidityPoolEntity.LpTokenId)},

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler.cs
@@ -16,6 +16,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
         private static readonly string SqlQuery =
             @$"SELECT
                 {nameof(LiquidityPoolEntity.Id)},
+                {nameof(LiquidityPoolEntity.Name)},
                 {nameof(LiquidityPoolEntity.Address)},
                 {nameof(LiquidityPoolEntity.SrcTokenId)},
                 {nameof(LiquidityPoolEntity.LpTokenId)},

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolsWithFilterQueryHandler.cs
@@ -140,7 +140,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
             }
 
             // Mining filter
-            if (request.Cursor.MiningFilter != LiquidityPoolMiningStatusFilter.Default)
+            if (request.Cursor.MiningFilter != LiquidityPoolMiningStatusFilter.Any)
             {
                 tableJoins += $" JOIN pool_mining pm on pl.{nameof(LiquidityPoolEntity.Id)} = pm.{nameof(MiningPoolEntity.LiquidityPoolId)}";
 
@@ -152,7 +152,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
             }
 
             // Staking filter
-            if (request.Cursor.StakingFilter != LiquidityPoolStakingStatusFilter.Default)
+            if (request.Cursor.StakingFilter != LiquidityPoolStakingStatusFilter.Any)
             {
                 var prefix = whereFilter.HasValue() ? " AND" : " WHERE";
                 whereFilter += request.Cursor.StakingFilter == LiquidityPoolStakingStatusFilter.Enabled
@@ -165,7 +165,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools
             }
 
             // Nominated filter
-            if (request.Cursor.NominationFilter != LiquidityPoolNominationStatusFilter.Default)
+            if (request.Cursor.NominationFilter != LiquidityPoolNominationStatusFilter.Any)
             {
                 tableJoins += $@" JOIN governance_nomination gn
                                     ON gn.{nameof(MiningGovernanceNominationEntity.LiquidityPoolId)} = pl.{nameof(LiquidityPoolEntity.Id)}";

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
@@ -77,7 +77,7 @@ namespace Opdex.Platform.Infrastructure
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<LiquidityPoolEntity, LiquidityPool>()
-                .ConstructUsing(src => new LiquidityPool(src.Id, src.Address, src.SrcTokenId, src.LpTokenId, src.MarketId, src.CreatedBlock, src.ModifiedBlock))
+                .ConstructUsing(src => new LiquidityPool(src.Id, src.Address, src.Name, src.SrcTokenId, src.LpTokenId, src.MarketId, src.CreatedBlock, src.ModifiedBlock))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<LiquidityPoolSummaryEntity, LiquidityPoolSummary>()
@@ -423,6 +423,7 @@ namespace Opdex.Platform.Infrastructure
             CreateMap<LiquidityPool, LiquidityPoolEntity>()
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
                 .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
                 .ForMember(dest => dest.SrcTokenId, opt => opt.MapFrom(src => src.SrcTokenId))
                 .ForMember(dest => dest.LpTokenId, opt => opt.MapFrom(src => src.LpTokenId))
                 .ForMember(dest => dest.MarketId, opt => opt.MapFrom(src => src.MarketId))

--- a/src/Opdex.Platform.WebApi/Controllers/LiquidityPoolsController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/LiquidityPoolsController.cs
@@ -39,10 +39,10 @@ namespace Opdex.Platform.WebApi.Controllers
         }
 
         /// <summary>Get Liquidity Pools</summary>
-        /// <remarks>Retrieve a list of pools that match the filters provided.</remarks>
-        /// <param name="filters">Filter liquidity pools by staking status. Default null is ignored.</param>
+        /// <remarks>Search and filter liquidity pools with pagination.</remarks>
+        /// <param name="filters">Liquidity pool filter options.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>List of <see cref="LiquidityPoolResponseModel"/>'s that match the filter criteria.</returns>
+        /// <returns><see cref="LiquidityPoolsResponseModel"/> of matching results and paging details.</returns>
         [HttpGet]
         [ProducesResponseType(typeof(LiquidityPoolsResponseModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -91,6 +91,7 @@ namespace Opdex.Platform.WebApi.Mappers
 
             CreateMap<LiquidityPoolDto, LiquidityPoolResponseModel>()
                 .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
+                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
                 .ForMember(dest => dest.TransactionFee, opt => opt.MapFrom(src => src.TransactionFee))
                 .ForMember(dest => dest.Token, opt => opt.MapFrom(src => src))
                 .ForMember(dest => dest.TransactionCount, opt => opt.MapFrom(src => src.Summary.TransactionCount))
@@ -107,6 +108,11 @@ namespace Opdex.Platform.WebApi.Mappers
                 .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.SrcToken))
                 .ForMember(dest => dest.Lp, opt => opt.MapFrom(src => src.LpToken))
                 .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.StakingToken))
+                .ForAllOtherMembers(opt => opt.Ignore());
+
+            CreateMap<LiquidityPoolsDto, LiquidityPoolsResponseModel>()
+                .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.LiquidityPools))
+                .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<LiquidityPoolSnapshotDto, LiquidityPoolSummaryResponseModel>()

--- a/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
@@ -26,7 +26,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.LiquidityPools
         public IEnumerable<Address> Markets { get; set; }
 
         /// <summary>
-        /// LiquidityPools to filter specifically for.
+        /// Liquidity pools to filter specifically for.
         /// </summary>
         public IEnumerable<Address> LiquidityPools { get; set; }
 

--- a/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
@@ -1,0 +1,69 @@
+using Opdex.Platform.Common.Extensions;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
+using System.Collections.Generic;
+
+namespace Opdex.Platform.WebApi.Models.Requests.LiquidityPools
+{
+    public class LiquidityPoolFilterParameters : FilterParameters<LiquidityPoolsCursor>
+    {
+        public LiquidityPoolFilterParameters()
+        {
+            Markets = new List<Address>();
+            LiquidityPools = new List<Address>();
+            Tokens = new List<Address>();
+        }
+
+        /// <summary>
+        /// A generic keyword search against liquidity pool addresses and names.
+        /// </summary>
+        public string Keyword { get; set; }
+
+        /// <summary>
+        /// Markets to search liquidity pools within.
+        /// </summary>
+        public IEnumerable<Address> Markets { get; set; }
+
+        /// <summary>
+        /// LiquidityPools to filter specifically for.
+        /// </summary>
+        public IEnumerable<Address> LiquidityPools { get; set; }
+
+        /// <summary>
+        /// Tokens to filter specifically for.
+        /// </summary>
+        public IEnumerable<Address> Tokens { get; set; }
+
+        /// <summary>
+        /// Staking status filter, default ignores filter.
+        /// </summary>
+        public LiquidityPoolStakingStatusFilter StakingFilter { get; set; }
+
+        /// <summary>
+        /// Nomination status filter, default ignores filter.
+        /// </summary>
+        public LiquidityPoolNominationStatusFilter NominationFilter { get; set; }
+
+        /// <summary>
+        /// Mining status filter, default ignores filter.
+        /// </summary>
+        public LiquidityPoolMiningStatusFilter MiningFilter { get; set; }
+
+        /// <summary>
+        /// The order to sort records by.
+        /// </summary>
+        public LiquidityPoolOrderByType OrderBy { get; set; }
+
+        /// <inheritdoc />
+        protected override LiquidityPoolsCursor InternalBuildCursor()
+        {
+            if (Cursor is null) return new LiquidityPoolsCursor(Keyword, Markets, LiquidityPools, Tokens, StakingFilter, NominationFilter, MiningFilter,
+                                                                OrderBy, Direction, Limit, PagingDirection.Forward, default);
+            Cursor.TryBase64Decode(out var decodedCursor);
+            LiquidityPoolsCursor.TryParse(decodedCursor, out var cursor);
+
+            return cursor;
+        }
+    }
+}

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolResponseModel.cs
@@ -7,6 +7,7 @@ namespace Opdex.Platform.WebApi.Models.Responses.Pools
     public class LiquidityPoolResponseModel : LiquidityPoolSummaryResponseModel
     {
         public Address Address { get; set; }
+        public string Name { get; set; }
         public decimal TransactionFee { get; set; }
         public LiquidityPoolTokenGroupResponseModel Token { get; set; }
         public MiningPoolResponseModel Mining { get; set; }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolsResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolsResponseModel.cs
@@ -1,0 +1,6 @@
+namespace Opdex.Platform.WebApi.Models.Responses.Pools
+{
+    public class LiquidityPoolsResponseModel : PaginatedResponseModel<LiquidityPoolResponseModel>
+    {
+    }
+}

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokensResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokensResponseModel.cs
@@ -2,6 +2,5 @@ namespace Opdex.Platform.WebApi.Models.Responses.Tokens
 {
     public class TokensResponseModel : PaginatedResponseModel<TokenResponseModel>
     {
-
     }
 }

--- a/src/Opdex.Platform.WebApi/Validation/LiquidityPools/LiquidityPoolFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/LiquidityPools/LiquidityPoolFilterParametersValidator.cs
@@ -7,14 +7,14 @@ using System.Text.RegularExpressions;
 
 namespace Opdex.Platform.WebApi.Validation.LiquidityPools
 {
-    public class LiquidityPoolFilterParametersTests : AbstractCursorValidator<LiquidityPoolFilterParameters, LiquidityPoolsCursor>
+    public class LiquidityPoolFilterParametersValidator : AbstractCursorValidator<LiquidityPoolFilterParameters, LiquidityPoolsCursor>
     {
-        private static readonly Regex Regex = new Regex("^[0-9A-Za-z ]+$");
+       const string RegexPattern = "^[0-9A-Za-z ]+$";
 
-        public LiquidityPoolFilterParametersTests()
+        public LiquidityPoolFilterParametersValidator()
         {
             RuleFor(filter => filter.Keyword)
-                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword))
+                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword, RegexPattern, RegexOptions.Compiled))
                 .WithMessage("Keyword must consist of letters, numbers and spaces only.");
 
             RuleFor(filter => filter.OrderBy).MustBeValidEnumValue();

--- a/src/Opdex.Platform.WebApi/Validation/LiquidityPools/LiquidityPoolFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/LiquidityPools/LiquidityPoolFilterParametersValidator.cs
@@ -9,12 +9,12 @@ namespace Opdex.Platform.WebApi.Validation.LiquidityPools
 {
     public class LiquidityPoolFilterParametersValidator : AbstractCursorValidator<LiquidityPoolFilterParameters, LiquidityPoolsCursor>
     {
-       const string RegexPattern = "^[0-9A-Za-z ]+$";
+       private static readonly Regex Alphanumeric = new Regex("^[0-9A-Za-z ]+$", RegexOptions.Compiled);
 
         public LiquidityPoolFilterParametersValidator()
         {
             RuleFor(filter => filter.Keyword)
-                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword, RegexPattern, RegexOptions.Compiled))
+                .Must(keyword => !keyword.HasValue() || Alphanumeric.IsMatch(keyword))
                 .WithMessage("Keyword must consist of letters, numbers and spaces only.");
 
             RuleFor(filter => filter.OrderBy).MustBeValidEnumValue();

--- a/src/Opdex.Platform.WebApi/Validation/LiquidityPools/LiquidityPoolFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/LiquidityPools/LiquidityPoolFilterParametersValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using Opdex.Platform.Common.Extensions;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
+using Opdex.Platform.WebApi.Models.Requests.LiquidityPools;
+using System.Text.RegularExpressions;
+
+namespace Opdex.Platform.WebApi.Validation.LiquidityPools
+{
+    public class LiquidityPoolFilterParametersTests : AbstractCursorValidator<LiquidityPoolFilterParameters, LiquidityPoolsCursor>
+    {
+        private static readonly Regex Regex = new Regex("^[0-9A-Za-z ]+$");
+
+        public LiquidityPoolFilterParametersTests()
+        {
+            RuleFor(filter => filter.Keyword)
+                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword))
+                .WithMessage("Keyword must consist of letters, numbers and spaces only.");
+
+            RuleFor(filter => filter.OrderBy).MustBeValidEnumValue();
+            RuleFor(filter => filter.StakingFilter).MustBeValidEnumValue();
+            RuleFor(filter => filter.MiningFilter).MustBeValidEnumValue();
+            RuleFor(filter => filter.NominationFilter).MustBeValidEnumValue();
+            RuleForEach(filter => filter.Markets).MustBeNetworkAddress();
+            RuleForEach(filter => filter.LiquidityPools).MustBeNetworkAddress();
+            RuleForEach(filter => filter.Tokens).MustBeNetworkAddress();
+            RuleFor(filter => filter.Limit).LessThanOrEqualTo(Cursor.DefaultMaxLimit);
+        }
+    }
+}

--- a/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
@@ -9,12 +9,12 @@ namespace Opdex.Platform.WebApi.Validation.Tokens
 {
     public class TokenFilterParametersValidator : AbstractCursorValidator<TokenFilterParameters, TokensCursor>
     {
-        const string RegexPattern = "^[0-9A-Za-z ]+$";
+        private static readonly Regex Alphanumeric = new Regex("^[0-9A-Za-z ]+$", RegexOptions.Compiled);
 
         public TokenFilterParametersValidator()
         {
             RuleFor(filter => filter.Keyword)
-                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword, RegexPattern, RegexOptions.Compiled))
+                .Must(keyword => !keyword.HasValue() || Alphanumeric.IsMatch(keyword))
                 .WithMessage("Keyword must consist of letters, numbers and spaces only.");
 
             RuleFor(filter => filter.OrderBy).MustBeValidEnumValue();

--- a/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
@@ -9,12 +9,12 @@ namespace Opdex.Platform.WebApi.Validation.Tokens
 {
     public class TokenFilterParametersValidator : AbstractCursorValidator<TokenFilterParameters, TokensCursor>
     {
-        private static readonly Regex Regex = new Regex("^[0-9A-Za-z ]+$");
+        const string RegexPattern = "^[0-9A-Za-z ]+$";
 
         public TokenFilterParametersValidator()
         {
             RuleFor(filter => filter.Keyword)
-                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword))
+                .Must(keyword => !keyword.HasValue() || Regex.IsMatch(keyword, RegexPattern, RegexOptions.Compiled))
                 .WithMessage("Keyword must consist of letters, numbers and spaces only.");
 
             RuleFor(filter => filter.OrderBy).MustBeValidEnumValue();

--- a/test/Opdex.Platform.Application.Tests/Assemblers/MarketTokenDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/MarketTokenDtoAssemblerTests.cs
@@ -107,7 +107,7 @@ namespace Opdex.Platform.Application.Tests.Assemblers
             var market = new Market(19, "kN2kwXwmu3wuFYmPBWQ38k7iYnkfGPPGgM", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
             var tokenSummary = new TokenSummary(1, market.Id, token.Id, 1.12m, 3.45m, 9, 10);
             var marketToken = new MarketToken(market, token);
-            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", token.Id, 15, market.Id, 500, 505);
+            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "STRAX-CRS", token.Id, 15, market.Id, 500, 505);
 
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenSummaryByMarketAndTokenIdQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(tokenSummary);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/MiningPositionDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/MiningPositionDtoAssemblerTests.cs
@@ -77,7 +77,7 @@ namespace Opdex.Platform.Application.Tests.Assemblers
             var miningPool = new MiningPool(10, 5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", UInt256.Parse("5000"), UInt256.Parse("1000"), 500000, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMiningPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(miningPool);
 
-            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", 5, 15, 25, 500, 505);
+            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
 
             // Act
@@ -100,7 +100,7 @@ namespace Opdex.Platform.Application.Tests.Assemblers
             var miningPool = new MiningPool(10, 5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", UInt256.Parse("5000"), UInt256.Parse("1000"), 500000, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMiningPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(miningPool);
 
-            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", 5, 15, 25, 500, 505);
+            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
 
             var token = new Token(15, "PWcdTKU64jVFCDoHJgUKz633jsy1XTenAy", true, "wBTC/CRS OLPT", "OLPT", 8, 8, UInt256.Parse("10000000000000000000"), 500, 505);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/StakingPositionDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/StakingPositionDtoAssemblerTests.cs
@@ -54,7 +54,7 @@ namespace Opdex.Platform.Application.Tests.Assemblers
             // Arrange
             var addressStaking = new AddressStaking(5, 10, "PMU9EjmivLgqqARwmH1iT1GLsMroh6zXXN", UInt256.Parse("50000000"), 500, 505);
 
-            var liquidityPool = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", 5, 15, 25, 500, 505);
+            var liquidityPool = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
 
             // Act
@@ -74,7 +74,7 @@ namespace Opdex.Platform.Application.Tests.Assemblers
             // Arrange
             var addressStaking = new AddressStaking(5, 10, "PMU9EjmivLgqqARwmH1iT1GLsMroh6zXXN", UInt256.Parse("50000000"), 500, 505);
 
-            var liquidityPool = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", 5, 15, 25, 500, 505);
+            var liquidityPool = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
 
             var market = new Market(5, "PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", 10, 50, Address.Empty, "PCiNwuLQemjMk63A6r5mS2Ma9Kskki6HZK", false, false, false, 1, true, 500, 505);
@@ -97,7 +97,7 @@ namespace Opdex.Platform.Application.Tests.Assemblers
             // Arrange
             var addressStaking = new AddressStaking(5, 10, "PMU9EjmivLgqqARwmH1iT1GLsMroh6zXXN", UInt256.Parse("5000000000"), 500, 505);
 
-            var liquidityPool = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", 5, 15, 25, 500, 505);
+            var liquidityPool = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
 
             var market = new Market(5, "PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", 10, 50, Address.Empty, "PCiNwuLQemjMk63A6r5mS2Ma9Kskki6HZK", false, false, false, 1, true, 500, 505);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Mining/GetMiningPositionByPoolQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Mining/GetMiningPositionByPoolQueryHandlerTests.cs
@@ -106,7 +106,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Mining
             var request = new GetMiningPositionByPoolQuery("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX");
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 15, 20, 25, 30);
+            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "ETH-CRS", 10, 15, 20, 25, 30);
             var addressMining = new AddressMining(5, 10, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", UInt256.Parse("100000000000"), 50, 500);
             var miningPool = new MiningPool(5, 5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", UInt256.Parse("10"), UInt256.Parse("10"), 10000, 25, 30);
 
@@ -132,7 +132,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Mining
             var request = new GetMiningPositionByPoolQuery("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX");
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 15, 20, 25, 30);
+            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "GOV-CRS", 10, 15, 20, 25, 30);
             var addressMining = new AddressMining(5, 10, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", 100000000000, 50, 500);
             var miningPool = new MiningPool(5, 5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 10, 10000, 25, 30);
             var token = new Token(5, "PDrzyNsewpj4KDnDttqcJT5EK7vZXQufNU", false, "Governance Token", "GOV", 8, 10000000, 10000000000000000000, 10, 20);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Staking/CreateRewindStakingPositionsCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Staking/CreateRewindStakingPositionsCommandHandlerTests.cs
@@ -79,7 +79,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Staking
                 new AddressStaking(2, 2, "P5uJYUcmAsqAEgUXjBJPuCXfcNKdN28FQf", 500, 20, 50)
             };
 
-            var liquidityPool = new LiquidityPool(2, "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk", 8, 7, 6, 4, 5);
+            var liquidityPool = new LiquidityPool(2, "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk", "ETH-CRS", 8, 7, 6, 4, 5);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveStakingPositionsByModifiedBlockQuery>(), It.IsAny<CancellationToken>()))
                      .ReturnsAsync(stakingPositions);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Staking/GetStakingPositionByPoolQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Staking/GetStakingPositionByPoolQueryHandlerTests.cs
@@ -56,7 +56,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Staking
             var request = new GetStakingPositionByPoolQuery("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX");
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 15, 20, 25, 30);
+            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "ETH-CRS", 10, 15, 20, 25, 30);
 
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liqudityPool);
 
@@ -81,7 +81,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Staking
             var request = new GetStakingPositionByPoolQuery("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX");
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 15, 20, 25, 30);
+            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "ETH-CRS", 10, 15, 20, 25, 30);
             var addressStaking = new AddressStaking(5, 5, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", UInt256.Parse("50000000000"), 50, 100);
 
             _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liqudityPool);
@@ -106,7 +106,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Staking
             var request = new GetStakingPositionByPoolQuery("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX");
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 15, 20, 25, 30);
+            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "ETH-CRS", 10, 15, 20, 25, 30);
             var addressStaking = new AddressStaking(5, 5, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", UInt256.Parse("50000000000"), 50, 100);
             var market = new Market(5, "PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", 5, 25, Address.Empty, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, false, false, 3, false, 50, 100);
 
@@ -133,7 +133,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Staking
             var request = new GetStakingPositionByPoolQuery("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX");
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 15, 20, 25, 30);
+            var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "GOV-CRS", 10, 15, 20, 25, 30);
             var addressStaking = new AddressStaking(5, 5, "PUFLuoW2K4PgJZ4nt5fEUHfvQXyQWKG9hm", UInt256.Parse("50000000000"), 50, 100);
             var market = new Market(5, "PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", 5, 25, Address.Empty, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, false, false, 3, false, 50, 100);
             var token = new Token(5, "PDrzyNsewpj4KDnDttqcJT5EK7vZXQufNU", false, "Governance Token", "GOV", 8, 10000000, UInt256.Parse("10000000000000000000"), 10, 20);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateAddLiquidityTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateAddLiquidityTransactionQuoteCommandHandlerTests.cs
@@ -173,7 +173,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.LiquidityPools
             FixedDecimal amountSrcMin = FixedDecimal.Parse("1.8");
             const ulong deadline = 1ul;
 
-            var pool = new LiquidityPool(1, liquidityPool, 2, 3, 4, 6, 7);
+            var pool = new LiquidityPool(1, liquidityPool, "BTC-CRS", 2, 3, 4, 6, 7);
             var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
             var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
             var cancellationToken = new CancellationTokenSource().Token;
@@ -232,7 +232,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.LiquidityPools
             FixedDecimal amountSrcMin = FixedDecimal.Parse("1.8");
             const ulong deadline = 5400;
 
-            var pool = new LiquidityPool(1, liquidityPool, 2, 3, 4, 6, 7);
+            var pool = new LiquidityPool(1, liquidityPool, "BTC-CRS", 2, 3, 4, 6, 7);
             var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
             var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
             var cancellationToken = new CancellationTokenSource().Token;

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateRemoveLiquidityTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateRemoveLiquidityTransactionQuoteCommandHandlerTests.cs
@@ -147,7 +147,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.LiquidityPools
             FixedDecimal amountSrcMin = FixedDecimal.Parse("1.8");
             const ulong deadline = 1ul;
 
-            var pool = new LiquidityPool(1, liquidityPool.ToString(), 2, 3, 4, 6, 7);
+            var pool = new LiquidityPool(1, liquidityPool.ToString(), "BTC-CRS", 2, 3, 4, 6, 7);
             var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
             var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
             var cancellationToken = new CancellationTokenSource().Token;
@@ -205,7 +205,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.LiquidityPools
             FixedDecimal amountSrcMin = FixedDecimal.Parse("1.8");
             const ulong deadline = 5400ul;
 
-            var pool = new LiquidityPool(1, liquidityPool.ToString(), 2, 3, 4, 6, 7);
+            var pool = new LiquidityPool(1, liquidityPool.ToString(), "BTC-CRS", 2, 3, 4, 6, 7);
             var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
             var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
             var cancellationToken = new CancellationTokenSource().Token;

--- a/test/Opdex.Platform.Application.Tests/Handlers/Governances/MakeGovernanceNominationsCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Governances/MakeGovernanceNominationsCommandHandlerTests.cs
@@ -174,10 +174,10 @@ namespace Opdex.Platform.Application.Tests.Handlers.Governances
 
             var expectedLiquidityPools = new List<LiquidityPool>
             {
-                new LiquidityPool(2, "PU9EMroh6zXXNMjmivLgqqARwmH1iT1GLs", 20, 21, 1, 3, 4),
-                new LiquidityPool(3, "PjmivLgqqARwmH1iT1GLsU9EMroh6zXXNM", 22, 23, 1, 3, 4),
-                new LiquidityPool(4, "PH1iT1GLsU9EMroh6zXXNMjmivLgqqARwm", 24, 25, 1, 3, 4),
-                new LiquidityPool(5, "PARwmH1iT1GLsU9EMroh6zXXNMjmivLgqq", 26, 27, 1, 3, 4)
+                new LiquidityPool(2, "PU9EMroh6zXXNMjmivLgqqARwmH1iT1GLs", "ETH-CRS", 20, 21, 1, 3, 4),
+                new LiquidityPool(3, "PjmivLgqqARwmH1iT1GLsU9EMroh6zXXNM", "BTC-CRS", 22, 23, 1, 3, 4),
+                new LiquidityPool(4, "PH1iT1GLsU9EMroh6zXXNMjmivLgqqARwm", "BNB-CRS", 24, 25, 1, 3, 4),
+                new LiquidityPool(5, "PARwmH1iT1GLsU9EMroh6zXXNMjmivLgqq", "RRT-CRS", 26, 27, 1, 3, 4)
             };
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveActiveGovernanceNominationsByGovernanceIdQuery>(), It.IsAny<CancellationToken>()))
@@ -233,10 +233,10 @@ namespace Opdex.Platform.Application.Tests.Handlers.Governances
 
             var expectedLiquidityPools = new List<LiquidityPool>
             {
-                new LiquidityPool(4, "PU9EMroh6zXXNMjmivLgqqARwmH1iT1GLs", 20, 21, 1, 3, 4),
-                new LiquidityPool(5, "PjmivLgqqARwmH1iT1GLsU9EMroh6zXXNM", 22, 23, 1, 3, 4),
-                new LiquidityPool(6, "PH1iT1GLsU9EMroh6zXXNMjmivLgqqARwm", 24, 25, 1, 3, 4),
-                new LiquidityPool(7, "PARwmH1iT1GLsU9EMroh6zXXNMjmivLgqq", 26, 27, 1, 3, 4)
+                new LiquidityPool(4, "PU9EMroh6zXXNMjmivLgqqARwmH1iT1GLs", "BTC-CRS", 20, 21, 1, 3, 4),
+                new LiquidityPool(5, "PjmivLgqqARwmH1iT1GLsU9EMroh6zXXNM", "ETH-CRS", 22, 23, 1, 3, 4),
+                new LiquidityPool(6, "PH1iT1GLsU9EMroh6zXXNMjmivLgqqARwm", "BNB-CRS", 24, 25, 1, 3, 4),
+                new LiquidityPool(7, "PARwmH1iT1GLsU9EMroh6zXXNMjmivLgqq", "RRT-CRS", 26, 27, 1, 3, 4)
             };
 
             var expectedMiningPools = new List<MiningPool>

--- a/test/Opdex.Platform.Application.Tests/Handlers/LiquidityPools/MakeLiquidityPoolCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/LiquidityPools/MakeLiquidityPoolCommandHandlerTests.cs
@@ -38,7 +38,7 @@ namespace Opdex.Platform.Application.Tests.Handlers.LiquidityPools
         public async Task MakeLiquidityPoolCommand_Sends_PersistLiquidityPoolCommand()
         {
             // Arrange
-            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", 5, 15, 25, 500, 505);
+            var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "ETH-CRS", 5, 15, 25, 500, 505);
 
             // Act
             await _handler.Handle(new MakeLiquidityPoolCommand(liquidityPool), CancellationToken.None);

--- a/test/Opdex.Platform.Domain.Tests/Models/LiquidityPools/LiquidityPoolTests.cs
+++ b/test/Opdex.Platform.Domain.Tests/Models/LiquidityPools/LiquidityPoolTests.cs
@@ -13,10 +13,24 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
         {
             // Arrange
             // Act
-            void Act() => new LiquidityPool(null, 1, 2, 3, 4);
+            void Act() => new LiquidityPool(null, "ETH-CRS", 1, 2, 3, 4);
 
             // Assert
             Assert.Throws<ArgumentNullException>(Act).Message.Contains("Liquidity pool address must be provided");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void CreateNewLiquidityPool_InvalidName_ThrowsArgumentNullException(string name)
+        {
+            // Arrange
+            // Act
+            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", name, 1, 2, 3, 4);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(Act).Message.Contains("Name must be provided");
         }
 
         [Fact]
@@ -24,7 +38,7 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
         {
             // Arrange
             // Act
-            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", 0, 2, 3, 4);
+            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "ETH-CRS", 0, 2, 3, 4);
 
             // Assert
             Assert.Throws<ArgumentOutOfRangeException>(Act).Message.Contains("SRC token id must be greater than zero.");
@@ -35,7 +49,7 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
         {
             // Arrange
             // Act
-            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", 1, 0, 3, 4);
+            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "ETH-CRS", 1, 0, 3, 4);
 
             // Assert
             Assert.Throws<ArgumentOutOfRangeException>(Act).Message.Contains("Liquidity pool token id must be greater than zero.");
@@ -46,7 +60,7 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
         {
             // Arrange
             // Act
-            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", 1, 2, 0, 4);
+            void Act() => new LiquidityPool("PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "ETH-CRS", 1, 2, 0, 4);
 
             // Assert
             Assert.Throws<ArgumentOutOfRangeException>(Act).Message.Contains("Market id must be greater than zero.");
@@ -57,14 +71,16 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
         public void CreateNewLiquidityPool_Success()
         {
             Address address = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            const string name = "ETH-CRS";
             const ulong srcId = 2;
             const ulong lptId = 4;
             const ulong marketId = 1;
             const ulong createdBlock = 3;
 
-            var pool = new LiquidityPool(address, srcId, lptId, marketId, createdBlock);
+            var pool = new LiquidityPool(address, name, srcId, lptId, marketId, createdBlock);
 
             pool.Id.Should().Be(0);
+            pool.Name.Should().Be(name);
             pool.Address.Should().Be(address);
             pool.SrcTokenId.Should().Be(srcId);
             pool.LpTokenId.Should().Be(lptId);
@@ -76,6 +92,7 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
         public void CreateExistingLiquidityPool_Success()
         {
             Address address = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
+            const string name = "ETH-CRS";
             const ulong id = 999;
             const ulong srcId = 2;
             const ulong lptId = 4;
@@ -83,9 +100,10 @@ namespace Opdex.Platform.Domain.Tests.Models.LiquidityPools
             const ulong createdBlock = 3;
             const ulong modifiedBlock = 10;
 
-            var pool = new LiquidityPool(id, address, srcId, lptId, marketId, createdBlock, modifiedBlock);
+            var pool = new LiquidityPool(id, address, name, srcId, lptId, marketId, createdBlock, modifiedBlock);
 
             pool.Id.Should().Be(id);
+            pool.Name.Should().Be(name);
             pool.Address.Should().Be(address);
             pool.SrcTokenId.Should().Be(srcId);
             pool.LpTokenId.Should().Be(lptId);

--- a/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/LiquidityPoolsCursorTests/LiquidityPoolsCursorTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/LiquidityPoolsCursorTests/LiquidityPoolsCursorTests.cs
@@ -124,6 +124,19 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Tests.Data.Queries.Liquidit
         }
 
         [Fact]
+        public void Create_With_MarketAddress()
+        {
+            // Act
+            Address market = "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L";
+
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(market);
+
+            // Assert
+            cursor.Markets.Should().Contain(market);
+        }
+
+        [Fact]
         public void ToString_StringifiesCursor_FormatCorrectly()
         {
             // Arrange

--- a/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/LiquidityPoolsCursorTests/LiquidityPoolsCursorTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/LiquidityPoolsCursorTests/LiquidityPoolsCursorTests.cs
@@ -1,0 +1,247 @@
+using FluentAssertions;
+using Opdex.Platform.Common.Enums;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Opdex.Platform.Infrastructure.Abstractions.Tests.Data.Queries.LiquidityPoolsCursorTests
+{
+    public class LiquidityPoolsCursorTests
+    {
+        [Fact]
+        public void Create_LimitExceedsMaximum_ThrowArgumentOutOfRangeException()
+        {
+            // Arrange
+            // Act
+            static void Act() => new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                          Enumerable.Empty<Address>(),
+                                                          Enumerable.Empty<Address>(),
+                                                          Enumerable.Empty<Address>(),
+                                                          LiquidityPoolStakingStatusFilter.Any,
+                                                          LiquidityPoolNominationStatusFilter.Any,
+                                                          LiquidityPoolMiningStatusFilter.Any,
+                                                          LiquidityPoolOrderByType.Any,
+                                                          SortDirectionType.ASC,
+                                                          50 + 1,
+                                                          PagingDirection.Forward,
+                                                          ("0", 0));
+
+            // Assert
+            Assert.Throws<ArgumentOutOfRangeException>("limit", Act);
+        }
+
+        [Theory]
+        [InlineData(PagingDirection.Backward, null, 0)]
+        public void Create_InvalidPointer_ThrowArgumentException(PagingDirection pagingDirection, string orderByPointer, ulong pointer)
+        {
+            // Arrange
+            // Act
+            void Act() => new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                   Enumerable.Empty<Address>(),
+                                                   Enumerable.Empty<Address>(),
+                                                   Enumerable.Empty<Address>(),
+                                                   LiquidityPoolStakingStatusFilter.Any,
+                                                   LiquidityPoolNominationStatusFilter.Any,
+                                                   LiquidityPoolMiningStatusFilter.Any,
+                                                   LiquidityPoolOrderByType.Any,
+                                                   SortDirectionType.ASC,
+                                                   25,
+                                                   pagingDirection,
+                                                   (orderByPointer, pointer));
+
+            // Assert
+            Assert.Throws<ArgumentException>("pointer", Act);
+        }
+
+        [Fact]
+        public void Create_NullMarketsProvided_SetToEmpty()
+        {
+            // Act
+            // Arrange
+            var cursor = new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                  null,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  ("0", 10));
+
+            // Assert
+            cursor.Markets.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Create_NullLiquidityPoolsProvided_SetToEmpty()
+        {
+            // Act
+            // Arrange
+            var cursor = new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                  Enumerable.Empty<Address>(),
+                                                  null,
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  ("0", 10));
+
+            // Assert
+            cursor.LiquidityPools.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Create_NullTokensProvided_SetToEmpty()
+        {
+            // Act
+            // Arrange
+            var cursor = new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  null,
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  ("0", 10));
+
+            // Assert
+            cursor.Tokens.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ToString_StringifiesCursor_FormatCorrectly()
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                  new List<Address> { "PUMpPykkfL3XhYPefjjc9U4kqdSqkCrc4L"},
+                                                  new List<Address> { "Pfjjc9U4kqdSqkUMpPykkfL3XhYPeCrc4L"},
+                                                  new List<Address> { "PU4kqdSqkCrc4LUMpPykkfL3XhYPefjjc9"},
+                                                  LiquidityPoolStakingStatusFilter.Enabled,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Disabled,
+                                                  LiquidityPoolOrderByType.Liquidity,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  ("50.00", 10));
+
+            // Act
+            var result = cursor.ToString();
+
+            // Assert
+            result.Should().Contain("keyword:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;");
+            result.Should().Contain("markets:PUMpPykkfL3XhYPefjjc9U4kqdSqkCrc4L;");
+            result.Should().Contain("liquidityPools:Pfjjc9U4kqdSqkUMpPykkfL3XhYPeCrc4L;");
+            result.Should().Contain("tokens:PU4kqdSqkCrc4LUMpPykkfL3XhYPefjjc9;");
+            result.Should().Contain("stakingFilter:Enabled;");
+            result.Should().Contain("nominationFilter:Any;");
+            result.Should().Contain("miningFilter:Disabled;");
+            result.Should().Contain("orderBy:Liquidity;");
+            result.Should().Contain("direction:ASC;");
+            result.Should().Contain("limit:25;");
+            result.Should().Contain("paging:Forward;");
+            result.Should().Contain("pointer:KDUwLjAwLCAxMCk=;");
+        }
+
+        [Fact]
+        public void Turn_NonIdenticalPointer_ReturnAnotherCursor()
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
+                                                  new List<Address> { "PUMpPykkfL3XhYPefjjc9U4kqdSqkCrc4L"},
+                                                  new List<Address> { "Pfjjc9U4kqdSqkUMpPykkfL3XhYPeCrc4L"},
+                                                  new List<Address> { "PU4kqdSqkCrc4LUMpPykkfL3XhYPefjjc9"},
+                                                  LiquidityPoolStakingStatusFilter.Enabled,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Disabled,
+                                                  LiquidityPoolOrderByType.Liquidity,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  ("50.00", 10));
+
+            // Act
+            var result = cursor.Turn(PagingDirection.Backward, ("100.00", 567));
+
+            // Assert
+            result.Should().BeOfType<LiquidityPoolsCursor>();
+            var adjacentCursor = (LiquidityPoolsCursor)result;
+            adjacentCursor.Keyword.Should().Be(cursor.Keyword);
+            adjacentCursor.Markets.Should().BeEquivalentTo(cursor.Markets);
+            adjacentCursor.LiquidityPools.Should().BeEquivalentTo(cursor.LiquidityPools);
+            adjacentCursor.Tokens.Should().BeEquivalentTo(cursor.Tokens);
+            adjacentCursor.StakingFilter.Should().Be(cursor.StakingFilter);
+            adjacentCursor.MiningFilter.Should().Be(cursor.MiningFilter);
+            adjacentCursor.NominationFilter.Should().Be(cursor.NominationFilter);
+            adjacentCursor.OrderBy.Should().BeEquivalentTo(cursor.OrderBy);
+            adjacentCursor.SortDirection.Should().Be(cursor.SortDirection);
+            adjacentCursor.Limit.Should().Be(cursor.Limit);
+            adjacentCursor.PagingDirection.Should().Be(PagingDirection.Backward);
+            adjacentCursor.Pointer.Should().Be(("100.00", 567));
+        }
+
+        [Theory]
+        [ClassData(typeof(NullOrWhitespaceStringData))]
+        [InlineData(";:;;;;;::;;;:::;;;:::;;:::;;")]
+        [InlineData("direction:Invalid;limit:50;paging:Forward;pointer:NTAw;")] // invalid direction
+        [InlineData("limit:50;paging:Forward;pointer:NTAw;")] // missing direction
+        [InlineData("direction:ASC;limit:51;paging:Forward;pointer:NTAw;")] // over max limit
+        [InlineData("direction:ASC;paging:Forward;pointer:NTAw;")] // missing limit
+        [InlineData("direction:ASC;limit:50;paging:Invalid;pointer:NTAw;")] // invalid paging direction
+        [InlineData("direction:ASC;limit:50;pointer:NTAw;")] // missing paging direction
+        [InlineData("direction:ASC;limit:50;paging:Forward;pointer:LTE=;")] // pointer: -1;
+        [InlineData("direction:ASC;limit:50;paging:Forward;pointer:YWJj")] // pointer: abc;
+        [InlineData("direction:ASC;limit:50;paging:Forward;pointer:10")] // pointer not valid base64
+        [InlineData("direction:ASC;limit:50;paging:Forward;")] // pointer missing
+        public void TryParse_InvalidCursor_ReturnFalse(string stringified)
+        {
+            // Arrange
+            // Act
+            var canParse = LiquidityPoolsCursor.TryParse(stringified, out var cursor);
+
+            // Assert
+            canParse.Should().Be(false);
+            cursor.Should().Be(null);
+        }
+
+        [Fact]
+        public void TryParse_ValidCursor_ReturnTrue()
+        {
+            // Arrange
+            var stringified = "keyword:PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5;orderBy:Name;stakingFilter:Enabled;miningFilter:Any;nominationFilter:NonNominated;markets:PL3XhYPefjjc9U4kSqkCUMpPykkfqdrc4L;liquidityPools:PqkCUMpPykkfqdrc4LL3XhYPefjjc9U4kS;tokens:PXKprGLzzUCPT9Wqu5AmvCGQNeVVDMbgUk;direction:ASC;limit:50;paging:Forward;pointer:KDUwLjAwLCAxMCk=;"; // pointer: 10;
+
+            // Act
+            var canParse = LiquidityPoolsCursor.TryParse(stringified, out var cursor);
+
+            // Assert
+            canParse.Should().Be(true);
+            cursor.Keyword.Should().Be("PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5");
+            cursor.OrderBy.Should().Be(LiquidityPoolOrderByType.Name);
+            cursor.StakingFilter.Should().Be(LiquidityPoolStakingStatusFilter.Enabled);
+            cursor.NominationFilter.Should().Be(LiquidityPoolNominationStatusFilter.NonNominated);
+            cursor.MiningFilter.Should().Be(LiquidityPoolMiningStatusFilter.Any);
+            cursor.Markets.Should().ContainSingle(m => m == "PL3XhYPefjjc9U4kSqkCUMpPykkfqdrc4L");
+            cursor.LiquidityPools.Should().ContainSingle(lp => lp == "PqkCUMpPykkfqdrc4LL3XhYPefjjc9U4kS");
+            cursor.Tokens.Should().ContainSingle(t => t == "PXKprGLzzUCPT9Wqu5AmvCGQNeVVDMbgUk");
+            cursor.SortDirection.Should().Be(SortDirectionType.ASC);
+            cursor.Limit.Should().Be(50);
+            cursor.PagingDirection.Should().Be(PagingDirection.Forward);
+            cursor.Pointer.Should().Be(("50.00", 10));
+        }
+    }
+}

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/PersistLiquidityPoolCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/PersistLiquidityPoolCommandHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools
         [Fact]
         public async Task InsertLiquidityPool_Success()
         {
-            var pool = new LiquidityPool("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", 1, 4, 1, 2);
+            var pool = new LiquidityPool("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "ETH-CRS", 1, 4, 1, 2);
             var command = new PersistLiquidityPoolCommand(pool);
 
             _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))
@@ -46,7 +46,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools
         {
             const ulong id = 99ul;
 
-            var pool = new LiquidityPool(id, "PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", 2, 3, 4, 5, 6);
+            var pool = new LiquidityPool(id, "PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", "ETH-CRS", 2, 3, 4, 5, 6);
             var command = new PersistLiquidityPoolCommand(pool);
 
             _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))
@@ -60,7 +60,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools
         [Fact]
         public async Task InsertLiquidityPool_Fail()
         {
-            var pool = new LiquidityPool("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", 1, 4, 1, 2);
+            var pool = new LiquidityPool("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "ETH-CRS", 1, 4, 1, 2);
             var command = new PersistLiquidityPoolCommand(pool);
 
             _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))
@@ -74,7 +74,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools
         [Fact]
         public async Task InsertMiningPool_Throws()
         {
-            var pool = new LiquidityPool("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", 1, 4, 1, 2);
+            var pool = new LiquidityPool("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", "ETH-CRS", 1, 4, 1, 2);
             var command = new PersistLiquidityPoolCommand(pool);
 
             _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>())).Throws<Exception>();

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/SelectLiquidityPoolsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/SelectLiquidityPoolsWithFilterQueryHandlerTests.cs
@@ -25,38 +25,38 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools
             _handler = new SelectLiquidityPoolsWithFilterQueryHandler(_dbContext.Object, mapper);
         }
 
-        [Fact]
-        public async Task SelectAllPools_Success()
-        {
-            const ulong marketId = 3;
-
-            var expectedEntity = new LiquidityPoolEntity
-            {
-                Id = 123454,
-                SrcTokenId = 2,
-                LpTokenId = 5,
-                MarketId = marketId,
-                Address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u",
-                CreatedBlock = 1,
-                ModifiedBlock = 1
-            };
-
-            var responseList = new[] { expectedEntity }.AsEnumerable();
-
-            var command = new SelectLiquidityPoolsWithFilterQuery(marketId);
-
-            _dbContext.Setup(db => db.ExecuteQueryAsync<LiquidityPoolEntity>(It.IsAny<DatabaseQuery>())).ReturnsAsync(responseList);
-
-            var results = await _handler.Handle(command, CancellationToken.None);
-
-            foreach (var result in results)
-            {
-                result.Id.Should().Be(expectedEntity.Id);
-                result.SrcTokenId.Should().Be(expectedEntity.SrcTokenId);
-                result.LpTokenId.Should().Be(expectedEntity.LpTokenId);
-                result.MarketId.Should().Be(expectedEntity.MarketId);
-                result.Address.Should().Be(expectedEntity.Address);
-            }
-        }
+        // [Fact]
+        // public async Task SelectAllPools_Success()
+        // {
+        //     const ulong marketId = 3;
+        //
+        //     var expectedEntity = new LiquidityPoolEntity
+        //     {
+        //         Id = 123454,
+        //         SrcTokenId = 2,
+        //         LpTokenId = 5,
+        //         MarketId = marketId,
+        //         Address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u",
+        //         CreatedBlock = 1,
+        //         ModifiedBlock = 1
+        //     };
+        //
+        //     var responseList = new[] { expectedEntity }.AsEnumerable();
+        //
+        //     var command = new SelectLiquidityPoolsWithFilterQuery(marketId);
+        //
+        //     _dbContext.Setup(db => db.ExecuteQueryAsync<LiquidityPoolEntity>(It.IsAny<DatabaseQuery>())).ReturnsAsync(responseList);
+        //
+        //     var results = await _handler.Handle(command, CancellationToken.None);
+        //
+        //     foreach (var result in results)
+        //     {
+        //         result.Id.Should().Be(expectedEntity.Id);
+        //         result.SrcTokenId.Should().Be(expectedEntity.SrcTokenId);
+        //         result.LpTokenId.Should().Be(expectedEntity.LpTokenId);
+        //         result.MarketId.Should().Be(expectedEntity.MarketId);
+        //         result.Address.Should().Be(expectedEntity.Address);
+        //     }
+        // }
     }
 }

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/SelectLiquidityPoolsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/SelectLiquidityPoolsWithFilterQueryHandlerTests.cs
@@ -1,10 +1,15 @@
 using AutoMapper;
 using FluentAssertions;
 using Moq;
+using Opdex.Platform.Common.Enums;
+using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,38 +30,331 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools
             _handler = new SelectLiquidityPoolsWithFilterQueryHandler(_dbContext.Object, mapper);
         }
 
-        // [Fact]
-        // public async Task SelectAllPools_Success()
-        // {
-        //     const ulong marketId = 3;
-        //
-        //     var expectedEntity = new LiquidityPoolEntity
-        //     {
-        //         Id = 123454,
-        //         SrcTokenId = 2,
-        //         LpTokenId = 5,
-        //         MarketId = marketId,
-        //         Address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u",
-        //         CreatedBlock = 1,
-        //         ModifiedBlock = 1
-        //     };
-        //
-        //     var responseList = new[] { expectedEntity }.AsEnumerable();
-        //
-        //     var command = new SelectLiquidityPoolsWithFilterQuery(marketId);
-        //
-        //     _dbContext.Setup(db => db.ExecuteQueryAsync<LiquidityPoolEntity>(It.IsAny<DatabaseQuery>())).ReturnsAsync(responseList);
-        //
-        //     var results = await _handler.Handle(command, CancellationToken.None);
-        //
-        //     foreach (var result in results)
-        //     {
-        //         result.Id.Should().Be(expectedEntity.Id);
-        //         result.SrcTokenId.Should().Be(expectedEntity.SrcTokenId);
-        //         result.LpTokenId.Should().Be(expectedEntity.LpTokenId);
-        //         result.MarketId.Should().Be(expectedEntity.MarketId);
-        //         result.Address.Should().Be(expectedEntity.Address);
-        //     }
-        // }
+        [Fact]
+        public void SelectLiquidityPoolsWithFilterQuery_InvalidCursor_ThrowArgumentNullException()
+        {
+            // Arrange
+
+            // Act
+            void Act() => new SelectLiquidityPoolsWithFilterQuery(null);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(Act).Message.Should().Contain("Liquidity pools cursor must be set.");
+        }
+
+        [Fact]
+        public async Task Handle_Filter_Markets()
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  new List<Address> { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" },
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            const string expected = "WHERE m.Address IN @Markets";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(expected))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Filter_LiquidityPools()
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  new List<Address> { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" },
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            const string expected = "WHERE pl.Address IN @LiquidityPools";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(expected))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Filter_Tokens()
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  new List<Address> { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" },
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            const string expected = "WHERE t.Address IN @Tokens";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(expected))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Filter_Keyword()
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor("BTC",
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            const string name = "WHERE (pl.Name LIKE CONCAT('%', @Keyword, '%') OR";
+            const string address = "pl.Address LIKE CONCAT('%', @Keyword, '%'))";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(name) &&
+                                                                                                                q.Sql.Contains(address))), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(LiquidityPoolStakingStatusFilter.Enabled)]
+        [InlineData(LiquidityPoolStakingStatusFilter.Disabled)]
+        public async Task Handle_Filter_StakingFilter(LiquidityPoolStakingStatusFilter filter)
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  filter,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            string expected = filter == LiquidityPoolStakingStatusFilter.Enabled
+                ? "WHERE (m.StakingTokenId > 0 AND pl.SrcTokenId != m.StakingTokenId)"
+                : "WHERE (m.StakingTokenId = 0 OR (m.StakingTokenId > 0 AND pl.SrcTokenId = m.StakingTokenId))";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(expected))), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(LiquidityPoolMiningStatusFilter.Enabled)]
+        [InlineData(LiquidityPoolMiningStatusFilter.Disabled)]
+        public async Task Handle_Filter_MiningFilter(LiquidityPoolMiningStatusFilter filter)
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  filter,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            const string expectedJoin = "JOIN pool_mining pm on pl.Id = pm.LiquidityPoolId";
+            var conditional = filter == LiquidityPoolMiningStatusFilter.Enabled ? ">=" : "<";
+            string expectedFilter = $"WHERE (pm.MiningPeriodEndBlock {conditional} (SELECT Height FROM block ORDER BY Height DESC LIMIT 1))";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(expectedJoin) &&
+                                                                                                                q.Sql.Contains(expectedFilter))), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(LiquidityPoolNominationStatusFilter.Nominated)]
+        [InlineData(LiquidityPoolNominationStatusFilter.NonNominated)]
+        public async Task Handle_Filter_NominationFilter(LiquidityPoolNominationStatusFilter filter)
+        {
+            // Arrange
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  filter,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  SortDirectionType.ASC,
+                                                  25,
+                                                  PagingDirection.Forward,
+                                                  default);
+
+            const string expectedJoin = " JOIN governance_nomination gn ON gn.LiquidityPoolId = pl.Id";
+            var conditional = filter == LiquidityPoolNominationStatusFilter.Nominated ? "true" : "false";
+            string expectedFilter = $"WHERE gn.IsNominated = {conditional}";
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo => callTo.ExecuteQueryAsync<LiquidityPoolEntity>(It.Is<DatabaseQuery>(q => q.Sql.Contains(expectedJoin) &&
+                                                                                                                q.Sql.Contains(expectedFilter))), Times.Once);
+        }
+
+        [Fact]
+        public async Task SelectLiquidityPoolsWithFilter_ByCursor_NextASC()
+        {
+            // Arrange
+            const SortDirectionType direction = SortDirectionType.ASC;
+            const uint limit = 25U;
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Any,
+                                                  direction,
+                                                  limit,
+                                                  PagingDirection.Forward,
+                                                  (string.Empty, 10));
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo =>
+                                  callTo.ExecuteQueryAsync<LiquidityPoolEntity>(
+                                      It.Is<DatabaseQuery>(q => q.Sql.Contains("pl.Id > @LiquidityPoolId") &&
+                                                                q.Sql.Contains($"ORDER BY pl.Id {direction}") &&
+                                                                q.Sql.Contains($"LIMIT {limit + 1}"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task SelectLiquidityPoolsWithFilter_ByCursor_NextDESC()
+        {
+            // Arrange
+            const SortDirectionType direction = SortDirectionType.DESC;
+            const uint limit = 25U;
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Name,
+                                                  direction,
+                                                  limit,
+                                                  PagingDirection.Forward,
+                                                  ("Bitcoin", 10));
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo =>
+                                  callTo.ExecuteQueryAsync<LiquidityPoolEntity>(
+                                      It.Is<DatabaseQuery>(q => q.Sql.Contains("(pl.Name, pl.Id) < (@OrderByValue, @LiquidityPoolId)") &&
+                                                                q.Sql.Contains($"ORDER BY pl.Name {direction}, pl.Id {direction}") &&
+                                                                q.Sql.Contains($"LIMIT {limit + 1}"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task SelectLiquidityPoolsWithFilter_ByCursor_PreviousDESC()
+        {
+            // Arrange
+            const SortDirectionType direction = SortDirectionType.DESC;
+            const uint limit = 25U;
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Liquidity,
+                                                  direction,
+                                                  limit,
+                                                  PagingDirection.Backward,
+                                                  ("23.23", 10));
+
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo =>
+                                  callTo.ExecuteQueryAsync<LiquidityPoolEntity>(
+                                      It.Is<DatabaseQuery>(q => q.Sql.Contains("(pls.LiquidityUsd, pl.Id) > (@OrderByValue, @LiquidityPoolId)") &&
+                                                                q.Sql.Contains("ORDER BY pls.LiquidityUsd ASC, pl.Id ASC") &&
+                                                                q.Sql.Contains($"LIMIT {limit + 1}"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task SelectLiquidityPoolsWithFilter_ByCursor_PreviousASC()
+        {
+            // Arrange
+            const SortDirectionType direction = SortDirectionType.ASC;
+            const uint limit = 25U;
+            var cursor = new LiquidityPoolsCursor(string.Empty,
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  Enumerable.Empty<Address>(),
+                                                  LiquidityPoolStakingStatusFilter.Any,
+                                                  LiquidityPoolNominationStatusFilter.Any,
+                                                  LiquidityPoolMiningStatusFilter.Any,
+                                                  LiquidityPoolOrderByType.Volume,
+                                                  direction,
+                                                  limit,
+                                                  PagingDirection.Backward,
+                                                  ("23.23", 10));
+            // Act
+            await _handler.Handle(new SelectLiquidityPoolsWithFilterQuery(cursor), CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo =>
+                                  callTo.ExecuteQueryAsync<LiquidityPoolEntity>(
+                                      It.Is<DatabaseQuery>(q => q.Sql.Contains("(pls.VolumeUsd, pl.Id) < (@OrderByValue, @LiquidityPoolId)") &&
+                                                                q.Sql.Contains("ORDER BY pls.VolumeUsd DESC, pl.Id DESC") &&
+                                                                q.Sql.Contains($"LIMIT {limit + 1}"))), Times.Once);
+        }
     }
 }

--- a/test/Opdex.Platform.WebApi.Tests/Validation/LiquidityPools/LiquidityPoolFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/LiquidityPools/LiquidityPoolFilterParametersValidatorTests.cs
@@ -1,0 +1,346 @@
+using FluentValidation.TestHelper;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
+using Opdex.Platform.WebApi.Models.Requests.LiquidityPools;
+using Opdex.Platform.WebApi.Validation.LiquidityPools;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Validation.LiquidityPools
+{
+    public class LiquidityPoolFilterParametersValidatorTests
+    {
+        private readonly LiquidityPoolFilterParametersValidator _validator;
+
+        public LiquidityPoolFilterParametersValidatorTests()
+        {
+            _validator = new LiquidityPoolFilterParametersValidator();
+        }
+
+        [Theory]
+        [InlineData("*")]
+        [InlineData("?")]
+        [InlineData(":")]
+        [InlineData("asdf;")]
+        public void Keyword_Invalid(string keyword)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Keyword = keyword
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.Keyword).WithErrorMessage("Keyword must consist of letters, numbers and spaces only.");
+        }
+
+        [Theory]
+        [InlineData("asdf")]
+        [InlineData("fda")]
+        [InlineData("89df7g78eh5qehgn8943hg3")]
+        [InlineData("tVfGTqrToiTU9bfnvD5UDC5ZQVY4oj4jrc")]
+        [InlineData("Bitcoin Wrapped")]
+        public void Keyword_Valid(string keyword)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Keyword = keyword
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.Keyword);
+        }
+
+        [Fact]
+        public void OrderBy_Invalid()
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                OrderBy = (LiquidityPoolOrderByType)10000
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.OrderBy);
+        }
+
+        [Theory]
+        [InlineData(LiquidityPoolOrderByType.Liquidity)]
+        [InlineData(LiquidityPoolOrderByType.Volume)]
+        [InlineData(LiquidityPoolOrderByType.StakingWeight)]
+        [InlineData(LiquidityPoolOrderByType.Name)]
+        public void OrderBy_Valid(LiquidityPoolOrderByType orderBy)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                OrderBy = orderBy
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.OrderBy);
+        }
+
+        [Theory]
+        [ClassData(typeof(NullAddressData))]
+        [ClassData(typeof(EmptyAddressData))]
+        [ClassData(typeof(NonNetworkAddressData))]
+        public void LiquidityPools_LiquidityPools_Invalid(Address address)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                LiquidityPools = new List<Address> { address }
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.LiquidityPools);
+        }
+
+        [Fact]
+        public void LiquidityPools_LiquidityPools_Valid()
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                LiquidityPools = new List<Address> { new Address("tVfGTqrToiTU9bfnvD5UDC5ZQVY4oj4jrc") }
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.LiquidityPools);
+        }
+
+        [Theory]
+        [ClassData(typeof(NullAddressData))]
+        [ClassData(typeof(EmptyAddressData))]
+        [ClassData(typeof(NonNetworkAddressData))]
+        public void LiquidityPools_Tokens_Invalid(Address address)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Tokens = new List<Address> { address }
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.Tokens);
+        }
+
+        [Fact]
+        public void LiquidityPools_Tokens_Valid()
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Tokens = new List<Address> { new Address("tVfGTqrToiTU9bfnvD5UDC5ZQVY4oj4jrc") }
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.Tokens);
+        }
+
+        [Theory]
+        [ClassData(typeof(NullAddressData))]
+        [ClassData(typeof(EmptyAddressData))]
+        [ClassData(typeof(NonNetworkAddressData))]
+        public void LiquidityPools_Markets_Invalid(Address address)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Markets = new List<Address> { address }
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.Markets);
+        }
+
+        [Fact]
+        public void LiquidityPools_Markets_Valid()
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Markets = new List<Address> { new Address("tVfGTqrToiTU9bfnvD5UDC5ZQVY4oj4jrc") }
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.Markets);
+        }
+
+        [Theory]
+        [InlineData((LiquidityPoolStakingStatusFilter)1000)]
+        public void ProvisionalFilter_StakingFilter_Invalid(LiquidityPoolStakingStatusFilter filter)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                StakingFilter = filter
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.StakingFilter);
+        }
+
+        [Theory]
+        [InlineData((default))]
+        [InlineData(LiquidityPoolStakingStatusFilter.Any)]
+        [InlineData(LiquidityPoolStakingStatusFilter.Enabled)]
+        [InlineData(LiquidityPoolStakingStatusFilter.Disabled)]
+        public void ProvisionalFilter_StakingFilterValid(LiquidityPoolStakingStatusFilter filter)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                StakingFilter = filter
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.StakingFilter);
+        }
+
+        [Theory]
+        [InlineData((LiquidityPoolNominationStatusFilter)1000)]
+        public void ProvisionalFilter_NominationFilter_Invalid(LiquidityPoolNominationStatusFilter filter)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                NominationFilter = filter
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.NominationFilter);
+        }
+
+        [Theory]
+        [InlineData((default))]
+        [InlineData(LiquidityPoolNominationStatusFilter.Any)]
+        [InlineData(LiquidityPoolNominationStatusFilter.Nominated)]
+        [InlineData(LiquidityPoolNominationStatusFilter.NonNominated)]
+        public void ProvisionalFilter_NominationFilterValid(LiquidityPoolNominationStatusFilter filter)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                NominationFilter = filter
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.NominationFilter);
+        }
+
+        [Theory]
+        [InlineData((LiquidityPoolMiningStatusFilter)1000)]
+        public void ProvisionalFilter_MiningFilter_Invalid(LiquidityPoolMiningStatusFilter filter)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                MiningFilter = filter
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.MiningFilter);
+        }
+
+        [Theory]
+        [InlineData((default))]
+        [InlineData(LiquidityPoolMiningStatusFilter.Any)]
+        [InlineData(LiquidityPoolMiningStatusFilter.Enabled)]
+        [InlineData(LiquidityPoolMiningStatusFilter.Disabled)]
+        public void ProvisionalFilter_MiningFilterValid(LiquidityPoolMiningStatusFilter filter)
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                MiningFilter = filter
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.MiningFilter);
+        }
+
+        [Fact]
+        public void Limit_Invalid()
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Limit = Cursor.DefaultMaxLimit + 1
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(r => r.Limit);
+        }
+
+        [Fact]
+        public void Limit_Valid()
+        {
+            // Arrange
+            var request = new LiquidityPoolFilterParameters
+            {
+                Limit = Cursor.DefaultMaxLimit
+            };
+
+            // Act
+            var result = _validator.TestValidate(request);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(r => r.Limit);
+        }
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
@@ -1,5 +1,4 @@
 using FluentValidation.TestHelper;
-using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;


### PR DESCRIPTION
- market.stakingTokenId is no longer nullable
    - simplifies LP filtering and current implementation is inserting 0 instead of null anyways
- liquidity pool filter changes at GET `/liquidity-pools` with cursor pagination
- Adds indexed `Name` column to `pool_liquidity`, set during creation, for query simplification and improvements. 

*still need to add some tests*

Related to: https://github.com/Opdex/opdex-db-scripts/pull/23