### PR TITLE
Attempt Indexer Unlock

### DIFF
--- a/src/Opdex.Platform.WebApi/IndexerBackgroundService.cs
+++ b/src/Opdex.Platform.WebApi/IndexerBackgroundService.cs
@@ -59,8 +59,18 @@ namespace Opdex.Platform.WebApi
 
                     if (indexLock.Locked)
                     {
-                        _logger.LogWarning(IndexingAlreadyRunningLog);
-                        continue;
+                        if (indexLock.InstanceId != _opdexConfiguration.InstanceId)
+                        {
+                            _logger.LogWarning(IndexingAlreadyRunningLog);
+                            continue;
+                        }
+                        else
+                        {
+                            // Todo: If this is somehow the "fix" for the locking indexer bug seen occasionally consider a rewind after unlock
+                            // Rewind would go back to block prior to the previous locking timestamp to ensure all transactions and blocks were processed
+                            await mediator.Send(new MakeIndexerUnlockCommand());
+                            _logger.LogWarning("Indexer forcefully unlocked");
+                        }
                     }
 
                     await mediator.Send(new MakeIndexerLockCommand());

--- a/test/Opdex.Platform.WebApi.Tests/IndexerBackgroundServiceTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/IndexerBackgroundServiceTests.cs
@@ -20,14 +20,16 @@ namespace Opdex.Platform.WebApi.Tests
     {
         private readonly Mock<IMediator> _mediator;
         private readonly IndexerBackgroundService _indexerService;
-        private readonly string Identity;
+        private readonly string _primaryIdentity;
+        private readonly string _otherIdentity;
 
         public IndexerBackgroundServiceTests()
         {
             _mediator = new Mock<IMediator>();
 
             var opdexConfiguration = new OpdexConfiguration {Network = NetworkType.DEVNET};
-            Identity = opdexConfiguration.InstanceId;
+            _primaryIdentity = opdexConfiguration.InstanceId;
+            _otherIdentity = Guid.NewGuid().ToString();
 
             var logger = new NullLogger<IndexerBackgroundService>();
             var serviceCollection = new ServiceCollection();
@@ -55,7 +57,7 @@ namespace Opdex.Platform.WebApi.Tests
         {
             // Arrange
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(false, false, Identity, DateTime.UtcNow);
+            var indexLock = new IndexLock(false, false, _primaryIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
 
@@ -74,7 +76,8 @@ namespace Opdex.Platform.WebApi.Tests
         {
             // Arrange
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(true, true, Identity, DateTime.UtcNow);
+            // _primaryIdentity trying to index when _otherIdentity already is
+            var indexLock = new IndexLock(true, true, _otherIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
 
@@ -93,7 +96,7 @@ namespace Opdex.Platform.WebApi.Tests
         {
             // Arrange
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(true, false, Identity, DateTime.UtcNow);
+            var indexLock = new IndexLock(true, false, _primaryIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
             _mediator.Setup(callTo => callTo.Send(It.IsAny<MakeIndexerLockCommand>(), It.IsAny<CancellationToken>()))
@@ -114,7 +117,7 @@ namespace Opdex.Platform.WebApi.Tests
         {
             // Arrange
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(true, false, Identity, DateTime.UtcNow);
+            var indexLock = new IndexLock(true, false, _primaryIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
 
@@ -146,7 +149,7 @@ namespace Opdex.Platform.WebApi.Tests
         {
             // Arrange
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(true, false, Identity, DateTime.UtcNow);
+            var indexLock = new IndexLock(true, false, _primaryIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
 
@@ -161,9 +164,8 @@ namespace Opdex.Platform.WebApi.Tests
         public async Task StopAsync_DoesNotSend_MakeIndexerUnlockCommand_DifferentInstance()
         {
             // Arrange
-            var newIdentity = Guid.NewGuid().ToString();
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(true, true, newIdentity, DateTime.UtcNow);
+            var indexLock = new IndexLock(true, true, _otherIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
 
@@ -179,7 +181,7 @@ namespace Opdex.Platform.WebApi.Tests
         {
             // Arrange
             var token = new CancellationTokenSource().Token;
-            var indexLock = new IndexLock(true, true, Identity, DateTime.UtcNow);
+            var indexLock = new IndexLock(true, true, _primaryIdentity, DateTime.UtcNow);
 
             _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveIndexerLockQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(indexLock);
 


### PR DESCRIPTION
Attempt at resolving the occasional indexer locking seen on Testnet.

If the indexer is locked and the indexer comes back around to process next blocks, check if the instance that locked the table is the instance attempting to index, if so, unlock and move forward.

Based on findings of this implementation, we can take it further with a rewind to ensure no data was missed. 