### PR TITLE
[PAPI-149] Minimum and maximum

### DIFF
--- a/src/Opdex.Platform.WebApi/Models/Requests/Index/RewindRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Index/RewindRequest.cs
@@ -11,6 +11,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Index
         /// The block number to rewind too.
         /// </summary>
         [Required]
+        [Range(1, double.MaxValue)]
         public ulong Block { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Markets/CreateStandardMarketQuoteRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Markets/CreateStandardMarketQuoteRequest.cs
@@ -12,7 +12,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Markets
         public Address MarketOwner { get; set; }
 
         [Required]
-        [Range(0, double.MaxValue)]
+        [Range(0, 10)]
         public uint TransactionFee { get; set; }
 
         [Required]

--- a/src/Opdex.Platform.WebApi/Models/Requests/Markets/CreateStandardMarketQuoteRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Markets/CreateStandardMarketQuoteRequest.cs
@@ -12,6 +12,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.Markets
         public Address MarketOwner { get; set; }
 
         [Required]
+        [Range(0, double.MaxValue)]
         public uint TransactionFee { get; set; }
 
         [Required]

--- a/src/Opdex.Platform.WebApi/Models/Requests/WalletTransactions/AddLiquidityRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/WalletTransactions/AddLiquidityRequest.cs
@@ -40,6 +40,7 @@ namespace Opdex.Platform.WebApi.Models.Requests.WalletTransactions
         /// The block number limit that the transaction is valid through.
         /// </summary>
         /// <remarks>A 0 deadline is equivalent to no deadline. Anything else must be greater than the current chain height.</remarks>
+        [Range(0, double.MaxValue)]
         public ulong Deadline { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Blocks/BlockResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Blocks/BlockResponseModel.cs
@@ -1,12 +1,17 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Blocks
 {
     public class BlockResponseModel
     {
         public string Hash { get; set; }
+
+        [Range(1, double.MaxValue)]
         public ulong Height { get; set; }
+
         public DateTime Time { get; set; }
+        
         public DateTime MedianTime { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Governances/MiningGovernanceResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Governances/MiningGovernanceResponseModel.cs
@@ -1,16 +1,28 @@
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Governances
 {
     public class MiningGovernanceResponseModel
     {
         public Address Address { get; set; }
+
+        [Range(1, double.MaxValue)]
         public ulong PeriodEndBlock { get; set; }
+
+        [Range(0, double.MaxValue)]
         public ulong PeriodRemainingBlocks { get; set; }
+
+        [Range(1, double.MaxValue)]
         public ulong PeriodBlockDuration { get; set; }
+
+        [Range(0, double.MaxValue)]
         public uint PeriodsUntilRewardReset { get; set; }
+
         public FixedDecimal MiningPoolRewardPerPeriod { get; set; }
+
         public FixedDecimal TotalRewardsPerPeriod { get; set; }
+        
         public Address MinedToken { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/MiningPools/MiningPoolResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/MiningPools/MiningPoolResponseModel.cs
@@ -1,5 +1,6 @@
 using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.MiningPools
 {
@@ -15,6 +16,7 @@ namespace Opdex.Platform.WebApi.Models.Responses.MiningPools
         public Address LiquidityPool { get; set; }
 
         [NotNull]
+        [Range(1, double.MaxValue)]
         public ulong MiningPeriodEndBlock { get; set; }
 
         [NotNull]

--- a/src/Opdex.Platform.WebApi/Models/Responses/OHLC/OhlcDecimalResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/OHLC/OhlcDecimalResponseModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Opdex.Platform.WebApi.Models.Responses.OHLC
@@ -5,15 +6,19 @@ namespace Opdex.Platform.WebApi.Models.Responses.OHLC
     public class OhlcDecimalResponseModel
     {
         [NotNull]
+        [Range(0, double.MaxValue)]
         public decimal Open { get; set; }
 
         [NotNull]
+        [Range(0, double.MaxValue)]
         public decimal High { get; set; }
 
         [NotNull]
+        [Range(0, double.MaxValue)]
         public decimal Low { get; set; }
 
         [NotNull]
+        [Range(0, double.MaxValue)]
         public decimal Close { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolResponseModel.cs
@@ -1,16 +1,23 @@
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.WebApi.Models.Responses.MiningPools;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public class LiquidityPoolResponseModel : LiquidityPoolSummaryResponseModel
     {
         public Address Address { get; set; }
+
         public string Name { get; set; }
+
+        [Range(0, double.MaxValue)]
         public decimal TransactionFee { get; set; }
+
         public LiquidityPoolTokenGroupResponseModel Token { get; set; }
+
         public MiningPoolResponseModel Mining { get; set; }
+        
         public IEnumerable<LiquidityPoolSnapshotResponseModel> SnapshotHistory { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/LiquidityPoolSummaryResponseModel.cs
@@ -1,11 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
-    public abstract class LiquidityPoolSummaryResponseModel {
+    public abstract class LiquidityPoolSummaryResponseModel
+    {
+        [Range(0, double.MaxValue)]
         public long TransactionCount { get; set; }
+
         public ReservesResponseModel Reserves { get; set; }
+
         public RewardsResponseModel Rewards { get; set; }
+
         public StakingResponseModel Staking { get; set; }
+
         public VolumeResponseModel Volume { get; set; }
+        
         public CostResponseModel Cost { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/ReservesResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/ReservesResponseModel.cs
@@ -1,12 +1,17 @@
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public class ReservesResponseModel
     {
         public FixedDecimal Crs { get; set; }
+        
         public FixedDecimal Src { get; set; }
+
+        [Range(0, double.MaxValue)]
         public decimal Usd { get; set; }
+
         public decimal? UsdDailyChange { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/RewardsResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/RewardsResponseModel.cs
@@ -1,9 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public class RewardsResponseModel
     {
+        [Range(0, double.MaxValue)]
         public decimal ProviderUsd { get; set; }
+
+        [Range(0, double.MaxValue)]
         public decimal MarketUsd { get; set; }
+        
+        [Range(0, double.MaxValue)]
         public decimal TotalUsd { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/StakingResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/StakingResponseModel.cs
@@ -1,13 +1,19 @@
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public class StakingResponseModel
     {
         public FixedDecimal Weight { get; set; }
+
+        [Range(0, double.MaxValue)]
         public decimal Usd { get; set; }
+
         public decimal? WeightDailyChange { get; set; }
+
         public bool? IsActive { get; set; }
+        
         public bool? IsNominated { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Pools/VolumeResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Pools/VolumeResponseModel.cs
@@ -1,11 +1,15 @@
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Pools
 {
     public class VolumeResponseModel
     {
         public FixedDecimal Crs { get; set; }
+        
         public FixedDecimal Src { get; set; }
+
+        [Range(0, double.MaxValue)]
         public decimal Usd { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenResponseModel.cs
@@ -1,5 +1,6 @@
 using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Tokens
 {
@@ -27,12 +28,14 @@ namespace Opdex.Platform.WebApi.Models.Responses.Tokens
         /// The total number of decimal places the token has.
         /// </summary>
         [NotNull]
+        [Range(0, double.MaxValue)]
         public int Decimals { get; set; }
 
         /// <summary>
         /// The total number of satoshis per full token.
         /// </summary>
         [NotNull]
+        [Range(0, double.MaxValue)]
         public ulong Sats { get; set; }
 
         /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenSummaryResponseModel.cs
@@ -1,9 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Opdex.Platform.WebApi.Models.Responses.Tokens
 {
     public class TokenSummaryResponseModel
     {
+        [Range(0, double.MaxValue)]
         public decimal PriceUsd { get; set; }
+
         public decimal DailyPriceChangePercent { get; set; }
+
+        [Range(1, double.MaxValue)]
         public ulong ModifiedBlock { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionQuoteResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionQuoteResponseModel.cs
@@ -1,6 +1,7 @@
 using NJsonSchema.Annotations;
 using Opdex.Platform.WebApi.Models.Responses.Transactions.TransactionEvents;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Transactions
 {
@@ -12,9 +13,11 @@ namespace Opdex.Platform.WebApi.Models.Responses.Transactions
         }
 
         public object Result { get; set; }
+
         public string Error { get; set; }
 
         [NotNull]
+        [Range(0, double.MaxValue)]
         public uint GasUsed { get; set; }
 
         [NotNull]

--- a/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionResponseModel.cs
@@ -2,6 +2,7 @@ using Opdex.Platform.Common.Models;
 using Opdex.Platform.WebApi.Models.Responses.Blocks;
 using Opdex.Platform.WebApi.Models.Responses.Transactions.TransactionEvents;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Transactions
@@ -14,12 +15,20 @@ namespace Opdex.Platform.WebApi.Models.Responses.Transactions
         }
 
         public bool Success { get; set; }
+        
         public Sha256 Hash { get; set; }
+
         public Address NewContractAddress { get; set; }
+
         public BlockResponseModel Block { get; set; }
+
+        [Range(0, double.MaxValue)]
         public int GasUsed { get; set; }
+        
         public Address From { get; set; }
+
         public Address To { get; set; }
+
         public IEnumerable<TransactionEventResponseModel> Events { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultCertificateResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultCertificateResponseModel.cs
@@ -1,14 +1,22 @@
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Vaults
 {
     public class VaultCertificateResponseModel
     {
         public Address Owner { get; set; }
+
         public FixedDecimal Amount { get; set; }
+
+        [Range(1, double.MaxValue)]
         public ulong VestingStartBlock { get; set; }
+
+        [Range(1, double.MaxValue)]
         public ulong VestingEndBlock { get; set; }
+
         public bool Redeemed { get; set; }
+        
         public bool Revoked { get; set; }
     }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultResponseModel.cs
@@ -1,5 +1,6 @@
 using NJsonSchema.Annotations;
 using Opdex.Platform.Common.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Vaults
 {
@@ -14,6 +15,7 @@ namespace Opdex.Platform.WebApi.Models.Responses.Vaults
         public Address Owner { get; set; }
 
         [NotNull]
+        [Range(1, double.MaxValue)]
         public ulong Genesis { get; set; }
 
         [NotNull]


### PR DESCRIPTION
Specifies minimum and maximum on number fields for OpenAPI. Use of `double.MaxValue` indicates NSwag to ignore the maximum. Pretty ugly but it's the only way.