### PR TITLE
[PAPI-88] Liquidity Pool History

### DIFF
--- a/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQuery.cs
@@ -18,11 +18,13 @@ namespace Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools.Sn
         /// <param name="cursor">The snapshot cursor filter.</param>
         public GetLiquidityPoolSnapshotsWithFilterQuery(Address liquidityPool, SnapshotCursor cursor)
         {
-            if (liquidityPool == Address.Empty) throw new ArgumentNullException(nameof(liquidityPool), "Liquidity pool address must not be empty.");
-            if (cursor is null) throw new ArgumentNullException(nameof(cursor));
+            if (liquidityPool == Address.Empty)
+            {
+                throw new ArgumentNullException(nameof(liquidityPool), "Liquidity pool address must not be empty.");
+            }
 
             LiquidityPool = liquidityPool;
-            Cursor = cursor;
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
         }
 
         public Address LiquidityPool { get; }

--- a/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryQueries/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQuery.cs
@@ -1,38 +1,31 @@
 using MediatR;
 using Opdex.Platform.Application.Abstractions.Models.LiquidityPools;
-using Opdex.Platform.Common.Enums;
-using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using System;
-using System.Collections.Generic;
 
 namespace Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools.Snapshots
 {
-    public class GetLiquidityPoolSnapshotsWithFilterQuery : IRequest<IEnumerable<LiquidityPoolSnapshotDto>>
+    /// <summary>
+    /// Get snapshot data for a given liquidity pool.
+    /// </summary>
+    public class GetLiquidityPoolSnapshotsWithFilterQuery : IRequest<LiquidityPoolSnapshotsDto>
     {
-        public GetLiquidityPoolSnapshotsWithFilterQuery(Address liquidityPoolAddress, string candleSpan, string timeSpan)
+        /// <summary>
+        /// Creates a request to retrieve snapshot data for a given liquidity pool.
+        /// </summary>
+        /// <param name="liquidityPool">The address of the liquidity pool.</param>
+        /// <param name="cursor">The snapshot cursor filter.</param>
+        public GetLiquidityPoolSnapshotsWithFilterQuery(Address liquidityPool, SnapshotCursor cursor)
         {
-            if (liquidityPoolAddress == Address.Empty)
-            {
-                throw new ArgumentNullException(nameof(liquidityPoolAddress));
-            }
+            if (liquidityPool == Address.Empty) throw new ArgumentNullException(nameof(liquidityPool), "Liquidity pool address must not be empty.");
+            if (cursor is null) throw new ArgumentNullException(nameof(cursor));
 
-            timeSpan = timeSpan.HasValue() ? timeSpan : "1W";
-            candleSpan = candleSpan.HasValue() ? candleSpan : "Daily";
-
-            if (!Enum.TryParse<SnapshotType>(candleSpan, out var snapshotType) ||
-                (snapshotType != SnapshotType.Daily && snapshotType != SnapshotType.Hourly))
-            {
-                throw new ArgumentOutOfRangeException(nameof(snapshotType));
-            }
-
-            SnapshotType = snapshotType;
-            TimeSpan = timeSpan;
-            LiquidityPoolAddress = liquidityPoolAddress;
+            LiquidityPool = liquidityPool;
+            Cursor = cursor;
         }
 
-        public Address LiquidityPoolAddress { get; }
-        public SnapshotType SnapshotType { get; }
-        public string TimeSpan { get; }
+        public Address LiquidityPool { get; }
+        public SnapshotCursor Cursor { get; }
     }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSnapshotDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSnapshotDto.cs
@@ -13,9 +13,7 @@ namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools
         public VolumeDto Volume { get; set; }
         public CostDto Cost { get; set; }
         public int SnapshotTypeId { get; set; }
-        public DateTime StartDate { get; set; }
-        public DateTime EndDate { get; set; }
-        public DateTime ModifiedDate { get; set; }
+        public DateTime Timestamp { get; set; }
         public int SrcTokenDecimals { get; set; }
     }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSnapshotsDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSnapshotsDto.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools
+{
+    public class LiquidityPoolSnapshotsDto
+    {
+        public IEnumerable<LiquidityPoolSnapshotDto> Snapshots { get; set; }
+
+        public CursorDto Cursor { get; set; }
+    }
+}

--- a/src/Opdex.Platform.Application.Abstractions/Queries/LiquidityPools/Snapshots/RetrieveLiquidityPoolSnapshotsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Queries/LiquidityPools/Snapshots/RetrieveLiquidityPoolSnapshotsWithFilterQuery.cs
@@ -1,14 +1,13 @@
 using MediatR;
-using Opdex.Platform.Common.Enums;
-using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Domain.Models.LiquidityPools.Snapshots;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using System;
 using System.Collections.Generic;
 
 namespace Opdex.Platform.Application.Abstractions.Queries.LiquidityPools.Snapshots
 {
     /// <summary>
-    /// Retrieve liquidity pool snapshots by the associated liquidity pool id, a date range and snapshot type.
+    /// Retrieve snapshots for the provided liquidity pool.
     /// </summary>
     public class RetrieveLiquidityPoolSnapshotsWithFilterQuery : IRequest<IEnumerable<LiquidityPoolSnapshot>>
     {
@@ -16,40 +15,14 @@ namespace Opdex.Platform.Application.Abstractions.Queries.LiquidityPools.Snapsho
         /// Constructor to create the retrieve liquidity pool snapshots with filter query.
         /// </summary>
         /// <param name="liquidityPoolId">The liquidity pool id of snapshots to find.</param>
-        /// <param name="startDate">The start date, earliest snapshot to find.</param>
-        /// <param name="endDate">The end date, latest snapshot to find.</param>
-        /// <param name="snapshotType">The type of snapshots to return, hourly/daily options.</param>
-        public RetrieveLiquidityPoolSnapshotsWithFilterQuery(ulong liquidityPoolId, DateTime startDate, DateTime endDate, SnapshotType snapshotType)
+        /// <param name="cursor">The snapshot cursor filter.</param>
+        public RetrieveLiquidityPoolSnapshotsWithFilterQuery(ulong liquidityPoolId, SnapshotCursor cursor)
         {
-            if (liquidityPoolId < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(liquidityPoolId));
-            }
-
-            if (startDate.Equals(default))
-            {
-                throw new ArgumentOutOfRangeException(nameof(startDate));
-            }
-
-            if (endDate.Equals(default) || endDate < startDate)
-            {
-                throw new ArgumentOutOfRangeException(nameof(endDate));
-            }
-
-            if (!snapshotType.IsValid())
-            {
-                throw new ArgumentOutOfRangeException(nameof(snapshotType));
-            }
-
-            LiquidityPoolId = liquidityPoolId;
-            StartDate = startDate;
-            EndDate = endDate;
-            SnapshotType = snapshotType;
+            LiquidityPoolId = liquidityPoolId > 0 ? liquidityPoolId : throw new ArgumentOutOfRangeException(nameof(liquidityPoolId));
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
         }
 
         public ulong LiquidityPoolId { get; }
-        public DateTime StartDate { get; }
-        public DateTime EndDate { get; }
-        public SnapshotType SnapshotType { get; }
+        public SnapshotCursor Cursor { get; }
     }
 }

--- a/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using Opdex.Platform.Common.Models.UInt;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Markets;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 
 namespace Opdex.Platform.Application.Assemblers
 {
@@ -72,7 +73,8 @@ namespace Opdex.Platform.Application.Assemblers
             poolDto.LpToken = await AssembleMarketToken(pool.LpTokenId, market);
 
             // LP pool snapshot details
-            var liquidityPoolSnapshots = await _mediator.Send(new RetrieveLiquidityPoolSnapshotsWithFilterQuery(pool.Id, yesterday, now, SnapshotType));
+            var cursor = new SnapshotCursor(Interval.OneDay, yesterday, now, SortDirectionType.DESC, 2, PagingDirection.Forward, default);
+            var liquidityPoolSnapshots = await _mediator.Send(new RetrieveLiquidityPoolSnapshotsWithFilterQuery(pool.Id, cursor));
             var poolSnapshots = liquidityPoolSnapshots.ToList();
 
             // Get the current snapshot from the list, when null, retrieve the last possible snapshot or a new one entirely

--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/Snapshots/CreateRewindTokenDailySnapshotCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/Snapshots/CreateRewindTokenDailySnapshotCommandHandler.cs
@@ -30,8 +30,8 @@ namespace Opdex.Platform.Application.EntryHandlers.Tokens.Snapshots
             var srcTokenDailySnapshot = await _mediator.Send(new RetrieveTokenSnapshotWithFilterQuery(request.TokenId, request.MarketId,
                                                                                                       request.StartDate, SnapshotType.Daily));
 
-            // Get existing hourly snapshots for the token
-            var cursor = new SnapshotCursor(Interval.OneHour, request.StartDate, request.EndDate, default, 24, PagingDirection.Forward, default);
+            // Get existing hourly snapshots for the token in DESC order
+            var cursor = new SnapshotCursor(Interval.OneHour, request.StartDate, request.EndDate, SortDirectionType.ASC, 24, PagingDirection.Forward, default);
             var srcTokenHourlySnapshots = await _mediator.Send(new RetrieveTokenSnapshotsWithFilterQuery(request.TokenId, request.MarketId, cursor));
 
             // If the rewind block is within the first hour of the day, that hourly snapshot will be deleted and none will exist.

--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/Snapshots/CreateRewindTokenDailySnapshotCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/Snapshots/CreateRewindTokenDailySnapshotCommandHandler.cs
@@ -30,7 +30,7 @@ namespace Opdex.Platform.Application.EntryHandlers.Tokens.Snapshots
             var srcTokenDailySnapshot = await _mediator.Send(new RetrieveTokenSnapshotWithFilterQuery(request.TokenId, request.MarketId,
                                                                                                       request.StartDate, SnapshotType.Daily));
 
-            // Get existing hourly snapshots for the token in DESC order
+            // Get existing hourly snapshots for the token in ASC order
             var cursor = new SnapshotCursor(Interval.OneHour, request.StartDate, request.EndDate, SortDirectionType.ASC, 24, PagingDirection.Forward, default);
             var srcTokenHourlySnapshots = await _mediator.Send(new RetrieveTokenSnapshotsWithFilterQuery(request.TokenId, request.MarketId, cursor));
 

--- a/src/Opdex.Platform.Application/Handlers/LiquidityPools/Snapshots/RetrieveLiquidityPoolSnapshotsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/LiquidityPools/Snapshots/RetrieveLiquidityPoolSnapshotsWithFilterQueryHandler.cs
@@ -19,13 +19,9 @@ namespace Opdex.Platform.Application.Handlers.LiquidityPools.Snapshots
             _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         }
 
-        public Task<IEnumerable<LiquidityPoolSnapshot>> Handle(RetrieveLiquidityPoolSnapshotsWithFilterQuery request,
-                                                               CancellationToken cancellationToken)
+        public Task<IEnumerable<LiquidityPoolSnapshot>> Handle(RetrieveLiquidityPoolSnapshotsWithFilterQuery request, CancellationToken cancellationToken)
         {
-            return _mediator.Send(new SelectLiquidityPoolSnapshotsWithFilterQuery(request.LiquidityPoolId,
-                                                                                  request.StartDate,
-                                                                                  request.EndDate,
-                                                                                  request.SnapshotType), cancellationToken);
+            return _mediator.Send(new SelectLiquidityPoolSnapshotsWithFilterQuery(request.LiquidityPoolId, request.Cursor), cancellationToken);
         }
     }
 }

--- a/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
@@ -117,9 +117,7 @@ namespace Opdex.Platform.Application
                 .ForMember(dest => dest.Volume, opt => opt.MapFrom(src => src.Volume))
                 .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
                 .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
-                .ForMember(dest => dest.StartDate, opt => opt.MapFrom(src => src.StartDate))
-                .ForMember(dest => dest.EndDate, opt => opt.MapFrom(src => src.EndDate))
-                .ForMember(dest => dest.ModifiedDate, opt => opt.MapFrom(src => src.ModifiedDate))
+                .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.StartDate))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<RewardsSnapshot, RewardsDto>()

--- a/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
@@ -213,7 +213,7 @@ namespace Opdex.Platform.Application
             services.AddTransient<IRequestHandler<GetSwapAmountInQuery, FixedDecimal>, GetSwapAmountInQueryHandler>();
             services.AddTransient<IRequestHandler<GetSwapAmountOutQuery, FixedDecimal>, GetSwapAmountOutQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityAmountInQuoteQuery, FixedDecimal>, GetLiquidityAmountInQuoteQueryHandler>();
-            services.AddTransient<IRequestHandler<GetLiquidityPoolSnapshotsWithFilterQuery, IEnumerable<LiquidityPoolSnapshotDto>>, GetLiquidityPoolSnapshotsWithFilterQueryHandler>();
+            services.AddTransient<IRequestHandler<GetLiquidityPoolSnapshotsWithFilterQuery, LiquidityPoolSnapshotsDto>, GetLiquidityPoolSnapshotsWithFilterQueryHandler>();
             services.AddTransient<IRequestHandler<GetLiquidityPoolByAddressQuery, LiquidityPoolDto>, GetLiquidityPoolByAddressQueryHandler>();
 
             // Mining Pools

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQuery.cs
@@ -1,6 +1,4 @@
 using MediatR;
-using Opdex.Platform.Common.Enums;
-using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Domain.Models.LiquidityPools.Snapshots;
 using System;
 using System.Collections.Generic;

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQuery.cs
@@ -8,48 +8,22 @@ using System.Collections.Generic;
 namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools.Snapshots
 {
     /// <summary>
-    /// Select liquidity pool snapshots by the associated liquidity pool id, a date range and snapshot type.
+    /// Select snapshots for a given liquidity pool.
     /// </summary>
     public class SelectLiquidityPoolSnapshotsWithFilterQuery: IRequest<IEnumerable<LiquidityPoolSnapshot>>
     {
         /// <summary>
         /// Constructor to create the select liquidity pool snapshots with filter query.
         /// </summary>
-        /// <param name="poolId">The liquidity pool id of snapshots to find.</param>
-        /// <param name="startDate">The start date, earliest snapshot to find.</param>
-        /// <param name="endDate">The end date, latest snapshot to find.</param>
-        /// <param name="snapshotType">The type of snapshots to return, hourly/daily options.</param>
-        public SelectLiquidityPoolSnapshotsWithFilterQuery(ulong poolId, DateTime startDate, DateTime endDate, SnapshotType snapshotType)
+        /// <param name="liquidityPoolId">The liquidity pool id of snapshots to find.</param>
+        /// <param name="cursor">The snapshot cursor filter.</param>
+        public SelectLiquidityPoolSnapshotsWithFilterQuery(ulong liquidityPoolId, SnapshotCursor cursor)
         {
-            if (poolId < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(poolId));
-            }
-
-            if (startDate.Equals(default))
-            {
-                throw new ArgumentOutOfRangeException(nameof(startDate));
-            }
-
-            if (endDate.Equals(default) || endDate < startDate)
-            {
-                throw new ArgumentOutOfRangeException(nameof(endDate));
-            }
-
-            if (!snapshotType.IsValid())
-            {
-                throw new ArgumentOutOfRangeException(nameof(snapshotType));
-            }
-
-            PoolId = poolId;
-            StartDate = startDate;
-            EndDate = endDate;
-            SnapshotType = snapshotType;
+            LiquidityPoolId = liquidityPoolId > 0 ? liquidityPoolId : throw new ArgumentOutOfRangeException(nameof(liquidityPoolId));
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
         }
 
-        public ulong PoolId { get; }
-        public DateTime StartDate { get; }
-        public DateTime EndDate { get; }
-        public SnapshotType SnapshotType { get; }
+        public ulong LiquidityPoolId { get; }
+        public SnapshotCursor Cursor { get; }
     }
 }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/Tokens/Snapshots/SelectTokenSnapshotsWithFilterQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/Tokens/Snapshots/SelectTokenSnapshotsWithFilterQuery.cs
@@ -18,12 +18,9 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens.Snapsho
         /// <param name="cursor">The snapshot cursor filter.</param>
         public SelectTokenSnapshotsWithFilterQuery(ulong tokenId, ulong marketId, SnapshotCursor cursor)
         {
-            if (tokenId < 1) throw new ArgumentOutOfRangeException(nameof(tokenId));
-            if (cursor is null) throw new ArgumentNullException(nameof(cursor));
-
-            TokenId = tokenId;
             MarketId = marketId;
-            Cursor = cursor;
+            TokenId = tokenId > 0 ? tokenId : throw new ArgumentOutOfRangeException(nameof(tokenId));
+            Cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
         }
 
         public ulong TokenId { get; }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQueryHandler.cs
@@ -56,7 +56,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools.Snapshots
         public async Task<IEnumerable<LiquidityPoolSnapshot>> Handle(SelectLiquidityPoolSnapshotsWithFilterQuery request, CancellationToken cancellationToken)
         {
             var queryParams = new SqlParams(request.LiquidityPoolId, request.Cursor.StartTime, request.Cursor.EndTime,
-                                            ConvertToSnapshotType(request.Cursor.Interval), request.Cursor.Pointer);
+                                            _mapper.Map<SnapshotType>(request.Cursor.Interval), request.Cursor.Pointer);
 
             var query = DatabaseQuery.Create(QueryBuilder(request), queryParams, cancellationToken);
 
@@ -113,17 +113,6 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools.Snapshots
             // re-sort back into requested order
             return PagingBackwardQuery.Replace(InnerQuery, query)
                                       .Replace(SortDirection, Enum.GetName(typeof(SortDirectionType), request.Cursor.SortDirection));
-        }
-
-        // consider better solution, likely need to reuse
-        private static SnapshotType ConvertToSnapshotType(Interval interval)
-        {
-            return interval switch
-            {
-                Interval.OneHour => SnapshotType.Hourly,
-                Interval.OneDay => SnapshotType.Daily,
-                _ => throw new ArgumentOutOfRangeException(nameof(interval))
-            };
         }
 
         private sealed class SqlParams

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/SelectTokenSnapshotsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/SelectTokenSnapshotsWithFilterQueryHandler.cs
@@ -34,8 +34,8 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Snapshots
             WHERE
                 {nameof(TokenSnapshotEntity.TokenId)} = @{nameof(SqlParams.TokenId)} AND
                 {nameof(TokenSnapshotEntity.MarketId)} = @{nameof(SqlParams.MarketId)} AND
-                {nameof(TokenSnapshotEntity.StartDate)} BETWEEN @{nameof(SqlParams.StartDate)} AND @{nameof(TokenSnapshotEntity.EndDate)} AND
-                {nameof(TokenSnapshotEntity.SnapshotTypeId)} = @{nameof(TokenSnapshotEntity.SnapshotTypeId)}
+                {nameof(TokenSnapshotEntity.StartDate)} BETWEEN @{nameof(SqlParams.StartDate)} AND @{nameof(SqlParams.EndDate)} AND
+                {nameof(TokenSnapshotEntity.SnapshotTypeId)} = @{nameof(SqlParams.SnapshotTypeId)}
             {WhereFilter}
             {OrderBy}
             {Limit}".RemoveExcessWhitespace();
@@ -56,7 +56,8 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Snapshots
 
         public async Task<IEnumerable<TokenSnapshot>> Handle(SelectTokenSnapshotsWithFilterQuery request, CancellationToken cancellationToken)
         {
-            var queryParams = new SqlParams(request.TokenId, request.MarketId, request.Cursor.StartTime, request.Cursor.EndTime, ConvertToSnapshotType(request.Cursor.Interval), request.Cursor.Pointer);
+            var queryParams = new SqlParams(request.TokenId, request.MarketId, request.Cursor.StartTime, request.Cursor.EndTime,
+                                            ConvertToSnapshotType(request.Cursor.Interval), request.Cursor.Pointer);
 
             var query = DatabaseQuery.Create(QueryBuilder(request), queryParams, cancellationToken);
 
@@ -116,7 +117,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Snapshots
         }
 
         // consider better solution, likely need to reuse
-        private SnapshotType ConvertToSnapshotType(Interval interval)
+        private static SnapshotType ConvertToSnapshotType(Interval interval)
         {
             return interval switch
             {

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/SelectTokenSnapshotsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/SelectTokenSnapshotsWithFilterQueryHandler.cs
@@ -57,7 +57,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Snapshots
         public async Task<IEnumerable<TokenSnapshot>> Handle(SelectTokenSnapshotsWithFilterQuery request, CancellationToken cancellationToken)
         {
             var queryParams = new SqlParams(request.TokenId, request.MarketId, request.Cursor.StartTime, request.Cursor.EndTime,
-                                            ConvertToSnapshotType(request.Cursor.Interval), request.Cursor.Pointer);
+                                            _mapper.Map<SnapshotType>(request.Cursor.Interval), request.Cursor.Pointer);
 
             var query = DatabaseQuery.Create(QueryBuilder(request), queryParams, cancellationToken);
 
@@ -114,17 +114,6 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Snapshots
             // re-sort back into requested order
             return PagingBackwardQuery.Replace(InnerQuery, query)
                                       .Replace(SortDirection, Enum.GetName(typeof(SortDirectionType), request.Cursor.SortDirection));
-        }
-
-        // consider better solution, likely need to reuse
-        private static SnapshotType ConvertToSnapshotType(Interval interval)
-        {
-            return interval switch
-            {
-                Interval.OneHour => SnapshotType.Hourly,
-                Interval.OneDay => SnapshotType.Daily,
-                _ => throw new ArgumentOutOfRangeException(nameof(interval))
-            };
         }
 
         private sealed class SqlParams

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
@@ -35,6 +35,8 @@ using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions.Transa
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.OHLC;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Vaults;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using System;
 
 namespace Opdex.Platform.Infrastructure
 {
@@ -585,6 +587,17 @@ namespace Opdex.Platform.Infrastructure
                 .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
                 .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
                 .ForAllOtherMembers(opt => opt.Ignore());
+
+            CreateMap<Interval, SnapshotType>()
+                .ConstructUsing((src, ctx) =>
+                {
+                    return src switch
+                    {
+                        Interval.OneDay => SnapshotType.Daily,
+                        Interval.OneHour => SnapshotType.Hourly,
+                        _ => throw new ArgumentOutOfRangeException("Interval", "Invalid Interval to Snapshot type")
+                    };
+                });
         }
     }
 }

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -145,8 +145,8 @@ namespace Opdex.Platform.WebApi.Mappers
                 .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.Timestamp))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
-            CreateMap<LiquidityPoolsDto, LiquidityPoolsResponseModel>()
-                .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.LiquidityPools))
+            CreateMap<LiquidityPoolSnapshotsDto, LiquidityPoolSnapshotsResponseModel>()
+                .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Snapshots))
                 .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
                 .ForAllOtherMembers(opt => opt.Ignore());
 

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -142,8 +142,12 @@ namespace Opdex.Platform.WebApi.Mappers
                 .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => MapStaking(src.Staking, src.Staking != null)))
                 .ForMember(dest => dest.Volume, opt => opt.MapFrom(src => MapVolume(src.Volume, src.SrcTokenDecimals)))
                 .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => MapCost(src.Cost, src.SrcTokenDecimals)))
-                .ForMember(dest => dest.StartDate, opt => opt.MapFrom(src => src.StartDate))
-                .ForMember(dest => dest.EndDate, opt => opt.MapFrom(src => src.EndDate))
+                .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.Timestamp))
+                .ForAllOtherMembers(opt => opt.Ignore());
+
+            CreateMap<LiquidityPoolsDto, LiquidityPoolsResponseModel>()
+                .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.LiquidityPools))
+                .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<MiningPoolDto, MiningPoolResponseModel>()

--- a/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
@@ -60,7 +60,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.LiquidityPools
         {
             if (Cursor is null) return new LiquidityPoolsCursor(Keyword, Markets, LiquidityPools, Tokens, StakingFilter, NominationFilter, MiningFilter,
                                                                 OrderBy, Direction, Limit, PagingDirection.Forward, default);
-            Cursor.TryBase64Decode(out var decodedCursor);
+            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
             LiquidityPoolsCursor.TryParse(decodedCursor, out var cursor);
 
             return cursor;

--- a/src/Opdex.Platform.WebApi/Models/Requests/SnapshotFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/SnapshotFilterParameters.cs
@@ -25,7 +25,7 @@ namespace Opdex.Platform.WebApi.Models.Requests
         protected override SnapshotCursor InternalBuildCursor()
         {
             if (Cursor is null) return new SnapshotCursor(Interval, StartDateTime, EndDateTime, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            Cursor.TryBase64Decode(out var decodedCursor);
             SnapshotCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/SnapshotFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/SnapshotFilterParameters.cs
@@ -25,7 +25,7 @@ namespace Opdex.Platform.WebApi.Models.Requests
         protected override SnapshotCursor InternalBuildCursor()
         {
             if (Cursor is null) return new SnapshotCursor(Interval, StartDateTime, EndDateTime, Direction, Limit, PagingDirection.Forward, default);
-            Cursor.TryBase64Decode(out var decodedCursor);
+            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
             SnapshotCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
@@ -37,7 +37,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Tokens
         protected override TokensCursor InternalBuildCursor()
         {
             if (Cursor is null) return new TokensCursor(Keyword, Tokens, Provisional, OrderBy, Direction, Limit, PagingDirection.Forward, default);
-            Cursor.TryBase64Decode(out var decodedCursor);
+            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
             TokensCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSnapshotResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSnapshotResponseModel.cs
@@ -1,10 +1,14 @@
+using NJsonSchema.Annotations;
 using System;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public class LiquidityPoolSnapshotResponseModel : LiquidityPoolSummaryResponseModel
     {
-        public DateTime StartDate { get; set; }
-        public DateTime EndDate { get; set; }
+        /// <summary>
+        /// The start time for the snapshot.
+        /// </summary>
+        [NotNull]
+        public DateTime Timestamp { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSnapshotsResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSnapshotsResponseModel.cs
@@ -1,0 +1,6 @@
+namespace Opdex.Platform.WebApi.Models.Responses.Pools
+{
+    public class LiquidityPoolSnapshotsResponseModel : PaginatedResponseModel<LiquidityPoolSnapshotResponseModel>
+    {
+    }
+}

--- a/test/Opdex.Platform.Application.Abstractions.Tests/EntryQueries/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQueryTests.cs
+++ b/test/Opdex.Platform.Application.Abstractions.Tests/EntryQueries/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQueryTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools.Snapshots;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using System;
+using Xunit;
+
+namespace Opdex.Platform.Application.Abstractions.Tests.EntryQueries.LiquidityPools.Snapshots
+{
+    public class GetLiquidityPoolSnapshotsWithFilterQueryTests
+    {
+        [Fact]
+        public void Create_LiquidityPoolEmpty_ThrowArgumentNullException()
+        {
+            // Arrange
+            Address liquidityPool = Address.Empty;
+            SnapshotCursor cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, default, default, PagingDirection.Forward, default);
+
+            // Act
+            void Act() => new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPool, cursor);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            exception.ParamName.Should().Be("liquidityPool");
+        }
+
+        [Fact]
+        public void Create_CursorNull_ThrowArgumentNullException()
+        {
+            // Arrange
+            Address liquidityPool = new Address("PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZX");
+            SnapshotCursor cursor = null;
+
+            // Act
+            void Act() => new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPool, cursor);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            exception.ParamName.Should().Be("cursor");
+        }
+    }
+}

--- a/test/Opdex.Platform.Application.Abstractions.Tests/EntryQueries/MarketTokens/Snapshots/GetMarketTokenSnapshotsWithFilterQueryTests.cs
+++ b/test/Opdex.Platform.Application.Abstractions.Tests/EntryQueries/MarketTokens/Snapshots/GetMarketTokenSnapshotsWithFilterQueryTests.cs
@@ -5,7 +5,7 @@ using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using System;
 using Xunit;
 
-namespace Opdex.Platform.Application.Abstractions.Tests.EntryQueries.MarketTokens
+namespace Opdex.Platform.Application.Abstractions.Tests.EntryQueries.MarketTokens.Snapshots
 {
     public class GetMarketTokenSnapshotsWithFilterQueryTests
     {

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/Snapshots/GetLiquidityPoolSnapshotsWithFilterQueryHandlerTests.cs
@@ -1,0 +1,348 @@
+using AutoMapper;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools.Snapshots;
+using Opdex.Platform.Application.Abstractions.Models;
+using Opdex.Platform.Application.Abstractions.Models.LiquidityPools;
+using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
+using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools.Snapshots;
+using Opdex.Platform.Application.EntryHandlers.LiquidityPools.Snapshots;
+using Opdex.Platform.Common.Enums;
+using Opdex.Platform.Common.Extensions;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Domain.Models.LiquidityPools;
+using Opdex.Platform.Domain.Models.LiquidityPools.Snapshots;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.Application.Tests.EntryHandlers.LiquidityPools.Snapshots
+{
+    public class GetLiquidityPoolSnapshotsWithFilterQueryHandlerTests
+    {
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly Mock<IMapper> _mapperMock;
+
+        private readonly GetLiquidityPoolSnapshotsWithFilterQueryHandler _handler;
+
+        public GetLiquidityPoolSnapshotsWithFilterQueryHandlerTests()
+        {
+            _mediatorMock = new Mock<IMediator>();
+            _mapperMock = new Mock<IMapper>();
+
+            _handler = new GetLiquidityPoolSnapshotsWithFilterQueryHandler(_mediatorMock.Object, _mapperMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_RetrieveLiquidityPoolByAddressQuery_Send()
+        {
+            // Arrange
+            var liquidityPool = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, default, default, PagingDirection.Forward, default);
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPool, cursor);
+
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            // Act
+            try
+            {
+                await _handler.Handle(request, cancellationToken);
+            }
+            catch (Exception) { }
+
+            // Assert
+            _mediatorMock.Verify(callTo => callTo.Send(It.Is<RetrieveLiquidityPoolByAddressQuery>(query => query.Address == liquidityPool
+                                                                                                && query.FindOrThrow), cancellationToken), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_RetrieveLiquidityPoolSnapshotsWithFilterQuery_Send()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, default, default, PagingDirection.Forward, default);
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            // Act
+            try
+            {
+                await _handler.Handle(request, cancellationToken);
+            }
+            catch (Exception) { }
+
+            // Assert
+            _mediatorMock.Verify(callTo => callTo.Send(It.Is<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(query => query.LiquidityPoolId == liquidityPool.Id &&
+                                                                                                                     query.Cursor == cursor), cancellationToken), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_SnapshotsRetrieved_MapResults()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 10, PagingDirection.Forward, default);
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+
+            // Act
+            await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            _mapperMock.Verify(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>()), Times.Exactly(snapshots.Length));
+        }
+
+        [Fact]
+        public async Task Handle_LessThanLimitPlusOneResults_RemoveZero()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 3, PagingDirection.Forward, (DateTime.UtcNow, 10));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            dto.Snapshots.Count().Should().Be(snapshots.Length);
+        }
+
+        [Fact]
+        public async Task Handle_LimitPlusOneResultsPagingBackward_RemoveFirst()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 10));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            _mapperMock.Verify(callTo => callTo.Map<LiquidityPoolSnapshotDto>(snapshots[0]), Times.Never);
+            dto.Snapshots.Count().Should().Be(snapshots.Length - 1);
+        }
+
+        [Fact]
+        public async Task Handle_LimitPlusOneResultsPagingForward_RemoveLast()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 10));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            _mapperMock.Verify(callTo => callTo.Map<LiquidityPoolSnapshotDto>(snapshots[snapshots.Length - 1]), Times.Never);
+            dto.Snapshots.Count().Should().Be(snapshots.Length - 1);
+        }
+
+        [Fact]
+        public async Task Handle_FirstRequestInPagedResults_ReturnCursor()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, default);
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            AssertNext(dto.Cursor, (snapshots[^2].StartDate, snapshots[^2].Id));
+            dto.Cursor.Previous.Should().Be(null);
+        }
+
+        [Fact]
+        public async Task Handle_PagingForwardWithMoreResults_ReturnCursor()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 50));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            AssertNext(dto.Cursor, (snapshots[^2].StartDate, snapshots[^2].Id));
+            AssertPrevious(dto.Cursor, (snapshots[0].StartDate, snapshots[0].Id));
+        }
+
+        [Fact]
+        public async Task Handle_PagingBackwardWithMoreResults_ReturnCursor()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 50));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(3, 1, 4, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T08:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T08:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            AssertNext(dto.Cursor, (snapshots[^1].StartDate, snapshots[^1].Id));
+            AssertPrevious(dto.Cursor, (snapshots[1].StartDate, snapshots[1].Id));
+        }
+
+        [Fact]
+        public async Task Handle_PagingForwardLastPage_ReturnCursor()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 50));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            dto.Cursor.Next.Should().Be(null);
+            AssertPrevious(dto.Cursor, (snapshots[0].StartDate, snapshots[0].Id));
+        }
+
+        [Fact]
+        public async Task Handle_PagingBackwardLastPage_ReturnCursor()
+        {
+            // Arrange
+            var liquidityPoolAddress = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");
+            var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 50));
+            var request = new GetLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolAddress, cursor);
+
+            var liquidityPool = new LiquidityPool(1, liquidityPoolAddress, "BTC-CRS", 1, 2, 3, 4, 5);
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
+
+            var snapshots = new []
+            {
+                new LiquidityPoolSnapshot(1, 1, 2, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T10:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T10:59:59Z").ToUniversalTime(), DateTime.Now),
+                new LiquidityPoolSnapshot(2, 1, 3, new ReservesSnapshot(), new RewardsSnapshot(), new StakingSnapshot(), new VolumeSnapshot(), new CostSnapshot(), SnapshotType.Hourly, DateTime.Parse("2021-11-06T09:00:00Z").ToUniversalTime(), DateTime.Parse("2021-11-06T09:59:59Z").ToUniversalTime(), DateTime.Now)
+            };
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(snapshots);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotDto>(It.IsAny<LiquidityPoolSnapshot>())).Returns(new LiquidityPoolSnapshotDto());
+
+            // Act
+            var dto = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            AssertNext(dto.Cursor, (snapshots[^1].StartDate, snapshots[^1].Id));
+            dto.Cursor.Previous.Should().Be(null);
+        }
+
+        private void AssertNext(CursorDto dto, (DateTime, ulong) pointer)
+        {
+            SnapshotCursor.TryParse(dto.Next.Base64Decode(), out var next).Should().Be(true);
+            next.PagingDirection.Should().Be(PagingDirection.Forward);
+            next.Pointer.Should().Be(pointer);
+        }
+
+        private void AssertPrevious(CursorDto dto, (DateTime, ulong) pointer)
+        {
+            SnapshotCursor.TryParse(dto.Previous.Base64Decode(), out var next).Should().Be(true);
+            next.PagingDirection.Should().Be(PagingDirection.Backward);
+            next.Pointer.Should().Be(pointer);
+        }
+    }
+}

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Snapshots/GetTokenSnapshotsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Snapshots/GetTokenSnapshotsWithFilterQueryHandlerTests.cs
@@ -39,7 +39,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Tokens.Snapshots
         }
 
         [Fact]
-        public async Task Handle_RetreiveTokenByAddressQuery_Send()
+        public async Task Handle_RetrieveTokenByAddressQuery_Send()
         {
             // Arrange
             var token = new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm");

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotsWithFilterQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools.Snapshots;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.OHLC;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools.Snapshots;
 using Opdex.Platform.Infrastructure.Data.Handlers.LiquidityPools.Snapshots;
 using System;
@@ -36,6 +37,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools.Snaps
             var startDate = new DateTime(2021, 6, 21, 12, 0, 0);
             var endDate = new DateTime(2021, 6, 21, 15, 0, 0);
             const SnapshotType snapshotType = SnapshotType.Daily;
+            var cursor = new SnapshotCursor(Interval.OneDay, startDate, endDate, SortDirectionType.ASC, 10, PagingDirection.Forward, default);
 
             var expectedEntity = new LiquidityPoolSnapshotEntity
             {
@@ -59,7 +61,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools.Snaps
 
             var entities = new List<LiquidityPoolSnapshotEntity> { expectedEntity };
 
-            var command = new SelectLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolId, startDate, endDate, snapshotType);
+            var command = new SelectLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolId, cursor);
 
             _dbContext.Setup(db => db.ExecuteQueryAsync<LiquidityPoolSnapshotEntity>(It.IsAny<DatabaseQuery>()))
                 .Returns(() => Task.FromResult(entities.AsEnumerable()));
@@ -112,9 +114,8 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.LiquidityPools.Snaps
             const ulong liquidityPoolId = 1;
             var startDate = new DateTime(2021, 6, 21, 12, 0, 0);
             var endDate = new DateTime(2021, 6, 21, 15, 0, 0);
-            const SnapshotType snapshotType = SnapshotType.Daily;
-
-            var command = new SelectLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolId, startDate, endDate, snapshotType);
+            var cursor = new SnapshotCursor(Interval.OneDay, startDate, endDate, SortDirectionType.ASC, 10, PagingDirection.Forward, default);
+            var command = new SelectLiquidityPoolSnapshotsWithFilterQuery(liquidityPoolId, cursor);
 
             _dbContext.Setup(db => db.ExecuteQueryAsync<LiquidityPoolSnapshotEntity>(It.IsAny<DatabaseQuery>()))
                 .Returns(() => Task.FromResult<IEnumerable<LiquidityPoolSnapshotEntity>>(null));

--- a/test/Opdex.Platform.WebApi.Tests/Controllers/LiquidityPoolsControllerTests/GetLiquidityPoolHistoryTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Controllers/LiquidityPoolsControllerTests/GetLiquidityPoolHistoryTests.cs
@@ -1,0 +1,111 @@
+using AutoMapper;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Opdex.Platform.Application.Abstractions.EntryQueries.LiquidityPools.Snapshots;
+using Opdex.Platform.Application.Abstractions.Models.LiquidityPools;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.WebApi.Controllers;
+using Opdex.Platform.WebApi.Models;
+using Opdex.Platform.WebApi.Models.Requests;
+using Opdex.Platform.WebApi.Models.Responses.Pools;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Controllers.LiquidityPoolsControllerTests
+{
+    public class GetLiquidityPoolHistoryTests
+    {
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly Mock<IMediator> _mediatorMock;
+        private readonly Mock<IApplicationContext> _contextMock;
+        private readonly LiquidityPoolsController _controller;
+
+        public GetLiquidityPoolHistoryTests()
+        {
+            _mapperMock = new Mock<IMapper>();
+            _mediatorMock = new Mock<IMediator>();
+            _contextMock = new Mock<IApplicationContext>();
+            _controller = new LiquidityPoolsController(_mediatorMock.Object, _mapperMock.Object, _contextMock.Object);
+        }
+
+        [Fact]
+        public async Task GetLiquidityPoolHistory_GetLiquidityPoolSnapshotsWithFilterQuery_Send()
+        {
+            // Arrange
+            Address liquidityPool = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u";
+            var filters = new SnapshotFilterParameters
+            {
+                StartDateTime = DateTime.UtcNow.AddDays(-5),
+                EndDateTime = DateTime.UtcNow,
+                Interval = Interval.OneDay
+            };
+
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            // Act
+            await _controller.GetLiquidityPoolHistory(liquidityPool, filters, cancellationToken);
+
+            // Assert
+            _mediatorMock.Verify(callTo => callTo.Send(It.Is<GetLiquidityPoolSnapshotsWithFilterQuery>(query => query.Cursor.StartTime == filters.StartDateTime
+                                                                                                     && query.Cursor.EndTime == filters.EndDateTime
+                                                                                                     && query.Cursor.Interval == filters.Interval
+                                                                                                     && query.Cursor.IsFirstRequest
+                                                                                                     && query.LiquidityPool == liquidityPool),
+                                                       cancellationToken), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetLiquidityPoolHistory_LiquidityPoolDto_Map()
+        {
+            // Arrange
+            Address liquidityPool = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u";
+            var filters = new SnapshotFilterParameters
+            {
+                StartDateTime = DateTime.UtcNow.AddDays(-5),
+                EndDateTime = DateTime.UtcNow,
+                Interval = Interval.OneDay
+            };
+
+            var dto = new LiquidityPoolSnapshotsDto();
+
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<GetLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(dto);
+
+            // Act
+            await _controller.GetLiquidityPoolHistory(liquidityPool, filters, CancellationToken.None);
+
+            // Assert
+            _mapperMock.Verify(callTo => callTo.Map<LiquidityPoolSnapshotsResponseModel>(It.IsAny<LiquidityPoolSnapshotsDto>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetLiquidityPoolHistory_ReturnOk()
+        {
+            // Arrange
+            Address liquidityPool = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u";
+            var filters = new SnapshotFilterParameters
+            {
+                StartDateTime = DateTime.UtcNow.AddDays(-5),
+                EndDateTime = DateTime.UtcNow,
+                Interval = Interval.OneDay
+            };
+
+            var dto = new LiquidityPoolSnapshotsDto();
+            var liquidityPoolResponse = new LiquidityPoolSnapshotsResponseModel();
+
+            _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<GetLiquidityPoolSnapshotsWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(dto);
+            _mapperMock.Setup(callTo => callTo.Map<LiquidityPoolSnapshotsResponseModel>(It.IsAny<LiquidityPoolSnapshotsDto>())).Returns(liquidityPoolResponse);
+
+            // Act
+            var response = await _controller.GetLiquidityPoolHistory(liquidityPool, filters, CancellationToken.None);
+
+            // Act
+            response.Result.Should().BeOfType<OkObjectResult>();
+            ((OkObjectResult)response.Result).Value.Should().Be(liquidityPoolResponse);
+        }
+    }
+}


### PR DESCRIPTION
Implements pagination on the get liquidity pool history endpoint following the get token history implementation.

*adding more test coverage but otherwise ready for review*