### PR TITLE
[PAPI-247] Deploy Fixes

### DIFF
--- a/src/Opdex.Platform.Domain/Models/Transactions/SmartContractMethodParameter.cs
+++ b/src/Opdex.Platform.Domain/Models/Transactions/SmartContractMethodParameter.cs
@@ -5,6 +5,7 @@ using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Common.Models.UInt;
 using System;
+using System.Linq;
 
 namespace Opdex.Platform.Domain.Models.Transactions
 {
@@ -75,7 +76,7 @@ namespace Opdex.Platform.Domain.Models.Transactions
         public SmartContractMethodParameter(byte[] value)
         {
             if (value is null) throw new ArgumentNullException(nameof(value), "Byte array value must not be null.");
-            Value = BitConverter.ToString(value);
+            Value = BitConverter.ToString(value).Replace("-", "");
             Type = SmartContractParameterType.ByteArray;
         }
 
@@ -133,7 +134,9 @@ namespace Opdex.Platform.Domain.Models.Transactions
                 SmartContractParameterType.UInt64 => new SmartContractMethodParameter(ulong.Parse(values[1])),
                 SmartContractParameterType.Int64 => new SmartContractMethodParameter(long.Parse(values[1])),
                 SmartContractParameterType.Address => new SmartContractMethodParameter(new Address(values[1])),
-                SmartContractParameterType.ByteArray => new SmartContractMethodParameter(Array.ConvertAll(values[1].Split('-'), s => Convert.ToByte(s, 16))),
+                SmartContractParameterType.ByteArray => new SmartContractMethodParameter(Enumerable.Range(0, values[1].Length / 2)
+                                                                                                   .Select(x => Convert.ToByte(values[1].Substring(x * 2, 2), 16))
+                                                                                                   .ToArray()),
                 SmartContractParameterType.UInt128 => new SmartContractMethodParameter(UInt128.Parse(values[1])),
                 SmartContractParameterType.UInt256 => new SmartContractMethodParameter(UInt256.Parse(values[1])),
                 _ => throw new ArgumentException("Serialized parameter is not a recognized type."),

--- a/src/Opdex.Platform.WebApi/Controllers/DeployController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/DeployController.cs
@@ -1,5 +1,4 @@
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Application.Abstractions.Commands.Indexer;
@@ -52,7 +51,6 @@ namespace Opdex.Platform.WebApi.Controllers
         /// <param name="cancellationToken">cancellation token.</param>
         /// <returns>Success</returns>
         [HttpPost("dev-contracts")]
-        [Authorize(Policy = "AdminOnly")]
         [Network(NetworkType.DEVNET)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> DeployDevModeEnvironment(LocalWalletCredentials request, CancellationToken cancellationToken)

--- a/src/Opdex.Platform.WebApi/Controllers/DeployController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/DeployController.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Application.Abstractions.Commands.Indexer;
@@ -51,6 +52,7 @@ namespace Opdex.Platform.WebApi.Controllers
         /// <param name="cancellationToken">cancellation token.</param>
         /// <returns>Success</returns>
         [HttpPost("dev-contracts")]
+        [Authorize(Policy = "AdminOnly")]
         [Network(NetworkType.DEVNET)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> DeployDevModeEnvironment(LocalWalletCredentials request, CancellationToken cancellationToken)

--- a/test/Opdex.Platform.Domain.Tests/Models/Transactions/SmartContractMethodParameterTests.cs
+++ b/test/Opdex.Platform.Domain.Tests/Models/Transactions/SmartContractMethodParameterTests.cs
@@ -185,7 +185,7 @@ namespace Opdex.Platform.Domain.Tests.Models.Transactions
             var parameter = new SmartContractMethodParameter(value);
 
             // Assert
-            parameter.Value.Should().Be(BitConverter.ToString(value));
+            parameter.Value.Should().Be("64F1351C048282");
             parameter.Type.Should().Be(SmartContractParameterType.ByteArray);
         }
 
@@ -231,7 +231,7 @@ namespace Opdex.Platform.Domain.Tests.Models.Transactions
         }
 
         [Fact]
-        public void Deserialize()
+        public void Deserialize_Address()
         {
             // Arrange
             var address = new Address("PBSH3FTVne6gKiSgVBL4NRTJ31QmGShjMy");
@@ -243,6 +243,22 @@ namespace Opdex.Platform.Domain.Tests.Models.Transactions
             // Assert
             parameter.Type.Should().Be(SmartContractParameterType.Address);
             parameter.Value.Should().Be(address.ToString());
+        }
+
+        [Fact]
+        public void Deserialize_ByteArray()
+        {
+            // Arrange
+            byte[] value = new byte[] { 100, 241, 53, 28, 4, 130, 130 };
+            var serialized = new SmartContractMethodParameter(value).Serialize();
+
+            // Act
+            var parameter = SmartContractMethodParameter.Deserialize(serialized);
+
+            // Assert
+            parameter.Type.Should().Be(SmartContractParameterType.ByteArray);
+            parameter.Value.Should().Be("64F1351C048282");
+
         }
 
         [Fact]


### PR DESCRIPTION
* Correctly (de)serialize byte array smart contract params
* Remove auth from deployment - you can only have a market address of the auth token once the contracts are deployed