### PR TITLE
[PAPI-170] IP rate limiting

### DIFF
--- a/src/Opdex.Platform.WebApi/Exceptions/TooManyRequestsException.cs
+++ b/src/Opdex.Platform.WebApi/Exceptions/TooManyRequestsException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Opdex.Platform.WebApi.Exceptions
+{
+    public class TooManyRequestsException : Exception
+    {
+        public TooManyRequestsException(double limit, string period, string retryAfter)
+        {
+            Limit = limit;
+            Period = period;
+            RetryAfter = retryAfter;
+        }
+
+        public double Limit { get; }
+        public string Period { get; }
+        public string RetryAfter { get; }
+    }
+}

--- a/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj
+++ b/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
         <PackageReference Include="Autofac" Version="6.2.0" />
         <PackageReference Include="AutoMapper" Version="10.1.1" />
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />

--- a/src/Opdex.Platform.WebApi/appsettings.json
+++ b/src/Opdex.Platform.WebApi/appsettings.json
@@ -46,5 +46,32 @@
     "KeyVault": {
       "Name": ""
     }
+  },
+  "IpRateLimiting": {
+    "EnableEndpointRateLimiting": false,
+    "StackBlockedRequests": false,
+    "RealIpHeader": "X-Real-IP",
+    "ClientIdHeader": "X-ClientId",
+    "HttpStatusCode": 429,
+    "IpWhitelist": [
+      "127.0.0.1"
+    ],
+    "EndpointWhitelist": [],
+    "ClientWhitelist": [],
+    "GeneralRules": [
+      {
+        "Endpoint": "*",
+        "Period": "1s",
+        "Limit": 25
+      },
+      {
+        "Endpoint": "*",
+        "Period": "1m",
+        "Limit": 500
+      }
+    ]
+  },
+  "IpRateLimitPolicies": {
+    "IpRules": []
   }
 }


### PR DESCRIPTION
Basic IP rate limiting. Allows us to configure rules for each API instance.
Config can be used to turn off rate limiting for specific IP ranges, which could be useful, for example, if you wanted to route traffic through an API gateway.