### PR TITLE
[PAPI-231] Query params schema

### DIFF
--- a/src/Opdex.Platform.WebApi/Models/Requests/FilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/FilterParameters.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Mvc;
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
-using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Requests
 {
@@ -19,12 +21,16 @@ namespace Opdex.Platform.WebApi.Models.Requests
         /// <summary>
         /// Number of results to return per page.
         /// </summary>
-        public uint Limit { get; set; }
+        // virtual is used to be able to override the attribute
+        [Range(1, Cursor.DefaultMaxLimit)]
+        public virtual uint Limit { get; set; }
 
         /// <summary>
         /// The cursor when paging.
         /// </summary>
-        public string Cursor { get; set; }
+        [NotNull]
+        [FromQuery(Name = "cursor")]
+        public string EncodedCursor { get; set; }
 
         /// <summary>
         /// Builds a cursor filter used for querying.

--- a/src/Opdex.Platform.WebApi/Models/Requests/FilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/FilterParameters.cs
@@ -29,7 +29,7 @@ namespace Opdex.Platform.WebApi.Models.Requests
         /// The cursor when paging.
         /// </summary>
         [NotNull]
-        [FromQuery(Name = "cursor")]
+        [FromQuery(Name = "Cursor")]
         public string EncodedCursor { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Requests/Governances/GovernanceFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Governances/GovernanceFilterParameters.cs
@@ -15,8 +15,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Governances
         /// <inheritdoc />
         protected override MiningGovernancesCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new MiningGovernancesCursor(MinedToken, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new MiningGovernancesCursor(MinedToken, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             MiningGovernancesCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
@@ -23,16 +24,19 @@ namespace Opdex.Platform.WebApi.Models.Requests.LiquidityPools
         /// <summary>
         /// Markets to search liquidity pools within.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> Markets { get; set; }
 
         /// <summary>
         /// Liquidity pools to filter specifically for.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> LiquidityPools { get; set; }
 
         /// <summary>
         /// Tokens to filter specifically for.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> Tokens { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
@@ -19,6 +19,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.LiquidityPools
         /// <summary>
         /// A generic keyword search against liquidity pool addresses and names.
         /// </summary>
+        [NotNull]
         public string Keyword { get; set; }
 
         /// <summary>
@@ -62,9 +63,9 @@ namespace Opdex.Platform.WebApi.Models.Requests.LiquidityPools
         /// <inheritdoc />
         protected override LiquidityPoolsCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new LiquidityPoolsCursor(Keyword, Markets, LiquidityPools, Tokens, StakingFilter, NominationFilter, MiningFilter,
-                                                                OrderBy, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new LiquidityPoolsCursor(Keyword, Markets, LiquidityPools, Tokens, StakingFilter, NominationFilter, MiningFilter,
+                                                                       OrderBy, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             LiquidityPoolsCursor.TryParse(decodedCursor, out var cursor);
 
             return cursor;

--- a/src/Opdex.Platform.WebApi/Models/Requests/Markets/MarketSnapshotFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Markets/MarketSnapshotFilterParameters.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Requests.Markets
 {
@@ -9,18 +11,23 @@ namespace Opdex.Platform.WebApi.Models.Requests.Markets
         /// <summary>
         /// Start time for which to retrieve snapshots.
         /// </summary>
+        [BindRequired]
         public DateTime StartDateTime { get; set; }
 
         /// <summary>
         /// End time for which to retrieve snapshots.
         /// </summary>
+        [BindRequired]
         public DateTime EndDateTime { get; set; }
+
+        [Range(1, SnapshotCursor.MaxLimit)]
+        public override uint Limit { get => base.Limit; set => base.Limit = value; }
 
         /// <inheritdoc />
         protected override SnapshotCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new SnapshotCursor(Interval.OneDay, StartDateTime, EndDateTime, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new SnapshotCursor(Interval.OneDay, StartDateTime, EndDateTime, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             SnapshotCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/MiningPools/MiningPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/MiningPools/MiningPoolFilterParameters.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
@@ -16,6 +17,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.MiningPools
         /// <summary>
         /// The liquidity pools used for mining.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> LiquidityPools { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Requests/MiningPools/MiningPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/MiningPools/MiningPoolFilterParameters.cs
@@ -28,8 +28,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.MiningPools
         /// <inheritdoc />
         protected override MiningPoolsCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new MiningPoolsCursor(LiquidityPools, MiningStatus, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new MiningPoolsCursor(LiquidityPools, MiningStatus, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             MiningPoolsCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/SnapshotFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/SnapshotFilterParameters.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Requests
 {
@@ -14,18 +16,23 @@ namespace Opdex.Platform.WebApi.Models.Requests
         /// <summary>
         /// Start time for which to retrieve snapshots.
         /// </summary>
+        [BindRequired]
         public DateTime StartDateTime { get; set; }
 
         /// <summary>
         /// End time for which to retrieve snapshots.
         /// </summary>
+        [BindRequired]
         public DateTime EndDateTime { get; set; }
+
+        [Range(1, SnapshotCursor.MaxLimit)]
+        public override uint Limit { get => base.Limit; set => base.Limit = value; }
 
         /// <inheritdoc />
         protected override SnapshotCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new SnapshotCursor(Interval, StartDateTime, EndDateTime, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new SnapshotCursor(Interval, StartDateTime, EndDateTime, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             SnapshotCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
@@ -21,23 +22,25 @@ namespace Opdex.Platform.WebApi.Models.Requests.Tokens
         /// <summary>
         /// The type of token to filter for, liquidity pool tokens or not.
         /// </summary>
-        public TokenProvisionalFilter Provisional { get; set; }
+        public TokenProvisionalFilter TokenType { get; set; }
 
         /// <summary>
         /// Tokens to filter specifically for.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> Tokens { get; set; }
 
         /// <summary>
         /// A generic keyword search against token addresses, names and ticker symbols.
         /// </summary>
+        [NotNull]
         public string Keyword { get; set; }
 
         /// <inheritdoc />
         protected override TokensCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new TokensCursor(Keyword, Tokens, Provisional, OrderBy, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new TokensCursor(Keyword, Tokens, TokenType, OrderBy, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             TokensCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionFilterParameters.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
@@ -23,11 +24,13 @@ namespace Opdex.Platform.WebApi.Models.Requests.Transactions
         /// <summary>
         /// Optional list of smart contract addresses to filter transactions by.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> Contracts { get; set; }
 
         /// <summary>
         /// Filter transactions based on event types included.
         /// </summary>
+        [NotNull]
         public IEnumerable<TransactionEventType> EventTypes { get; set; }
 
         protected override TransactionsCursor InternalBuildCursor()

--- a/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionFilterParameters.cs
@@ -35,8 +35,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Transactions
 
         protected override TransactionsCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new TransactionsCursor(Wallet, EventTypes, Contracts, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new TransactionsCursor(Wallet, EventTypes, Contracts, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             TransactionsCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Vaults/VaultCertificateFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Vaults/VaultCertificateFilterParameters.cs
@@ -15,8 +15,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Vaults
         /// <inheritdoc />
         protected override VaultCertificatesCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new VaultCertificatesCursor(Holder, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new VaultCertificatesCursor(Holder, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             VaultCertificatesCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Vaults/VaultFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Vaults/VaultFilterParameters.cs
@@ -15,8 +15,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Vaults
         /// <inheritdoc />
         protected override VaultsCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new VaultsCursor(LockedToken, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new VaultsCursor(LockedToken, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             VaultsCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
@@ -35,8 +35,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <inheritdoc />
         protected override AddressBalancesCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new AddressBalancesCursor(Tokens, TokenType, IncludeZeroBalances, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new AddressBalancesCursor(Tokens, TokenType, IncludeZeroBalances, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             AddressBalancesCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
@@ -17,6 +18,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <summary>
         /// Specific tokens to lookup.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> Tokens { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/MiningPositionFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/MiningPositionFilterParameters.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
@@ -19,11 +20,13 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <summary>
         /// The specific mining pools to include.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> MiningPools { get; set; }
 
         /// <summary>
         /// The specific liquidity pools to include.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> LiquidityPools { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/MiningPositionFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/MiningPositionFilterParameters.cs
@@ -37,8 +37,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <inheritdoc />
         protected override MiningPositionsCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new MiningPositionsCursor(LiquidityPools, MiningPools, IncludeZeroAmounts, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new MiningPositionsCursor(LiquidityPools, MiningPools, IncludeZeroAmounts, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             MiningPositionsCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/StakingPositionFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/StakingPositionFilterParameters.cs
@@ -28,8 +28,8 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <inheritdoc />
         protected override StakingPositionsCursor InternalBuildCursor()
         {
-            if (Cursor is null) return new StakingPositionsCursor(LiquidityPools, IncludeZeroAmounts, Direction, Limit, PagingDirection.Forward, default);
-            Base64Extensions.TryBase64Decode(Cursor, out var decodedCursor);
+            if (EncodedCursor is null) return new StakingPositionsCursor(LiquidityPools, IncludeZeroAmounts, Direction, Limit, PagingDirection.Forward, default);
+            Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
             StakingPositionsCursor.TryParse(decodedCursor, out var cursor);
             return cursor;
         }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/StakingPositionFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/StakingPositionFilterParameters.cs
@@ -1,9 +1,9 @@
+using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Staking;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Opdex.Platform.WebApi.Models.Requests.Wallets
 {
@@ -17,6 +17,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Wallets
         /// <summary>
         /// The specific liquidity pools to include.
         /// </summary>
+        [NotNull]
         public IEnumerable<Address> LiquidityPools { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Startup.cs
+++ b/src/Opdex.Platform.WebApi/Startup.cs
@@ -108,6 +108,7 @@ namespace Opdex.Platform.WebApi
                 })
                 .AddFluentValidation(config =>
                 {
+                    config.DisableDataAnnotationsValidation = true;
                     config.RegisterValidatorsFromAssemblyContaining<Startup>();
                 })
                 .AddNetworkActionHidingConvention()

--- a/src/Opdex.Platform.WebApi/Startup.cs
+++ b/src/Opdex.Platform.WebApi/Startup.cs
@@ -234,12 +234,10 @@ namespace Opdex.Platform.WebApi
                 settings.TypeMappers.Add(new PrimitiveTypeMapper(typeof(Address), schema => schema.Type = JsonObjectType.String));
                 settings.TypeMappers.Add(new PrimitiveTypeMapper(typeof(FixedDecimal), schema =>
                 {
-                    schema.IsNullableRaw = false;
                     schema.Type = JsonObjectType.String;
                 }));
                 settings.TypeMappers.Add(new PrimitiveTypeMapper(typeof(Sha256), schema =>
                 {
-                    schema.IsNullableRaw = false;
                     schema.Type = JsonObjectType.String;
                     schema.Pattern = @"^[0-9a-fA-F]{64}$";
                 }));

--- a/src/Opdex.Platform.WebApi/Validation/AbstractCursorValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/AbstractCursorValidator.cs
@@ -13,8 +13,8 @@ namespace Opdex.Platform.WebApi.Validation
     {
         public AbstractCursorValidator()
         {
-            When(filter => filter.Cursor.HasValue(),
-                 () => RuleFor(filter => filter.Cursor).Must((filter, cursor) => filter.ValidateWellFormed()).WithMessage("Cursor not formed correctly."));
+            When(filter => filter.EncodedCursor.HasValue(),
+                 () => RuleFor(filter => filter.EncodedCursor).Must((filter, cursor) => filter.ValidateWellFormed()).WithMessage("Cursor not formed correctly."));
         }
 
         public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)

--- a/src/Opdex.Platform.WebApi/Validation/SnapshotFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/SnapshotFilterParametersValidator.cs
@@ -9,7 +9,7 @@ namespace Opdex.Platform.WebApi.Validation
     {
         public SnapshotFilterParametersValidator()
         {
-            When(filter => filter.Cursor is null, () =>
+            When(filter => filter.EncodedCursor is null, () =>
             {
                 RuleFor(filter => filter.StartDateTime).NotNull().LessThan(filter => filter.EndDateTime).WithMessage("Start time must be before end time.");
                 RuleFor(filter => filter.EndDateTime).NotNull().GreaterThan(filter => filter.StartDateTime).WithMessage("End time must be after start time.");

--- a/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
@@ -18,7 +18,7 @@ namespace Opdex.Platform.WebApi.Validation.Tokens
                 .WithMessage("Keyword must consist of letters, numbers and spaces only.");
 
             RuleFor(filter => filter.OrderBy).MustBeValidEnumValue();
-            RuleFor(filter => filter.Provisional).MustBeValidEnumValue();
+            RuleFor(filter => filter.TokenType).MustBeValidEnumValue();
             RuleForEach(filter => filter.Tokens).MustBeNetworkAddress();
             RuleFor(filter => filter.Limit).LessThanOrEqualTo(Cursor.DefaultMaxLimit);
         }

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/MiningPools/MiningPoolFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/MiningPools/MiningPoolFilterParametersTests.cs
@@ -53,7 +53,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.MiningPools
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new MiningPoolFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new MiningPoolFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -66,7 +66,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.MiningPools
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new MiningPoolFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new MiningPoolFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -79,7 +79,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.MiningPools
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new MiningPoolFilterParameters { Cursor = "bWluaW5nU3RhdHVzOkFueTtkaXJlY3Rpb246REVTQztsaW1pdDo1O3BhZ2luZzpGb3J3YXJkO3BvaW50ZXI6TXc9PTs=" };
+            var filters = new MiningPoolFilterParameters { EncodedCursor = "bWluaW5nU3RhdHVzOkFueTtkaXJlY3Rpb246REVTQztsaW1pdDo1O3BhZ2luZzpGb3J3YXJkO3BvaW50ZXI6TXc9PTs=" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Transactions/TransactionFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Transactions/TransactionFilterParametersTests.cs
@@ -56,7 +56,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Transactions
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new TransactionFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new TransactionFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -69,7 +69,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Transactions
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new TransactionFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new TransactionFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -82,7 +82,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Transactions
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new TransactionFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6NTtwYWdpbmc6Rm9yd2FyZDtwb2ludGVyOk13PT07" };
+            var filters = new TransactionFilterParameters { EncodedCursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6NTtwYWdpbmc6Rm9yd2FyZDtwb2ludGVyOk13PT07" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Vaults/VaultCertificateFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Vaults/VaultCertificateFilterParametersTests.cs
@@ -49,7 +49,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Vaults
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new VaultCertificateFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new VaultCertificateFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -62,7 +62,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Vaults
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new VaultCertificateFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new VaultCertificateFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -75,7 +75,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Vaults
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new VaultCertificateFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6NTtwYWdpbmc6Rm9yd2FyZDtwb2ludGVyOk13PT07" };
+            var filters = new VaultCertificateFilterParameters { EncodedCursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6NTtwYWdpbmc6Rm9yd2FyZDtwb2ludGVyOk13PT07" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Vaults/VaultFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Vaults/VaultFilterParametersTests.cs
@@ -49,7 +49,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Vaults
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new VaultFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new VaultFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -62,7 +62,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Vaults
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new VaultFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new VaultFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -75,7 +75,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Vaults
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new VaultFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6NTtwYWdpbmc6Rm9yd2FyZDtwb2ludGVyOk13PT07" };
+            var filters = new VaultFilterParameters { EncodedCursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6NTtwYWdpbmc6Rm9yd2FyZDtwb2ludGVyOk13PT07" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
@@ -56,7 +56,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new AddressBalanceFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new AddressBalanceFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -69,7 +69,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new AddressBalanceFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new AddressBalanceFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -82,7 +82,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new AddressBalanceFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDt0b2tlblR5cGU6UHJvdmlzaW9uYWw7aW5jbHVkZVplcm9CYWxhbmNlczpGYWxzZTtwb2ludGVyOk9EWT07" };
+            var filters = new AddressBalanceFilterParameters { EncodedCursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDt0b2tlblR5cGU6UHJvdmlzaW9uYWw7aW5jbHVkZVplcm9CYWxhbmNlczpGYWxzZTtwb2ludGVyOk9EWT07" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/MiningPositionFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/MiningPositionFilterParametersTests.cs
@@ -55,7 +55,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new MiningPositionFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new MiningPositionFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -68,7 +68,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new MiningPositionFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new MiningPositionFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -81,7 +81,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new MiningPositionFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDtpbmNsdWRlWmVyb0Ftb3VudHM6RmFsc2U7cG9pbnRlcjpNdz09Ow==" };
+            var filters = new MiningPositionFilterParameters { EncodedCursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDtpbmNsdWRlWmVyb0Ftb3VudHM6RmFsc2U7cG9pbnRlcjpNdz09Ow==" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/StakingPositionFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/StakingPositionFilterParametersTests.cs
@@ -52,7 +52,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_NotABase64CursorString_ReturnNull()
         {
             // Arrange
-            var filters = new StakingPositionFilterParameters { Cursor = "NOT_BASE_64_****" };
+            var filters = new StakingPositionFilterParameters { EncodedCursor = "NOT_BASE_64_****" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -65,7 +65,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_NotAValidCursorString_ReturnNull()
         {
             // Arrange
-            var filters = new StakingPositionFilterParameters { Cursor = "Tk9UX1ZBTElE" };
+            var filters = new StakingPositionFilterParameters { EncodedCursor = "Tk9UX1ZBTElE" };
 
             // Act
             var cursor = filters.BuildCursor();
@@ -78,7 +78,7 @@ namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets
         public void BuildCursor_ValidCursorString_ReturnCursor()
         {
             // Arrange
-            var filters = new StakingPositionFilterParameters { Cursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDtpbmNsdWRlWmVyb0Ftb3VudHM6RmFsc2U7cG9pbnRlcjpNdz09Ow==" };
+            var filters = new StakingPositionFilterParameters { EncodedCursor = "ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDtpbmNsdWRlWmVyb0Ftb3VudHM6RmFsc2U7cG9pbnRlcjpNdz09Ow==" };
 
             // Act
             var cursor = filters.BuildCursor();

--- a/test/Opdex.Platform.WebApi.Tests/Validation/AbstractCursorValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/AbstractCursorValidatorTests.cs
@@ -21,14 +21,14 @@ namespace Opdex.Platform.WebApi.Tests.Validation
             // Arrange
             var request = new NullFilterParameters
             {
-                Cursor = "INVALID_CURSOR"
+                EncodedCursor = "INVALID_CURSOR"
             };
 
             // Act
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(request => request.Cursor);
+            result.ShouldHaveValidationErrorFor(request => request.EncodedCursor);
         }
 
         [Fact]
@@ -37,14 +37,14 @@ namespace Opdex.Platform.WebApi.Tests.Validation
             // Arrange
             var request = new WellFormedFilterParameters
             {
-                Cursor = "VALID_CURSOR"
+                EncodedCursor = "VALID_CURSOR"
             };
 
             // Act
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldNotHaveValidationErrorFor(request => request.Cursor);
+            result.ShouldNotHaveValidationErrorFor(request => request.EncodedCursor);
         }
     }
 

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
@@ -135,14 +135,14 @@ namespace Opdex.Platform.WebApi.Tests.Validation.Tokens
             // Arrange
             var request = new TokenFilterParameters
             {
-                Provisional = filter
+                TokenType = filter
             };
 
             // Act
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(r => r.Provisional);
+            result.ShouldHaveValidationErrorFor(r => r.TokenType);
         }
 
         [Theory]
@@ -155,14 +155,14 @@ namespace Opdex.Platform.WebApi.Tests.Validation.Tokens
             // Arrange
             var request = new TokenFilterParameters
             {
-                Provisional = filter
+                TokenType = filter
             };
 
             // Act
             var result = _validator.TestValidate(request);
 
             // Assert
-            result.ShouldNotHaveValidationErrorFor(r => r.Provisional);
+            result.ShouldNotHaveValidationErrorFor(r => r.TokenType);
         }
 
         [Fact]


### PR DESCRIPTION
* Adds minimum/maximum to integer query params
* Cleans up nullable usage
* Mark required query params
* Renamed Provisional query param to TokenType to be consistent

Fairly ugly using attributes, although unfortunately it's not an easy feat to do it any other way. Also limited to what we can define. For example, we cannot really define regex patterns for addresses, as attributes are setup with constant values and the address format would have to be resolved based on the network config.

Only concern is NSwag generates minimum/maximum with a decimal point, so `1.0` as an example. _Shouldn't_ be a problem as it's defined integer but something to watch out for.