### PR TITLE
[PAPI-307] Token validation improvements

### DIFF
--- a/src/Opdex.Platform.WebApi/Controllers/WalletsController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/WalletsController.cs
@@ -35,7 +35,7 @@ public class WalletsController : ControllerBase
     }
 
     /// <summary>Get Approved Allowance</summary>
-    /// <remarks>Retrieve the allowance of a spender for tokens owned by another wallet.</remarks>
+    /// <remarks>Retrieve the allowance of a spender for SRC tokens owned by another wallet.</remarks>
     /// <param name="address">Address of the wallet.</param>
     /// <param name="token">Address of the token.</param>
     /// <param name="spender">Address for the spender of the allowance.</param>
@@ -52,7 +52,7 @@ public class WalletsController : ControllerBase
                                                                                  [FromRoute] Address spender,
                                                                                  CancellationToken cancellationToken)
     {
-        if (token == Address.Cirrus) throw new InvalidDataException(nameof(token), "Token must be network address for an SRC token.");
+        if (token == Address.Cirrus) throw new InvalidDataException(nameof(token), "Address must be SRC token address.");
         var allowances = await _mediator.Send(new GetAddressAllowanceQuery(address, spender, token), cancellationToken);
         var response = _mapper.Map<ApprovedAllowanceResponseModel>(allowances);
         return Ok(response);
@@ -102,7 +102,7 @@ public class WalletsController : ControllerBase
     }
 
     /// <summary>Refresh Balance</summary>
-    /// <remarks>Retrieves and indexes the latest balance of a token for an address.</remarks>
+    /// <remarks>Retrieves and indexes the latest balance of an SRC token for an address.</remarks>
     /// <param name="address">Address of the wallet.</param>
     /// <param name="token">Address of the token to refresh the balance of, or CRS.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -117,6 +117,7 @@ public class WalletsController : ControllerBase
                                                                                        [FromRoute] Address token,
                                                                                        CancellationToken cancellationToken)
     {
+        if (token == Address.Cirrus) throw new InvalidDataException(nameof(token), "Address must be SRC token address.");
         var balance = await _mediator.Send(new CreateRefreshAddressBalanceCommand(address, token), cancellationToken);
         var response = _mapper.Map<AddressBalanceResponseModel>(balance);
         return Ok(response);

--- a/src/Opdex.Platform.WebApi/OpenApi/Wallets/GetAddressBalanceByTokenOperationProcessor.cs
+++ b/src/Opdex.Platform.WebApi/OpenApi/Wallets/GetAddressBalanceByTokenOperationProcessor.cs
@@ -15,7 +15,7 @@ public class GetAddressBalanceByTokenOperationProcessor : IOperationProcessor
 
         var tokenAddressParameter = context.OperationDescription.Operation.Parameters.First(parameter => parameter.Name == "token");
         tokenAddressParameter.Schema.Example = "tF83sdXXt2nTkL7UyEYDVFMK4jTuYMbmR3";
-        tokenAddressParameter.Schema.MinLength = 30;
+        tokenAddressParameter.Schema.MinLength = 3;
         tokenAddressParameter.Schema.MaxLength = 42;
 
         return true;

--- a/src/Opdex.Platform.WebApi/OpenApi/Wallets/RefreshAddressBalanceOperationProcessor.cs
+++ b/src/Opdex.Platform.WebApi/OpenApi/Wallets/RefreshAddressBalanceOperationProcessor.cs
@@ -15,7 +15,7 @@ public class RefreshAddressBalanceOperationProcessor : IOperationProcessor
 
         var tokenAddressParameter = context.OperationDescription.Operation.Parameters.First(parameter => parameter.Name == "token");
         tokenAddressParameter.Schema.Example = "tF83sdXXt2nTkL7UyEYDVFMK4jTuYMbmR3";
-        tokenAddressParameter.Schema.MinLength = 3;
+        tokenAddressParameter.Schema.MinLength = 30;
         tokenAddressParameter.Schema.MaxLength = 42;
 
         return true;

--- a/src/Opdex.Platform.WebApi/OpenApi/Wallets/RefreshAddressBalanceOperationProcessor.cs
+++ b/src/Opdex.Platform.WebApi/OpenApi/Wallets/RefreshAddressBalanceOperationProcessor.cs
@@ -15,7 +15,7 @@ public class RefreshAddressBalanceOperationProcessor : IOperationProcessor
 
         var tokenAddressParameter = context.OperationDescription.Operation.Parameters.First(parameter => parameter.Name == "token");
         tokenAddressParameter.Schema.Example = "tF83sdXXt2nTkL7UyEYDVFMK4jTuYMbmR3";
-        tokenAddressParameter.Schema.MinLength = 30;
+        tokenAddressParameter.Schema.MinLength = 3;
         tokenAddressParameter.Schema.MaxLength = 42;
 
         return true;


### PR DESCRIPTION
* Amends OpenAPI definition so CRS is valid parameter for token parameter on `GET/POST /wallet/{address}/balance/{token}`.
* Force returning 401 if CRS is provided to `GET /wallet/{address}/allowance/{token}/spender/{spender}`, otherwise it returns 500 (call to full node fails)