### PR TITLE
[PAPI-244] Wallet position improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": "Local DEVNET",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Opdex.Platform.WebApi/bin/Debug/netcoreapp3.1/Opdex.Platform.WebApi.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Opdex.Platform.WebApi",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            // "serverReadyAction": {
+            //     "action": "openExternally",
+            //     "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            // },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "OpdexConfiguration:Network": "DEVNET",
+                "OpdexConfiguration:ApiUrl": "https://localhost:44392"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            },
+            "logging": {
+                "moduleLoad": false
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandler.cs
@@ -8,8 +8,8 @@ using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
-using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Balances;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -58,7 +58,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances
         {
             var balanceId = request.Cursor.Pointer;
 
-            var queryParams = new SqlParams(balanceId, request.Address, request.Cursor.Tokens, request.Cursor.IncludeLpTokens);
+            var queryParams = new SqlParams(balanceId, request.Address, request.Cursor.Tokens, request.Cursor.TokenType == TokenProvisionalFilter.All || request.Cursor.TokenType == TokenProvisionalFilter.NonProvisional);
 
             var query = DatabaseQuery.Create(QueryBuilder(request), queryParams, cancellationToken);
 
@@ -72,7 +72,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances
             var whereFilter = $"WHERE ab.{nameof(AddressBalanceEntity.Owner)} = @{nameof(SqlParams.Wallet)}";
             var tableJoins = string.Empty;
 
-            if (request.Cursor.Tokens.Any() || !request.Cursor.IncludeLpTokens)
+            if (request.Cursor.Tokens.Any() || request.Cursor.TokenType != TokenProvisionalFilter.All)
             {
                 tableJoins += $" JOIN token t ON t.{nameof(TokenEntity.Id)} = ab.{nameof(AddressBalanceEntity.TokenId)}";
             }
@@ -101,7 +101,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances
                 whereFilter += $" AND t.{nameof(TokenEntity.Address)} IN @{nameof(SqlParams.Tokens)}";
             }
 
-            if (!request.Cursor.IncludeLpTokens)
+            if (request.Cursor.TokenType != TokenProvisionalFilter.All)
             {
                 whereFilter += $" AND t.{nameof(TokenEntity.IsLpt)} = @{nameof(SqlParams.IncludeLpTokens)}";
             }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandler.cs
@@ -58,7 +58,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances
         {
             var balanceId = request.Cursor.Pointer;
 
-            var queryParams = new SqlParams(balanceId, request.Address, request.Cursor.Tokens, request.Cursor.TokenType == TokenProvisionalFilter.All || request.Cursor.TokenType == TokenProvisionalFilter.NonProvisional);
+            var queryParams = new SqlParams(balanceId, request.Address, request.Cursor.Tokens, request.Cursor.TokenType == TokenProvisionalFilter.Provisional);
 
             var query = DatabaseQuery.Create(QueryBuilder(request), queryParams, cancellationToken);
 
@@ -103,7 +103,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances
 
             if (request.Cursor.TokenType != TokenProvisionalFilter.All)
             {
-                whereFilter += $" AND t.{nameof(TokenEntity.IsLpt)} = @{nameof(SqlParams.IncludeLpTokens)}";
+                whereFilter += $" AND t.{nameof(TokenEntity.IsLpt)} = @{nameof(SqlParams.IsLpt)}";
             }
 
             if (!request.Cursor.IncludeZeroBalances)
@@ -140,18 +140,18 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances
 
         private sealed class SqlParams
         {
-            internal SqlParams(ulong balanceId, Address wallet, IEnumerable<Address> tokens, bool includeLpTokens)
+            internal SqlParams(ulong balanceId, Address wallet, IEnumerable<Address> tokens, bool isLpt)
             {
                 BalanceId = balanceId;
                 Wallet = wallet;
                 Tokens = tokens.Select(token => token.ToString());
-                IncludeLpTokens = includeLpTokens;
+                IsLpt = isLpt;
             }
 
             public ulong BalanceId { get; }
             public Address Wallet { get; }
             public IEnumerable<string> Tokens { get; }
-            public bool IncludeLpTokens { get; }
+            public bool IsLpt { get; }
         }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
@@ -2,6 +2,7 @@ using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Balances;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using System.Collections.Generic;
 
 namespace Opdex.Platform.WebApi.Models.Requests.Wallets
@@ -11,7 +12,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         public AddressBalanceFilterParameters()
         {
             Tokens = new List<Address>();
-            IncludeLpTokens = true;
+            TokenType = TokenProvisionalFilter.All;
         }
 
         /// <summary>
@@ -20,9 +21,9 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         public IEnumerable<Address> Tokens { get; set; }
 
         /// <summary>
-        /// Includes all tokens if true, otherwise excludes liquidity pool tokens if false. Default true.
+        /// The type of token to filter by, either provisional or non-provisional.
         /// </summary>
-        public bool IncludeLpTokens { get; set; }
+        public TokenProvisionalFilter TokenType { get; set; }
 
         /// <summary>
         /// Includes zero balances if true, otherwise filters out zero balances if false. Default false.
@@ -32,7 +33,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <inheritdoc />
         protected override AddressBalancesCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new AddressBalancesCursor(Tokens, IncludeLpTokens, IncludeZeroBalances, Direction, Limit, PagingDirection.Forward, default);
+            if (Cursor is null) return new AddressBalancesCursor(Tokens, TokenType, IncludeZeroBalances, Direction, Limit, PagingDirection.Forward, default);
             Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
             AddressBalancesCursor.TryParse(decodedCursor, out var cursor);
             return cursor;

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Balances/GetAddressBalancesWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Balances/GetAddressBalancesWithFilterQueryHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_RetrieveAddressBalancesWithFilterQuery_Send()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 25, PagingDirection.Backward, 55);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 25, PagingDirection.Backward, 55);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
             var cancellationToken = new CancellationTokenSource().Token;
 
@@ -60,7 +60,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_BalancesRetrieved_MapResults()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 25, PagingDirection.Backward, 55);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 25, PagingDirection.Backward, 55);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balance = new AddressBalance(5, 10, "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", 10000000000, 500, 505);
@@ -78,7 +78,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_LessThanLimitPlusOneResults_RemoveZero()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 3, PagingDirection.Backward, 55);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 3, PagingDirection.Backward, 55);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -101,7 +101,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_LimitPlusOneResultsPagingBackward_RemoveFirst()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Backward, 55);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Backward, 55);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -125,7 +125,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_LimitPlusOneResultsPagingForward_RemoveLast()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 55);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 55);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -149,7 +149,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_FirstRequestInPagedResults_ReturnCursor()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 0);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 0);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -173,7 +173,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_PagingForwardWithMoreResults_ReturnCursor()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 50);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -197,7 +197,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_PagingBackwardWithMoreResults_ReturnCursor()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Backward, 50);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -221,7 +221,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_PagingForwardLastPage_ReturnCursor()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Forward, 50);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]
@@ -244,7 +244,7 @@ namespace Opdex.Platform.Application.Tests.EntryHandlers.Addresses.Balances
         public async Task Handle_PagingBackwardLastPage_ReturnCursor()
         {
             // Arrange
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, SortDirectionType.ASC, 2, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, SortDirectionType.ASC, 2, PagingDirection.Backward, 50);
             var request = new GetAddressBalancesWithFilterQuery("PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", cursor);
 
             var balances = new AddressBalance[]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
@@ -6,6 +6,7 @@ using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Balances;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances;
 using System.Linq;
 using System.Threading;
@@ -35,7 +36,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             const SortDirectionType direction = SortDirectionType.ASC;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, direction, limit, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, direction, limit, PagingDirection.Backward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -56,7 +57,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             var tokens = new Address[] { "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj" };
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(tokens, false, false, direction, limit, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(tokens, default, false, direction, limit, PagingDirection.Backward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -71,15 +72,15 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
         }
 
         [Fact]
-        public async Task SelectAddressBalancesWithFilter_ExcludeLpTokens()
+        public async Task SelectAddressBalancesWithFilter_OnlyProvisionalTokens()
         {
             // Arrange
             const SortDirectionType direction = SortDirectionType.ASC;
             Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
-            const bool includeLpTokens = false;
+            const TokenProvisionalFilter tokenType = TokenProvisionalFilter.Provisional;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), includeLpTokens, false, direction, limit, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -94,6 +95,52 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
         }
 
         [Fact]
+        public async Task SelectAddressBalancesWithFilter_OnlyNonProvisionalTokens()
+        {
+            // Arrange
+            const SortDirectionType direction = SortDirectionType.ASC;
+            Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
+            const TokenProvisionalFilter tokenType = TokenProvisionalFilter.NonProvisional;
+            const uint limit = 10;
+
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
+
+            var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
+
+            // Act
+            await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo =>
+                                  callTo.ExecuteQueryAsync<AddressBalanceEntity>(
+                                      It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
+                                                                q.Sql.Contains("t.IsLpt = @IncludeLpTokens"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task SelectAddressBalancesWithFilter_AllTokens()
+        {
+            // Arrange
+            const SortDirectionType direction = SortDirectionType.ASC;
+            Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
+            const TokenProvisionalFilter tokenType = TokenProvisionalFilter.All;
+            const uint limit = 10;
+
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
+
+            var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
+
+            // Act
+            await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            _dbContext.Verify(callTo =>
+                                  callTo.ExecuteQueryAsync<AddressBalanceEntity>(
+                                      It.Is<DatabaseQuery>(q => !q.Sql.Contains("JOIN token t") &&
+                                                                !q.Sql.Contains("t.IsLpt = @IncludeLpTokens"))), Times.Once);
+        }
+
+        [Fact]
         public async Task SelectAddressBalancesWithFilter_ExcludeZeroBalanceTokens()
         {
             // Arrange
@@ -102,7 +149,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             const bool includeZeroBalance = false;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, includeZeroBalance, direction, limit, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, includeZeroBalance, direction, limit, PagingDirection.Backward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -123,7 +170,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             const SortDirectionType direction = SortDirectionType.ASC;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, direction, limit, PagingDirection.Forward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, direction, limit, PagingDirection.Forward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -146,7 +193,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             const SortDirectionType direction = SortDirectionType.DESC;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, direction, limit, PagingDirection.Forward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, direction, limit, PagingDirection.Forward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -169,7 +216,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             const SortDirectionType requestDirection = SortDirectionType.DESC;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, requestDirection, limit, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, requestDirection, limit, PagingDirection.Backward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -192,7 +239,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             const SortDirectionType requestDirection = SortDirectionType.ASC;
             const uint limit = 10;
 
-            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), false, false, requestDirection, limit, PagingDirection.Backward, 50);
+            var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), default, false, requestDirection, limit, PagingDirection.Backward, 50);
 
             var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
@@ -91,7 +91,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             _dbContext.Verify(callTo =>
                                   callTo.ExecuteQueryAsync<AddressBalanceEntity>(
                                       It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
-                                                                q.Sql.Contains("t.IsLpt = @IncludeLpTokens"))), Times.Once);
+                                                                q.Sql.Contains("t.IsLpt = @IsLpt"))), Times.Once);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             _dbContext.Verify(callTo =>
                                   callTo.ExecuteQueryAsync<AddressBalanceEntity>(
                                       It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
-                                                                q.Sql.Contains("t.IsLpt = @IncludeLpTokens"))), Times.Once);
+                                                                q.Sql.Contains("t.IsLpt = @IsLpt"))), Times.Once);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Addresses.Balances
             _dbContext.Verify(callTo =>
                                   callTo.ExecuteQueryAsync<AddressBalanceEntity>(
                                       It.Is<DatabaseQuery>(q => !q.Sql.Contains("JOIN token t") &&
-                                                                !q.Sql.Contains("t.IsLpt = @IncludeLpTokens"))), Times.Once);
+                                                                !q.Sql.Contains("t.IsLpt = @IsLpt"))), Times.Once);
         }
 
         [Fact]

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using Opdex.Platform.WebApi.Models.Requests.Wallets;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
 
             // Assert
             filters.Tokens.Should().BeEmpty();
-            filters.IncludeLpTokens.Should().Be(true);
+            filters.TokenType.Should().Be(TokenProvisionalFilter.All);
             filters.IncludeZeroBalances.Should().Be(false);
             filters.Direction.Should().Be(default(SortDirectionType));
             filters.Limit.Should().Be(default);
@@ -31,7 +32,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
             var filters = new AddressBalanceFilterParameters
             {
                 Tokens = new Address[] { new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm") },
-                IncludeLpTokens = false,
+                TokenType = TokenProvisionalFilter.Provisional,
                 IncludeZeroBalances = true,
                 Limit = 20,
                 Direction = SortDirectionType.DESC
@@ -42,7 +43,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
 
             // Assert
             cursor.Tokens.Should().BeEquivalentTo(filters.Tokens);
-            cursor.IncludeLpTokens.Should().Be(filters.IncludeLpTokens);
+            cursor.TokenType.Should().Be(filters.TokenType);
             cursor.IncludeZeroBalances.Should().Be(filters.IncludeZeroBalances);
             cursor.SortDirection.Should().Be(filters.Direction);
             cursor.Limit.Should().Be(filters.Limit);
@@ -81,7 +82,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new AddressBalanceFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDtpbmNsdWRlTHBUb2tlbnM6VHJ1ZTtpbmNsdWRlWmVyb0JhbGFuY2VzOkZhbHNlO3BvaW50ZXI6T0RZPTs=" };
+            var filters = new AddressBalanceFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDt0b2tlblR5cGU6UHJvdmlzaW9uYWw7aW5jbHVkZVplcm9CYWxhbmNlczpGYWxzZTtwb2ludGVyOk9EWT07" };
 
             // Act
             var cursor = filters.BuildCursor();


### PR DESCRIPTION
Replaces `IncludeLpTokens` filter with `TokenType` that allows balances to be filtered by: `NonProvisional`, `Provisional` and `All`.