### PR TITLE
[PAPI-325] Token Attributes

### DIFF
--- a/src/Opdex.Platform.Application.Abstractions/EntryCommands/Tokens/CreateTokenCommand.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryCommands/Tokens/CreateTokenCommand.cs
@@ -1,6 +1,8 @@
 using MediatR;
+using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Models;
 using System;
+using System.Collections.Generic;
 
 namespace Opdex.Platform.Application.Abstractions.EntryCommands.Tokens;
 
@@ -13,8 +15,9 @@ public class CreateTokenCommand : IRequest<ulong>
     /// Constructor for the create token command.
     /// </summary>
     /// <param name="token">The SRC token contract address.</param>
+    /// <param name="attributes">List of token attributes to apply to the token.</param>
     /// <param name="blockHeight">The block height the token is being added at.</param>
-    public CreateTokenCommand(Address token, ulong blockHeight)
+    public CreateTokenCommand(Address token, IEnumerable<TokenAttributeType> attributes, ulong blockHeight)
     {
         if (token == Address.Empty)
         {
@@ -28,8 +31,10 @@ public class CreateTokenCommand : IRequest<ulong>
 
         Token = token;
         BlockHeight = blockHeight;
+        Attributes = attributes;
     }
 
     public Address Token { get; }
+    public  IEnumerable<TokenAttributeType> Attributes { get; }
     public ulong BlockHeight { get; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/EntryCommands/Tokens/CreateTokenCommand.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryCommands/Tokens/CreateTokenCommand.cs
@@ -35,6 +35,6 @@ public class CreateTokenCommand : IRequest<ulong>
     }
 
     public Address Token { get; }
-    public  IEnumerable<TokenAttributeType> Attributes { get; }
+    public IEnumerable<TokenAttributeType> Attributes { get; }
     public ulong BlockHeight { get; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenDto.cs
@@ -1,4 +1,6 @@
+using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Models;
+using System.Collections.Generic;
 
 namespace Opdex.Platform.Application.Abstractions.Models.Tokens;
 
@@ -11,5 +13,6 @@ public class TokenDto
     public int Decimals { get; set; }
     public ulong Sats { get; set; }
     public FixedDecimal TotalSupply { get; set; }
+    public IEnumerable<TokenAttributeType> Attributes { get; set; }
     public TokenSummaryDto Summary { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Queries/Tokens/RetrieveTokenAttributeByTokenIdQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Queries/Tokens/RetrieveTokenAttributeByTokenIdQuery.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using Opdex.Platform.Domain.Models.Tokens;
+using System;
+using System.Collections.Generic;
+
+namespace Opdex.Platform.Application.Abstractions.Queries.Tokens;
+
+/// <summary>
+/// Retrieve token attributes based on a TokenId.
+/// </summary>
+public class RetrieveTokenAttributesByTokenIdQuery : IRequest<IEnumerable<TokenAttribute>>
+{
+    /// <summary>
+    /// Constructor to build a retrieve token attributes by token id query.
+    /// </summary>
+    /// <param name="tokenId">The token id to select attributes for.</param>
+    public RetrieveTokenAttributesByTokenIdQuery(ulong tokenId)
+    {
+        TokenId = tokenId > 0 ? tokenId : throw new ArgumentOutOfRangeException(nameof(tokenId), "TokenId must be greater than zero.");
+    }
+
+    public ulong TokenId { get; }
+}

--- a/src/Opdex.Platform.Application/Assemblers/MarketTokenDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/MarketTokenDtoAssembler.cs
@@ -34,7 +34,10 @@ public class MarketTokenDtoAssembler : IModelAssembler<MarketToken, MarketTokenD
         }
 
         var tokenAttributes = await _mediator.Send(new RetrieveTokenAttributesByTokenIdQuery(token.Id), CancellationToken.None);
-        var isLpt = tokenAttributes.Select(attr => attr.AttributeType).Contains(TokenAttributeType.Provisional);
+
+        marketTokenDto.Attributes = tokenAttributes.Select(attr => attr.AttributeType);
+
+        var isLpt = marketTokenDto.Attributes.Contains(TokenAttributeType.Provisional);
 
         var liquidityPool = isLpt
             ? await _mediator.Send(new RetrieveLiquidityPoolByAddressQuery(token.Address))

--- a/src/Opdex.Platform.Application/Assemblers/MarketTokenDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/MarketTokenDtoAssembler.cs
@@ -3,8 +3,11 @@ using MediatR;
 using Opdex.Platform.Application.Abstractions.Models.Tokens;
 using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
+using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Domain.Models.Tokens;
 using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Opdex.Platform.Application.Assemblers;
@@ -30,7 +33,10 @@ public class MarketTokenDtoAssembler : IModelAssembler<MarketToken, MarketTokenD
             if (summary is not null) marketTokenDto.Summary = _mapper.Map<TokenSummaryDto>(summary);
         }
 
-        var liquidityPool = token.IsLpt
+        var tokenAttributes = await _mediator.Send(new RetrieveTokenAttributesByTokenIdQuery(token.Id), CancellationToken.None);
+        var isLpt = tokenAttributes.Select(attr => attr.AttributeType).Contains(TokenAttributeType.Provisional);
+
+        var liquidityPool = isLpt
             ? await _mediator.Send(new RetrieveLiquidityPoolByAddressQuery(token.Address))
             : await _mediator.Send(new RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQuery(token.Id, token.Market.Id));
 

--- a/src/Opdex.Platform.Application/Assemblers/TokenDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/TokenDtoAssembler.cs
@@ -4,6 +4,8 @@ using Opdex.Platform.Application.Abstractions.Models.Tokens;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
 using Opdex.Platform.Domain.Models.Tokens;
 using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Opdex.Platform.Application.Assemblers;
@@ -25,12 +27,13 @@ public class TokenDtoAssembler : IModelAssembler<Token, TokenDto>
     {
         var tokenDto = _mapper.Map<TokenDto>(token);
 
+        var attributes = await _mediator.Send(new RetrieveTokenAttributesByTokenIdQuery(token.Id), CancellationToken.None);
+
+        tokenDto.Attributes = attributes.Select(attribute => attribute.AttributeType);
+
         var summary = await _mediator.Send(new RetrieveTokenSummaryByMarketAndTokenIdQuery(MarketId, token.Id, findOrThrow: false));
 
-        if (summary != null)
-        {
-            tokenDto.Summary = _mapper.Map<TokenSummaryDto>(summary);
-        }
+        if (summary != null) tokenDto.Summary = _mapper.Map<TokenSummaryDto>(summary);
 
         return tokenDto;
     }

--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateAddTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateAddTokenCommandHandler.cs
@@ -49,7 +49,7 @@ public class CreateAddTokenCommandHandler : IRequestHandler<CreateAddTokenComman
             throw new InvalidDataException("tokenAddress", "Unable to validate SRC token.");
         }
 
-        token = new Token(request.Token, summary.IsLpt.Value, summary.Name, summary.Symbol, (int)summary.Decimals.Value, summary.Sats.Value,
+        token = new Token(request.Token, summary.Name, summary.Symbol, (int)summary.Decimals.Value, summary.Sats.Value,
                           summary.TotalSupply.Value, latestBlock.Height);
 
         var tokenId = await _mediator.Send(new MakeTokenCommand(token, latestBlock.Height));

--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/Snapshots/CreateCrsTokenSnapshotsCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/Snapshots/CreateCrsTokenSnapshotsCommandHandler.cs
@@ -38,7 +38,7 @@ public class CreateCrsTokenSnapshotsCommandHandler : IRequestHandler<CreateCrsTo
         // If CRS doesn't exist, create it
         if (crsId == 0)
         {
-            crs = new Token(Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+            crs = new Token(Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                             TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, request.BlockHeight);
 
             crsId = await _mediator.Send(new MakeTokenCommand(crs, request.BlockHeight), CancellationToken.None);

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/ProcessGovernanceDeploymentTransactionCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/ProcessGovernanceDeploymentTransactionCommandHandler.cs
@@ -13,6 +13,7 @@ using Opdex.Platform.Application.Abstractions.EntryCommands.Vaults;
 using Opdex.Platform.Application.Abstractions.Queries.Blocks;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
 using Opdex.Platform.Application.Abstractions.Queries.Transactions;
+using Opdex.Platform.Common.Enums;
 
 namespace Opdex.Platform.Application.EntryHandlers.Transactions;
 
@@ -62,7 +63,8 @@ public class ProcessGovernanceDeploymentTransactionCommandHandler : IRequestHand
             await _mediator.Send(new CreateCrsTokenSnapshotsCommand(blockTime, transaction.BlockHeight), CancellationToken.None);
 
             // Insert Staking Token
-            var stakingTokenId = await _mediator.Send(new CreateTokenCommand(transaction.NewContractAddress, transaction.BlockHeight));
+            var stakingAttributes = new[] { TokenAttributeType.Staking };
+            var stakingTokenId = await _mediator.Send(new CreateTokenCommand(transaction.NewContractAddress, stakingAttributes, transaction.BlockHeight));
 
             // Get token summary
             var stakingTokenSummary = await _mediator.Send(new RetrieveStakingTokenContractSummaryQuery(transaction.NewContractAddress,

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/MarketDeployers/ProcessCreateMarketLogCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/MarketDeployers/ProcessCreateMarketLogCommandHandler.cs
@@ -48,7 +48,8 @@ public class ProcessCreateMarketLogCommandHandler : IRequestHandler<ProcessCreat
             Token stakingToken = null;
             if (!request.Log.StakingToken.IsZero)
             {
-                var tokenId = await _mediator.Send(new CreateTokenCommand(request.Log.StakingToken, request.BlockHeight));
+                var stakingAttributes = new[] { TokenAttributeType.Staking };
+                var tokenId = await _mediator.Send(new CreateTokenCommand(request.Log.StakingToken, stakingAttributes, request.BlockHeight));
                 if (tokenId == 0)
                 {
                     _logger.LogError("Unable to create market staking token");

--- a/src/Opdex.Platform.Application/Handlers/Tokens/Attributes/MakeTokenAttributeCommandHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Tokens/Attributes/MakeTokenAttributeCommandHandler.cs
@@ -22,7 +22,7 @@ public class MakeTokenAttributeCommandHandler : IRequestHandler<MakeTokenAttribu
     {
         var attributes = await _mediator.Send(new SelectTokenAttributesByTokenIdQuery(request.TokenAttribute.TokenId));
 
-        if (attributes.All(a => a.AttributeType != (request.TokenAttribute.AttributeType)))
+        if (attributes.All(a => a.AttributeType != request.TokenAttribute.AttributeType))
         {
             return await _mediator.Send(new PersistTokenAttributeCommand(request.TokenAttribute));
         }

--- a/src/Opdex.Platform.Application/Handlers/Tokens/MakeTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Tokens/MakeTokenCommandHandler.cs
@@ -23,11 +23,11 @@ public class MakeTokenCommandHandler : IRequestHandler<MakeTokenCommand, ulong>
         {
             var summary = await _mediator.Send(new CallCirrusGetStandardTokenContractSummaryQuery(request.Token.Address,
                                                                                                   request.BlockHeight,
-                                                                                                  includeTotalSupply: request.RefreshTotalSupply));
+                                                                                                  includeTotalSupply: request.RefreshTotalSupply), CancellationToken.None);
 
             request.Token.Update(summary);
         }
 
-        return await _mediator.Send(new PersistTokenCommand(request.Token));
+        return await _mediator.Send(new PersistTokenCommand(request.Token), CancellationToken.None);
     }
 }

--- a/src/Opdex.Platform.Application/Handlers/Tokens/RetrieveTokenAttributesByTokenIdQueryHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Tokens/RetrieveTokenAttributesByTokenIdQueryHandler.cs
@@ -1,0 +1,25 @@
+using MediatR;
+using Opdex.Platform.Application.Abstractions.Queries.Tokens;
+using Opdex.Platform.Domain.Models.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opdex.Platform.Application.Handlers.Tokens;
+
+public class RetrieveTokenAttributesByTokenIdQueryHandler : IRequestHandler<RetrieveTokenAttributesByTokenIdQuery, IEnumerable<TokenAttribute>>
+{
+    private readonly IMediator _mediator;
+
+    public RetrieveTokenAttributesByTokenIdQueryHandler(IMediator mediator)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public Task<IEnumerable<TokenAttribute>> Handle(RetrieveTokenAttributesByTokenIdQuery request, CancellationToken cancellationToken)
+    {
+        return _mediator.Send(new SelectTokenAttributesByTokenIdQuery(request.TokenId), cancellationToken);
+    }
+}

--- a/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationServiceCollectionExtensions.cs
@@ -487,6 +487,7 @@ public static class PlatformApplicationServiceCollectionExtensions
         services.AddTransient<IRequestHandler<RetrieveTokenByIdQuery, Token>, RetrieveTokenByIdQueryHandler>();
         services.AddTransient<IRequestHandler<RetrieveTokenByAddressQuery, Token>, RetrieveTokenByAddressQueryHandler>();
         services.AddTransient<IRequestHandler<RetrieveTokenSummaryByMarketAndTokenIdQuery, TokenSummary>, RetrieveTokenSummaryByMarketAndTokenIdQueryHandler>();
+        services.AddTransient<IRequestHandler<RetrieveTokenAttributesByTokenIdQuery, IEnumerable<TokenAttribute>>, RetrieveTokenAttributesByTokenIdQueryHandler>();
 
         // Mining Governances
         services.AddTransient<IRequestHandler<RetrieveMiningGovernanceContractSummaryByAddressQuery, MiningGovernanceContractSummary>, RetrieveMiningGovernanceContractSummaryByAddressQueryHandler>();

--- a/src/Opdex.Platform.Common/Enums/TokenAttributeType.cs
+++ b/src/Opdex.Platform.Common/Enums/TokenAttributeType.cs
@@ -1,10 +1,25 @@
 namespace Opdex.Platform.Common.Enums;
 
+/// <summary>
+/// Attribute applied to token's matching values of database lookups.
+/// </summary>
 public enum TokenAttributeType
 {
+    /// <summary>
+    /// An Opdex Liquidity Pool Token, received for provisioning liquidity in a pool.
+    /// </summary>
     Provisional = 1,
+
+    /// <summary>
+    /// A unique SRC token, used in liquidity pool pairings.
+    /// </summary>
     NonProvisional = 2,
+
+    /// <summary>
+    /// Opdex mined, staking governance type tokens.
+    /// </summary>
     Staking = 3,
+
     /// <summary>
     /// Considered a security
     /// </summary>

--- a/src/Opdex.Platform.Common/Enums/TokenAttributeType.cs
+++ b/src/Opdex.Platform.Common/Enums/TokenAttributeType.cs
@@ -2,8 +2,11 @@ namespace Opdex.Platform.Common.Enums;
 
 public enum TokenAttributeType
 {
+    Provisional = 1,
+    NonProvisional = 2,
+    Staking = 3,
     /// <summary>
     /// Considered a security
     /// </summary>
-    Security = 1
+    Security = 4
 }

--- a/src/Opdex.Platform.Domain/Models/Tokens/MarketToken.cs
+++ b/src/Opdex.Platform.Domain/Models/Tokens/MarketToken.cs
@@ -6,7 +6,7 @@ namespace Opdex.Platform.Domain.Models.Tokens;
 public class MarketToken : TokenBase
 {
     public MarketToken(Market market, TokenBase token)
-        : base(token.Id, token.Address, token.IsLpt, token.Name, token.Symbol, token.Decimals, token.Sats, token.TotalSupply,
+        : base(token.Id, token.Address, token.Name, token.Symbol, token.Decimals, token.Sats, token.TotalSupply,
                token.CreatedBlock, token.ModifiedBlock)
     {
         Market = market ?? throw new ArgumentNullException(nameof(market), "Market must be provided.");

--- a/src/Opdex.Platform.Domain/Models/Tokens/Token.cs
+++ b/src/Opdex.Platform.Domain/Models/Tokens/Token.cs
@@ -5,14 +5,14 @@ namespace Opdex.Platform.Domain.Models.Tokens;
 
 public class Token : TokenBase
 {
-    public Token(Address address, bool isLpt, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply, ulong createdBlock)
-        : base(address, isLpt, name, symbol, decimals, sats, totalSupply, createdBlock)
+    public Token(Address address, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply, ulong createdBlock)
+        : base(address, name, symbol, decimals, sats, totalSupply, createdBlock)
     {
     }
 
-    public Token(ulong id, Address address, bool isLpt, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply,
+    public Token(ulong id, Address address, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply,
                  ulong createdBlock, ulong modifiedBlock)
-        : base(id, address, isLpt, name, symbol, decimals, sats, totalSupply, createdBlock, modifiedBlock)
+        : base(id, address, name, symbol, decimals, sats, totalSupply, createdBlock, modifiedBlock)
     {
     }
 

--- a/src/Opdex.Platform.Domain/Models/Tokens/TokenBase.cs
+++ b/src/Opdex.Platform.Domain/Models/Tokens/TokenBase.cs
@@ -8,7 +8,7 @@ namespace Opdex.Platform.Domain.Models.Tokens;
 
 public abstract class TokenBase : BlockAudit
 {
-    protected TokenBase(Address address, bool isLpt, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply, ulong createdBlock)
+    protected TokenBase(Address address, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply, ulong createdBlock)
         : base(createdBlock)
     {
         if (address == Address.Empty)
@@ -37,7 +37,6 @@ public abstract class TokenBase : BlockAudit
         }
 
         Address = address;
-        IsLpt = isLpt;
         Name = name;
         Symbol = symbol;
         Decimals = decimals;
@@ -45,12 +44,11 @@ public abstract class TokenBase : BlockAudit
         TotalSupply = totalSupply;
     }
 
-    protected TokenBase(ulong id, Address address, bool isLpt, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply,
+    protected TokenBase(ulong id, Address address, string name, string symbol, int decimals, ulong sats, UInt256 totalSupply,
                         ulong createdBlock, ulong modifiedBlock) : base(createdBlock, modifiedBlock)
     {
         Id = id;
         Address = address;
-        IsLpt = isLpt;
         Name = name;
         Symbol = symbol;
         Decimals = decimals;
@@ -60,7 +58,6 @@ public abstract class TokenBase : BlockAudit
 
     public ulong Id { get; }
     public Address Address { get; }
-    public bool IsLpt { get; }
     public string Name { get; }
     public string Symbol { get; }
     public int Decimals { get; }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/Tokens/TokenEntity.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/Tokens/TokenEntity.cs
@@ -6,7 +6,6 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 public class TokenEntity : AuditEntity
 {
     public ulong Id { get; set; }
-    public bool IsLpt { get; set; }
     public Address Address { get; set; }
     public string Symbol { get; set; }
     public string Name { get; set; }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/Addresses/Balances/AddressBalancesCursor.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/Addresses/Balances/AddressBalancesCursor.cs
@@ -11,7 +11,7 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Bala
 
 public class AddressBalancesCursor : Cursor<ulong>
 {
-    public AddressBalancesCursor(IEnumerable<Address> tokens, TokenProvisionalFilter tokenType, bool includeZeroBalances,
+    public AddressBalancesCursor(IEnumerable<Address> tokens, TokenAttributeFilter tokenType, bool includeZeroBalances,
                                  SortDirectionType sortDirection, uint limit, PagingDirection pagingDirection,
                                  ulong pointer)
         : base(sortDirection, limit, pagingDirection, pointer)
@@ -22,7 +22,7 @@ public class AddressBalancesCursor : Cursor<ulong>
     }
 
     public IEnumerable<Address> Tokens { get; }
-    public TokenProvisionalFilter TokenType { get; }
+    public TokenAttributeFilter TokenType { get; }
     public bool IncludeZeroBalances { get; }
 
     /// <inheritdoc />
@@ -68,7 +68,7 @@ public class AddressBalancesCursor : Cursor<ulong>
 
         TryGetCursorProperties<Address>(values, "tokens", out var tokens);
 
-        if (!TryGetCursorProperty<TokenProvisionalFilter>(values, "tokenType", out var tokenType)) return false;
+        if (!TryGetCursorProperty<TokenAttributeFilter>(values, "tokenType", out var tokenType)) return false;
 
         if (!TryGetCursorProperty<bool>(values, "includeZeroBalances", out var includeZeroBalances)) return false;
 

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/Tokens/TokensCursor.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Queries/Tokens/TokensCursor.cs
@@ -10,14 +10,14 @@ namespace Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 
 public class TokensCursor : Cursor<(string, ulong)>
 {
-    public TokensCursor(string keyword, IEnumerable<Address> tokens, TokenProvisionalFilter provisionalFilter, bool includeZeroLiquidity, TokenOrderByType orderBy,
+    public TokensCursor(string keyword, IEnumerable<Address> tokens, TokenAttributeFilter provisionalFilter, bool includeZeroLiquidity, TokenOrderByType orderBy,
                         SortDirectionType sortDirection, uint limit, PagingDirection pagingDirection, (string, ulong) pointer)
         : base(sortDirection, limit, pagingDirection, pointer)
     {
         Keyword = keyword;
         OrderBy = orderBy;
         Tokens = tokens ?? Enumerable.Empty<Address>();
-        ProvisionalFilter = provisionalFilter;
+        AttributeFilter = provisionalFilter;
         IncludeZeroLiquidity = includeZeroLiquidity;
     }
 
@@ -39,7 +39,7 @@ public class TokensCursor : Cursor<(string, ulong)>
     /// <summary>
     /// The type of token to filter for, liquidity pool tokens or not.
     /// </summary>
-    public TokenProvisionalFilter ProvisionalFilter { get; }
+    public TokenAttributeFilter AttributeFilter { get; }
 
     /// <summary>
     /// Includes tokens with no liquidity if true.
@@ -55,7 +55,7 @@ public class TokensCursor : Cursor<(string, ulong)>
         var sb = new StringBuilder();
         sb.AppendFormat("direction:{0};limit:{1};paging:{2};", SortDirection, Limit, PagingDirection);
         foreach (var token in Tokens) sb.AppendFormat("tokens:{0};", token);
-        sb.AppendFormat("provisional:{0};", ProvisionalFilter);
+        sb.AppendFormat("provisional:{0};", AttributeFilter);
         sb.AppendFormat("includeZeroLiquidity:{0};", IncludeZeroLiquidity);
         sb.AppendFormat("keyword:{0};", Keyword);
         sb.AppendFormat("orderBy:{0};", OrderBy);
@@ -69,7 +69,7 @@ public class TokensCursor : Cursor<(string, ulong)>
         if (!direction.IsValid()) throw new ArgumentOutOfRangeException(nameof(direction), "Invalid paging direction.");
         if (pointer == Pointer) throw new ArgumentOutOfRangeException(nameof(pointer), "Cannot paginate with an identical pointer.");
 
-        return new TokensCursor(Keyword, Tokens, ProvisionalFilter, IncludeZeroLiquidity, OrderBy, SortDirection, Limit, direction, pointer);
+        return new TokensCursor(Keyword, Tokens, AttributeFilter, IncludeZeroLiquidity, OrderBy, SortDirection, Limit, direction, pointer);
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public class TokensCursor : Cursor<(string, ulong)>
 
         TryGetCursorProperties<Address>(values, "tokens", out var tokens);
 
-        TryGetCursorProperty<TokenProvisionalFilter>(values, "provisional", out var provisional);
+        TryGetCursorProperty<TokenAttributeFilter>(values, "provisional", out var provisional);
 
         TryGetCursorProperty<bool>(values, "includeZeroLiquidity", out var includeZeroLiquidity);
 
@@ -142,7 +142,7 @@ public class TokensCursor : Cursor<(string, ulong)>
 /// <summary>
 /// Filter for a tokens status whether it is an Opdex liquidity pool token or not.
 /// </summary>
-public enum TokenProvisionalFilter
+public enum TokenAttributeFilter
 {
     /// <summary>
     /// Non Opdex liquidity pool tokens.
@@ -155,9 +155,14 @@ public enum TokenProvisionalFilter
     Provisional = 1,
 
     /// <summary>
+    /// Opdex mined, staking tokens
+    /// </summary>
+    Staking = 2,
+
+    /// <summary>
     /// All tokens.
     /// </summary>
-    All = 2
+    All = 3
 }
 
 /// <summary>

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/PersistTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/PersistTokenCommandHandler.cs
@@ -16,7 +16,6 @@ public class PersistTokenCommandHandler : IRequestHandler<PersistTokenCommand, u
     private static readonly string InsertSqlCommand =
         $@"INSERT INTO token (
                 {nameof(TokenEntity.Address)},
-                {nameof(TokenEntity.IsLpt)},
                 {nameof(TokenEntity.Name)},
                 {nameof(TokenEntity.Symbol)},
                 {nameof(TokenEntity.Decimals)},
@@ -26,7 +25,6 @@ public class PersistTokenCommandHandler : IRequestHandler<PersistTokenCommand, u
                 {nameof(TokenEntity.ModifiedBlock)}
               ) VALUES (
                 @{nameof(TokenEntity.Address)},
-                @{nameof(TokenEntity.IsLpt)},
                 @{nameof(TokenEntity.Name)},
                 @{nameof(TokenEntity.Symbol)},
                 @{nameof(TokenEntity.Decimals)},

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByAddressQueryHandler.cs
@@ -18,7 +18,6 @@ public class SelectTokenByAddressQueryHandler : IRequestHandler<SelectTokenByAdd
         @$"Select
                 {nameof(TokenEntity.Id)},
                 {nameof(TokenEntity.Address)},
-                {nameof(TokenEntity.IsLpt)},
                 {nameof(TokenEntity.Name)},
                 {nameof(TokenEntity.Symbol)},
                 {nameof(TokenEntity.Decimals)},

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByIdQueryHandler.cs
@@ -17,7 +17,6 @@ public class SelectTokenByIdQueryHandler: IRequestHandler<SelectTokenByIdQuery, 
         @$"Select
                 {nameof(TokenEntity.Id)},
                 {nameof(TokenEntity.Address)},
-                {nameof(TokenEntity.IsLpt)},
                 {nameof(TokenEntity.Name)},
                 {nameof(TokenEntity.Symbol)},
                 {nameof(TokenEntity.Decimals)},

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
@@ -53,7 +53,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<TokenEntity, Token>()
-            .ConstructUsing((src, ctx) => new Token(src.Id, src.Address, src.IsLpt, src.Name, src.Symbol, src.Decimals, src.Sats, src.TotalSupply, src.CreatedBlock, src.ModifiedBlock))
+            .ConstructUsing((src, ctx) => new Token(src.Id, src.Address, src.Name, src.Symbol, src.Decimals, src.Sats, src.TotalSupply, src.CreatedBlock, src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<TokenSummaryEntity, TokenSummary>()
@@ -435,7 +435,6 @@ public class PlatformInfrastructureMapperProfile : Profile
         CreateMap<Token, TokenEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
-            .ForMember(dest => dest.IsLpt, opt => opt.MapFrom(src => src.IsLpt))
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
             .ForMember(dest => dest.Symbol, opt => opt.MapFrom(src => src.Symbol))
             .ForMember(dest => dest.Decimals, opt => opt.MapFrom(src => src.Decimals))

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -62,6 +62,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Decimals, opt => opt.MapFrom(src => src.Decimals))
             .ForMember(dest => dest.Sats, opt => opt.MapFrom(src => src.Sats))
             .ForMember(dest => dest.TotalSupply, opt => opt.MapFrom(src => src.TotalSupply))
+            .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.Attributes))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -77,6 +78,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Decimals, opt => opt.MapFrom(src => src.Decimals))
             .ForMember(dest => dest.Sats, opt => opt.MapFrom(src => src.Sats))
             .ForMember(dest => dest.TotalSupply, opt => opt.MapFrom(src => src.TotalSupply))
+            .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.Attributes))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForMember(dest => dest.LiquidityPool, opt => opt.MapFrom(src => src.LiquidityPool))
             .ForMember(dest => dest.Market, opt => opt.MapFrom(src => src.Market))

--- a/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
@@ -12,6 +12,7 @@ public sealed class TokenFilterParameters : FilterParameters<TokensCursor>
     public TokenFilterParameters()
     {
         Tokens = new List<Address>();
+        TokenAttributes = new List<TokenAttributeFilter>();
         IncludeZeroLiquidity = true;
     }
 
@@ -22,10 +23,10 @@ public sealed class TokenFilterParameters : FilterParameters<TokensCursor>
     public TokenOrderByType OrderBy { get; set; }
 
     /// <summary>
-    /// The type of token to filter for, liquidity pool tokens or not.
+    /// The types of token to filter for.
     /// </summary>
     /// <example>Provisional</example>
-    public TokenAttributeFilter TokenType { get; set; }
+    public IEnumerable<TokenAttributeFilter> TokenAttributes { get; set; }
 
     /// <summary>
     /// Tokens to filter specifically for.
@@ -50,7 +51,7 @@ public sealed class TokenFilterParameters : FilterParameters<TokensCursor>
     /// <inheritdoc />
     protected override TokensCursor InternalBuildCursor()
     {
-        if (EncodedCursor is null) return new TokensCursor(Keyword, Tokens, TokenType, IncludeZeroLiquidity, OrderBy, Direction, Limit, PagingDirection.Forward, default);
+        if (EncodedCursor is null) return new TokensCursor(Keyword, Tokens, TokenAttributes, IncludeZeroLiquidity, OrderBy, Direction, Limit, PagingDirection.Forward, default);
         Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
         _ = TokensCursor.TryParse(decodedCursor, out var cursor);
         return cursor;

--- a/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Tokens/TokenFilterParameters.cs
@@ -25,7 +25,7 @@ public sealed class TokenFilterParameters : FilterParameters<TokensCursor>
     /// The type of token to filter for, liquidity pool tokens or not.
     /// </summary>
     /// <example>Provisional</example>
-    public TokenProvisionalFilter TokenType { get; set; }
+    public TokenAttributeFilter TokenType { get; set; }
 
     /// <summary>
     /// Tokens to filter specifically for.

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
@@ -13,7 +13,7 @@ public sealed class AddressBalanceFilterParameters : FilterParameters<AddressBal
     public AddressBalanceFilterParameters()
     {
         Tokens = new List<Address>();
-        TokenType = TokenAttributeFilter.All;
+        TokenAttributes = new List<TokenAttributeFilter>();
     }
 
     /// <summary>
@@ -24,10 +24,10 @@ public sealed class AddressBalanceFilterParameters : FilterParameters<AddressBal
     public IEnumerable<Address> Tokens { get; set; }
 
     /// <summary>
-    /// The type of token to filter by, either provisional or non-provisional.
+    /// The types of token to filter balances by.
     /// </summary>
     /// <example>Provisional</example>
-    public TokenAttributeFilter TokenType { get; set; }
+    public IEnumerable<TokenAttributeFilter> TokenAttributes { get; set; }
 
     /// <summary>
     /// Includes zero balances if true, otherwise filters out zero balances if false. Default false.
@@ -38,7 +38,7 @@ public sealed class AddressBalanceFilterParameters : FilterParameters<AddressBal
     /// <inheritdoc />
     protected override AddressBalancesCursor InternalBuildCursor()
     {
-        if (EncodedCursor is null) return new AddressBalancesCursor(Tokens, TokenType, IncludeZeroBalances, Direction, Limit, PagingDirection.Forward, default);
+        if (EncodedCursor is null) return new AddressBalancesCursor(Tokens, TokenAttributes, IncludeZeroBalances, Direction, Limit, PagingDirection.Forward, default);
         Base64Extensions.TryBase64Decode(EncodedCursor, out var decodedCursor);
         AddressBalancesCursor.TryParse(decodedCursor, out var cursor);
         return cursor;

--- a/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Wallets/AddressBalanceFilterParameters.cs
@@ -13,7 +13,7 @@ public sealed class AddressBalanceFilterParameters : FilterParameters<AddressBal
     public AddressBalanceFilterParameters()
     {
         Tokens = new List<Address>();
-        TokenType = TokenProvisionalFilter.All;
+        TokenType = TokenAttributeFilter.All;
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public sealed class AddressBalanceFilterParameters : FilterParameters<AddressBal
     /// The type of token to filter by, either provisional or non-provisional.
     /// </summary>
     /// <example>Provisional</example>
-    public TokenProvisionalFilter TokenType { get; set; }
+    public TokenAttributeFilter TokenType { get; set; }
 
     /// <summary>
     /// Includes zero balances if true, otherwise filters out zero balances if false. Default false.

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenResponseModel.cs
@@ -1,5 +1,7 @@
 using NJsonSchema.Annotations;
+using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Models;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Opdex.Platform.WebApi.Models.Responses.Tokens;
@@ -52,6 +54,12 @@ public class TokenResponseModel
     /// <example>"2100000000000000"</example>
     [NotNull]
     public FixedDecimal TotalSupply { get; set; }
+
+    /// <summary>
+    /// Attributes currently applied to the token.
+    /// </summary>
+    /// <example>["NonProvisional", "Staking"]</example>
+    public IEnumerable<TokenAttributeType> Attributes { get; set; }
 
     /// <summary>
     /// A summary including the USD price of the token and daily price change percentage if exists. Market tokens receive

--- a/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Tokens/TokenFilterParametersValidator.cs
@@ -18,7 +18,7 @@ public class TokenFilterParametersValidator : AbstractCursorValidator<TokenFilte
             .WithMessage("Keyword must consist of letters, numbers and spaces only.");
 
         RuleFor(filter => filter.OrderBy).MustBeValidEnumValue().WithMessage("Order must be valid for the enumeration values.");
-        RuleFor(filter => filter.TokenType).MustBeValidEnumValue().WithMessage("Token type must be valid for the enumeration values.");
+        RuleForEach(filter => filter.TokenAttributes).MustBeValidEnumValue().WithMessage("Token attributes must be valid for the enumeration values.");
         RuleForEach(filter => filter.Tokens).MustBeNetworkAddress().WithMessage("Token must be valid address.");
         RuleFor(filter => filter.Limit).LessThanOrEqualTo(Cursor.DefaultMaxLimit).WithMessage($"Limit must be between 1 and {Cursor.DefaultMaxLimit}.");
     }

--- a/src/Opdex.Platform.WebApi/Validation/Wallets/AddressBalanceFilterParametersValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Wallets/AddressBalanceFilterParametersValidator.cs
@@ -10,6 +10,7 @@ public class AddressBalanceFilterParametersValidator : AbstractCursorValidator<A
     public AddressBalanceFilterParametersValidator()
     {
         RuleForEach(filter => filter.Tokens).MustBeNetworkAddress().WithMessage("Token must be valid address.");
+        RuleForEach(filter => filter.TokenAttributes).MustBeValidEnumValue().WithMessage("Token attributes must be valid for the enumeration values.");
         RuleFor(filter => filter.Limit).LessThanOrEqualTo(Cursor.DefaultMaxLimit).WithMessage($"Limit must be between 1 and {Cursor.DefaultMaxLimit}.");
     }
 }

--- a/test/Opdex.Platform.Application.Tests/Assemblers/AddressAllowanceDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/AddressAllowanceDtoAssemblerTests.cs
@@ -75,7 +75,7 @@ public class AddressAllowanceDtoAssemblerTests
             Owner = "PXRNXAEYkCjMJpqdgdRG4FzbguG4GcdZuN",
             Spender = "PRpStaZSj3T5zYkU4Dw9WiyB73KAHi5tRY"
         };
-        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
         var source = new AddressAllowance(5, 5, "PXRNXAEYkCjMJpqdgdRG4FzbguG4GcdZuN", "PRpStaZSj3T5zYkU4Dw9WiyB73KAHi5tRY", new UInt256("500000000"), 5, 50);
 
         _mapperMock.Setup(callTo => callTo.Map<AddressAllowanceDto>(It.IsAny<AddressAllowance>())).Returns(dto);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/AddressBalanceDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/AddressBalanceDtoAssemblerTests.cs
@@ -71,7 +71,7 @@ public class AddressBalanceDtoAssemblerTests
     {
         // Arrange
         var dto = new AddressBalanceDto { Address = "PQFv8x66vXEQEjw7ZBi8kCavrz15S1ShcH" };
-        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
         var source = new AddressBalance(5, 5, "PQFv8x66vXEQEjw7ZBi8kCavrz15S1ShcG", 500000000, 5, 50);
 
         _mapperMock.Setup(callTo => callTo.Map<AddressBalanceDto>(It.IsAny<AddressBalance>())).Returns(dto);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/MarketDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/MarketDtoAssemblerTests.cs
@@ -76,7 +76,7 @@ public class MarketDtoAssemblerTests
         // Arrange
         var market = new Market(10, "t3eYNv5BL2FAC3iS1PEGC4VsovkDgib1MD", 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         var summary = new MarketSummary(10, 25);
-        var crs = new Token(1, "CRS", false, "Cirrus", "CRS", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
+        var crs = new Token(1, "CRS", "Cirrus", "CRS", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveMarketSummaryByMarketIdQuery>(query => query.MarketId == market.Id),
                                                   CancellationToken.None)).ReturnsAsync(summary);
@@ -99,7 +99,7 @@ public class MarketDtoAssemblerTests
         // Arrange
         var market = new Market(10, "t3eYNv5BL2FAC3iS1PEGC4VsovkDgib1MD", 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         var summary = new MarketSummary(10, 25);
-        var crs = new Token(1, "CRS", false, "Cirrus", "CRS", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
+        var crs = new Token(1, "CRS", "Cirrus", "CRS", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveMarketSummaryByMarketIdQuery>(query => query.MarketId == market.Id),
                                                   CancellationToken.None)).ReturnsAsync(summary);
@@ -126,8 +126,8 @@ public class MarketDtoAssemblerTests
         // Arrange
         var market = new Market(10, "t3eYNv5BL2FAC3iS1PEGC4VsovkDgib1MD", 2, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         var summary = new MarketSummary(10, 25);
-        var crs = new Token(1, "CRS", false, "Cirrus", "CRS", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
-        var stakingToken = new Token(5, "t5BL2FAC3iS1PEGC43eYNvVsovkDgib1MD", false, "Opdex Token", "ODX", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
+        var crs = new Token(1, "CRS", "Cirrus", "CRS", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
+        var stakingToken = new Token(5, "t5BL2FAC3iS1PEGC43eYNvVsovkDgib1MD", "Opdex Token", "ODX", 8, 100_000_000, new UInt256("2100000000000000"), 10, 11);
         var marketToken = new MarketToken(market, stakingToken);
         _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveMarketSummaryByMarketIdQuery>(query => query.MarketId == market.Id),
                                                   CancellationToken.None)).ReturnsAsync(summary);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/MarketTokenDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/MarketTokenDtoAssemblerTests.cs
@@ -120,6 +120,9 @@ public class MarketTokenDtoAssemblerTests
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(liquidityPool);
 
+        _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveTokenAttributesByTokenIdQuery>(query => query.TokenId == token.Id), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new [] { new TokenAttribute(1, 1, TokenAttributeType.NonProvisional)});
+
         // Act
         var tokenDto = await _assembler.Assemble(marketToken);
 
@@ -131,6 +134,7 @@ public class MarketTokenDtoAssemblerTests
         tokenDto.Decimals.Should().Be(token.Decimals);
         tokenDto.Sats.Should().Be(token.Sats);
         tokenDto.TotalSupply.Should().Be(token.TotalSupply.ToDecimal(token.Decimals));
+        tokenDto.Attributes.Should().BeEquivalentTo(new [] {TokenAttributeType.NonProvisional});
         tokenDto.Summary.PriceUsd.Should().Be(token.Summary.PriceUsd);
         tokenDto.Summary.DailyPriceChangePercent.Should().Be(token.Summary.DailyPriceChangePercent);
         tokenDto.Summary.ModifiedBlock.Should().Be(token.Summary.ModifiedBlock);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/MarketTokenDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/MarketTokenDtoAssemblerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Opdex.Platform.Application.Abstractions.Queries.LiquidityPools;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
 using Opdex.Platform.Application.Assemblers;
+using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models.UInt;
 using Opdex.Platform.Domain.Models.LiquidityPools;
@@ -34,7 +35,7 @@ public class MarketTokenDtoAssemblerTests
     public async Task Assemble_RetrieveLiquidityPoolBySrcTokenIdAndMarketIdQuery_Send()
     {
         // Arrange
-        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", false, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
         var market = new Market(19, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
         var marketToken = new MarketToken(market, token);
 
@@ -55,12 +56,39 @@ public class MarketTokenDtoAssemblerTests
     }
 
     [Fact]
+    public async Task Assemble_RetrieveTokenAttributesByTokenIdQuery_Send()
+    {
+        // Arrange
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var market = new Market(19, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
+        var marketToken = new MarketToken(market, token);
+
+        // Act
+        try
+        {
+            await _assembler.Assemble(marketToken);
+        }
+        catch
+        {
+            // ignored
+        }
+
+        // Assert
+
+        _mediatorMock.Verify(callTo => callTo.Send(It.Is<RetrieveTokenAttributesByTokenIdQuery>(query => query.TokenId == token.Id),
+                                                   It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Assemble_RetrieveLiquidityPoolByAddressQuery_Send()
     {
         // Arrange
-        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", true, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
         var market = new Market(19, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
         var marketToken = new MarketToken(market, token);
+
+        _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveTokenAttributesByTokenIdQuery>(query => query.TokenId == token.Id), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new [] { new TokenAttribute(1, 1, TokenAttributeType.Provisional)});
 
         // Act
         try
@@ -82,7 +110,7 @@ public class MarketTokenDtoAssemblerTests
     public async Task Assemble_HappyPath_Map()
     {
         // Arrange
-        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", false, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
         token.SetSummary(new TokenSummary(5, 10, 15, -5.00m, 23.53m, 50, 50));
         var market = new Market(19, "kN2kwXwmu3wuFYmPBWQ38k7iYnkfGPPGgM", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
         var marketToken = new MarketToken(market, token);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/MiningPositionDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/MiningPositionDtoAssemblerTests.cs
@@ -103,7 +103,7 @@ public class MiningPositionDtoAssemblerTests
         var liquidityPool = new LiquidityPool(5, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liquidityPool);
 
-        var token = new Token(15, "PWcdTKU64jVFCDoHJgUKz633jsy1XTenAy", true, "wBTC/CRS OLPT", "OLPT", 8, 8, UInt256.Parse("10000000000000000000"), 500, 505);
+        var token = new Token(15, "PWcdTKU64jVFCDoHJgUKz633jsy1XTenAy", "wBTC/CRS OLPT", "OLPT", 8, 8, UInt256.Parse("10000000000000000000"), 500, 505);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         // Act

--- a/test/Opdex.Platform.Application.Tests/Assemblers/StakingPositionDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/StakingPositionDtoAssemblerTests.cs
@@ -103,7 +103,7 @@ public class StakingPositionDtoAssemblerTests
         var market = new Market(5, "PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", 10, 50, Address.Empty, "PCiNwuLQemjMk63A6r5mS2Ma9Kskki6HZK", false, false, false, 1, true, 500, 505);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
 
-        var token = new Token(50, "PWcdTKU64jVFCDoHJgUKz633jsy1XTenAy", true, "Governance Token", "GOV", 8, 8, UInt256.Parse("10000000000000000000"), 500, 505);
+        var token = new Token(50, "PWcdTKU64jVFCDoHJgUKz633jsy1XTenAy", "Governance Token", "GOV", 8, 8, UInt256.Parse("10000000000000000000"), 500, 505);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         // Act

--- a/test/Opdex.Platform.Application.Tests/Assemblers/TokenDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/TokenDtoAssemblerTests.cs
@@ -57,7 +57,6 @@ public class TokenDtoAssemblerTests
         catch { }
 
         // Assert
-
         _mediatorMock.Verify(callTo => callTo.Send(It.Is<RetrieveTokenAttributesByTokenIdQuery>(query => query.TokenId == token.Id),
                                                    It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/test/Opdex.Platform.Application.Tests/Assemblers/TokenDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/TokenDtoAssemblerTests.cs
@@ -31,7 +31,7 @@ public class TokenDtoAssemblerTests
     public async Task Assemble_RetrieveTokenSummaryByMarketAndTokenIdQuery_Send()
     {
         // Arrange
-        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", false, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
 
         // Act
         await _assembler.Assemble(token);
@@ -46,7 +46,7 @@ public class TokenDtoAssemblerTests
     public async Task Assemble_HappyPath_Map()
     {
         // Arrange
-        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", false, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
         var tokenSummary = new TokenSummary(1, 0, token.Id, 1.12m, 3.45m, 9, 10);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenSummaryByMarketAndTokenIdQuery>(), It.IsAny<CancellationToken>()))

--- a/test/Opdex.Platform.Application.Tests/Assemblers/TokenDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/TokenDtoAssemblerTests.cs
@@ -4,6 +4,7 @@ using MediatR;
 using Moq;
 using Opdex.Platform.Application.Abstractions.Queries.Tokens;
 using Opdex.Platform.Application.Assemblers;
+using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Common.Models.UInt;
 using Opdex.Platform.Domain.Models.Tokens;
@@ -43,6 +44,25 @@ public class TokenDtoAssemblerTests
     }
 
     [Fact]
+    public async Task Assemble_RetrieveTokenAttributesByTokenIdQuery_Send()
+    {
+        // Arrange
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+
+        // Act
+        try
+        {
+            await _assembler.Assemble(token);
+        }
+        catch { }
+
+        // Assert
+
+        _mediatorMock.Verify(callTo => callTo.Send(It.Is<RetrieveTokenAttributesByTokenIdQuery>(query => query.TokenId == token.Id),
+                                                   It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Assemble_HappyPath_Map()
     {
         // Arrange
@@ -51,6 +71,9 @@ public class TokenDtoAssemblerTests
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenSummaryByMarketAndTokenIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(tokenSummary);
+
+        _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveTokenAttributesByTokenIdQuery>(query => query.TokenId == token.Id), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new [] { new TokenAttribute(1, 1, TokenAttributeType.NonProvisional)});
 
         // Act
         var tokenDto = await _assembler.Assemble(token);
@@ -63,6 +86,7 @@ public class TokenDtoAssemblerTests
         tokenDto.Decimals.Should().Be(token.Decimals);
         tokenDto.Sats.Should().Be(token.Sats);
         tokenDto.TotalSupply.Should().Be(token.TotalSupply.ToDecimal(token.Decimals));
+        tokenDto.Attributes.Should().BeEquivalentTo(new [] {TokenAttributeType.NonProvisional});
         tokenDto.Summary.PriceUsd.Should().Be(tokenSummary.PriceUsd);
         tokenDto.Summary.DailyPriceChangePercent.Should().Be(tokenSummary.DailyPriceChangePercent);
         tokenDto.Summary.ModifiedBlock.Should().Be(tokenSummary.ModifiedBlock);

--- a/test/Opdex.Platform.Application.Tests/Assemblers/VaultGovernanceDtoAssemblerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Assemblers/VaultGovernanceDtoAssemblerTests.cs
@@ -36,7 +36,7 @@ public class VaultDtoAssemblerTests
     public async Task Assemble_TokenAddress()
     {
         // Arrange
-        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var balance = new AddressBalance(5, 5, "PQFv8x66vXEQEjw7ZBi8kCavrz15S1ShcG", 500000000, 5, 50);
@@ -59,7 +59,7 @@ public class VaultDtoAssemblerTests
     public async Task Assemble_BalanceNotNull_TokensLockedFromBalance()
     {
         // Arrange
-        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var balance = new AddressBalance(5, 5, "PQFv8x66vXEQEjw7ZBi8kCavrz15S1ShcG", 500000000, 5, 50);
@@ -82,7 +82,7 @@ public class VaultDtoAssemblerTests
     public async Task Assemble_NullBalance_TokensLockedZero()
     {
         // Arrange
-        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var token = new Token(5, "PHrN1DPvMcp17i5YL4yUzUCVcH2QimMvHi", "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         _mediatorMock

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Balances/CreateAddressBalanceCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Balances/CreateAddressBalanceCommandHandlerTests.cs
@@ -98,7 +98,7 @@ public class CreateAddressBalanceCommandHandlerTests
         Address token = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk";
         const ulong blockHeight = 10;
 
-        var tokenResponse = new Token(1, token, false, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
+        var tokenResponse = new Token(1, token, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
 
         _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(tokenResponse);
@@ -126,7 +126,7 @@ public class CreateAddressBalanceCommandHandlerTests
         const ulong blockHeight = 10;
         const ulong balanceModifiedBlock = 11;
 
-        var tokenResponse = new Token(2, token, false, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
+        var tokenResponse = new Token(2, token, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
 
         var balance = new AddressBalance(1, tokenResponse.Id, walletAddress, 10, 3, balanceModifiedBlock);
 
@@ -152,7 +152,7 @@ public class CreateAddressBalanceCommandHandlerTests
         Address token = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk";
         const ulong blockHeight = 10;
 
-        var tokenResponse = new Token(2, token, false, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
+        var tokenResponse = new Token(2, token, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
 
         var balance = new AddressBalance(1, tokenResponse.Id, walletAddress, 10, 3, blockHeight);
 
@@ -180,7 +180,7 @@ public class CreateAddressBalanceCommandHandlerTests
         Address token = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk";
         const ulong blockHeight = 10;
 
-        var tokenResponse = new Token(2, token, false, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
+        var tokenResponse = new Token(2, token, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
 
         _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(tokenResponse);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Balances/CreateRewindAddressBalancesCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Balances/CreateRewindAddressBalancesCommandHandlerTests.cs
@@ -91,7 +91,7 @@ public class CreateRewindAddressBalancesCommandHandlerTests
             new AddressBalance(2, 2, "P5uJYUcmAsqAEgUXjBJPuCXfcNKdN28FQf", 5, 3, 4)
         };
 
-        var tokenResponse = new Token(2, "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk", false, "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
+        var tokenResponse = new Token(2, "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXk", "TokenName", "Symbol", 8, 100_000_00, 10000000000, 4, 5);
 
         _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveAddressBalancesByModifiedBlockQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(balances);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Mining/GetMiningPositionByPoolQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Mining/GetMiningPositionByPoolQueryHandlerTests.cs
@@ -135,7 +135,7 @@ public class GetMiningPositionByPoolQueryHandlerTests
         var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "GOV-CRS", 10, 15, 20, 25, 30);
         var addressMining = new AddressMining(5, 10, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", 100000000000, 50, 500);
         var miningPool = new MiningPool(5, 5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", 10, 10, 10000, 25, 30);
-        var token = new Token(5, "PDrzyNsewpj4KDnDttqcJT5EK7vZXQufNU", false, "Governance Token", "GOV", 8, 10000000, 10000000000000000000, 10, 20);
+        var token = new Token(5, "PDrzyNsewpj4KDnDttqcJT5EK7vZXQufNU", "Governance Token", "GOV", 8, 10000000, 10000000000000000000, 10, 20);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByIdQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liqudityPool);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMiningPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(miningPool);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Staking/GetStakingPositionByPoolQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Addresses/Staking/GetStakingPositionByPoolQueryHandlerTests.cs
@@ -136,7 +136,7 @@ public class GetStakingPositionByPoolQueryHandlerTests
         var liqudityPool = new LiquidityPool(5, "PXResSytiRhJwNiD1DS9aZinPjEUvk8BuX", "GOV-CRS", 10, 15, 20, 25, 30);
         var addressStaking = new AddressStaking(5, 5, "PUFLuoW2K4PgJZ4nt5fEUHfvQXyQWKG9hm", UInt256.Parse("50000000000"), 50, 100);
         var market = new Market(5, "PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", 5, 25, Address.Empty, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, false, false, 3, false, 50, 100);
-        var token = new Token(5, "PDrzyNsewpj4KDnDttqcJT5EK7vZXQufNU", false, "Governance Token", "GOV", 8, 10000000, UInt256.Parse("10000000000000000000"), 20, 25);
+        var token = new Token(5, "PDrzyNsewpj4KDnDttqcJT5EK7vZXQufNU", "Governance Token", "GOV", 8, 10000000, UInt256.Parse("10000000000000000000"), 20, 25);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveLiquidityPoolByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(liqudityPool);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveAddressStakingByLiquidityPoolIdAndOwnerQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(addressStaking);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateAddLiquidityTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateAddLiquidityTransactionQuoteCommandHandlerTests.cs
@@ -174,7 +174,7 @@ public class CreateAddLiquidityTransactionQuoteCommandHandlerTests
         const ulong deadline = 1ul;
 
         var pool = new LiquidityPool(1, liquidityPool, "BTC-CRS", 2, 3, 4, 6, 7);
-        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
+        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
         var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
         var cancellationToken = new CancellationTokenSource().Token;
 
@@ -233,7 +233,7 @@ public class CreateAddLiquidityTransactionQuoteCommandHandlerTests
         const ulong deadline = 5400;
 
         var pool = new LiquidityPool(1, liquidityPool, "BTC-CRS", 2, 3, 4, 6, 7);
-        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
+        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
         var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
         var cancellationToken = new CancellationTokenSource().Token;
 

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateRemoveLiquidityTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/LiquidityPools/CreateRemoveLiquidityTransactionQuoteCommandHandlerTests.cs
@@ -148,7 +148,7 @@ public class CreateRemoveLiquidityTransactionQuoteCommandHandlerTests
         const ulong deadline = 1ul;
 
         var pool = new LiquidityPool(1, liquidityPool.ToString(), "BTC-CRS", 2, 3, 4, 6, 7);
-        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
+        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
         var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
         var cancellationToken = new CancellationTokenSource().Token;
 
@@ -206,7 +206,7 @@ public class CreateRemoveLiquidityTransactionQuoteCommandHandlerTests
         const ulong deadline = 5400ul;
 
         var pool = new LiquidityPool(1, liquidityPool.ToString(), "BTC-CRS", 2, 3, 4, 6, 7);
-        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
+        var token = new Token(1, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
         var marketRouter = new MarketRouter(1, "PMsinMXrr2uNEL5AQD1LpiYTRFiRTA8uZU", 2, true, 3, 4);
         var cancellationToken = new CancellationTokenSource().Token;
 

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/MarketTokens/GetMarketTokenSnapshotsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/MarketTokens/GetMarketTokenSnapshotsWithFilterQueryHandlerTests.cs
@@ -120,7 +120,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
 
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -147,7 +147,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 10, PagingDirection.Forward, default);
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -176,7 +176,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 3, PagingDirection.Forward, (DateTime.UtcNow, 10));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -206,7 +206,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 10));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -237,7 +237,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 10));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -268,7 +268,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, default);
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -299,7 +299,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 50));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -330,7 +330,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 50));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -361,7 +361,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 50));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -391,7 +391,7 @@ public class GetMarketTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 50));
         var request = new GetMarketTokenSnapshotsWithFilterQuery(marketAddress, tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
         var market = new Market(10, marketAddress, 1, 5, Address.Empty, new Address("tS1PEGC4VsovkDgib1MD3eYNv5BL2FAC3i"), false, false, false, 3, true, 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Markets/Quotes/CreateCollectStandardMarketFeesTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Markets/Quotes/CreateCollectStandardMarketFeesTransactionQuoteCommandHandlerTests.cs
@@ -111,7 +111,7 @@ public class CreateCollectStandardMarketFeesTransactionQuoteCommandHandlerTests
         var command = new CreateCollectStandardMarketFeesTransactionQuoteCommand(market, owner, tokenAddress, amount);
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var token = new Token(5, "PNEPCzpKSXns3jWtVfkF7WJeZKdNeEZTBK", false, "Opdex", "dODX", 8, 10000000000, 50000000000000, 9, 10);
+        var token = new Token(5, "PNEPCzpKSXns3jWtVfkF7WJeZKdNeEZTBK", "Opdex", "dODX", 8, 10000000000, 50000000000000, 9, 10);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var expectedParameters = new List<TransactionQuoteRequestParameter>
@@ -149,7 +149,7 @@ public class CreateCollectStandardMarketFeesTransactionQuoteCommandHandlerTests
         var command = new CreateCollectStandardMarketFeesTransactionQuoteCommand(market, owner, tokenAddress, amount);
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var token = new Token(5, "PNEPCzpKSXns3jWtVfkF7WJeZKdNeEZTBK", false, "Opdex", "dODX", 8, 10000000000, 500000000000, 9, 10);
+        var token = new Token(5, "PNEPCzpKSXns3jWtVfkF7WJeZKdNeEZTBK", "Opdex", "dODX", 8, 10000000000, 500000000000, 9, 10);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var expectedRequest = new TransactionQuoteRequest(market, owner, FixedDecimal.Zero, StandardMarketConstants.Methods.CollectMarketFees, _config.WalletTransactionCallback);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Routers/GetSwapAmountInQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Routers/GetSwapAmountInQueryHandlerTests.cs
@@ -32,8 +32,8 @@ public class GetSwapAmountInQueryHandlerTests
     public async Task Handle_RetrieveTokenByAddressQuery_SendForTokenIn()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountInQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, tokenOut.Address,
@@ -51,8 +51,8 @@ public class GetSwapAmountInQueryHandlerTests
     public async Task Handle_RetrieveTokenByAddressQuery_SendForTokenOut()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountInQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, tokenOut.Address,
@@ -70,8 +70,8 @@ public class GetSwapAmountInQueryHandlerTests
     public async Task Handle_RetrieveMarketByAddressQuery_Send()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountInQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, tokenOut.Address,
@@ -91,8 +91,8 @@ public class GetSwapAmountInQueryHandlerTests
         // Arrange
         var market = new Market(88, new Address("PWbQLxNnYdyUBLmeEL3ET1WdNx7dvbH8mi"), 20, 25, Address.Empty,
                                 new Address("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh"), false, false, false, 3, true, 2, 250);
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut, market);
 
         var request = new GetSwapAmountInQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, tokenOut.Address,
@@ -110,8 +110,8 @@ public class GetSwapAmountInQueryHandlerTests
     public async Task Handle_RetrieveSwapAmountInQuery_Send()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountInQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, tokenOut.Address,
@@ -129,8 +129,8 @@ public class GetSwapAmountInQueryHandlerTests
     public async Task Handle_RetrieveSwapAmountInQuery_ReturnDecimal()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountInQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, tokenOut.Address, FixedDecimal.Parse("34209.34821118"));

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Routers/GetSwapAmountOutQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Routers/GetSwapAmountOutQueryHandlerTests.cs
@@ -32,8 +32,8 @@ public class GetSwapAmountOutQueryHandlerTests
     public async Task Handle_RetrieveTokenByAddressQuery_SendForTokenIn()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountOutQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, FixedDecimal.Parse("34209.34821118"),
@@ -51,8 +51,8 @@ public class GetSwapAmountOutQueryHandlerTests
     public async Task Handle_RetrieveTokenByAddressQuery_SendForTokenOut()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountOutQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, FixedDecimal.Parse("34209.34821118"),
@@ -70,8 +70,8 @@ public class GetSwapAmountOutQueryHandlerTests
     public async Task Handle_RetrieveMarketByAddressQuery_Send()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountOutQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, FixedDecimal.Parse("34209.34821118"),
@@ -91,8 +91,8 @@ public class GetSwapAmountOutQueryHandlerTests
         // Arrange
         var market = new Market(88, new Address("PWbQLxNnYdyUBLmeEL3ET1WdNx7dvbH8mi"), 20, 25, Address.Empty,
                                 new Address("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh"), false, false, false, 3, true, 2, 250);
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut, market);
 
         var request = new GetSwapAmountOutQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, FixedDecimal.Parse("34209.34821118"),
@@ -110,8 +110,8 @@ public class GetSwapAmountOutQueryHandlerTests
     public async Task Handle_RetrieveSwapAmountOutQuery_Send()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountOutQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, FixedDecimal.Parse("34209.34821118"),
@@ -129,8 +129,8 @@ public class GetSwapAmountOutQueryHandlerTests
     public async Task Handle_RetrieveSwapAmountOutQuery_ReturnDecimal()
     {
         // Arrange
-        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
-        var tokenOut = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 6, 1000000000, 21000000000000000, 50, 50);
+        var tokenOut = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 50, 50);
         SetupDomain(tokenIn, tokenOut);
 
         var request = new GetSwapAmountOutQuery(new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), tokenIn.Address, FixedDecimal.Parse("34209.34821118"),

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/CreateAddTokenCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/CreateAddTokenCommandHandlerTests.cs
@@ -40,7 +40,7 @@ public class CreateAddTokenCommandHandlerTests
     {
         // Arrange
         Address tokenAddress = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV";
-        var token = new Token(1, tokenAddress, false, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
+        var token = new Token(1, tokenAddress, "Bitcoin", "BTC", 8, 100_000_000, 10000000, 2, 3);
         _mockMediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         // Act

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetMarketTokenByMarketAndTokenAddressQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetMarketTokenByMarketAndTokenAddressQueryHandlerTests.cs
@@ -109,7 +109,7 @@ public class GetMarketTokenByMarketAndTokenAddressQueryHandlerTests
         // Arrange
         Address marketAddress = "PGgMkN2kwXwmu3wuFYmBWQ38k7iYnkfGPP";
         Address tokenAddress = "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm";
-        var token = new Token(1, tokenAddress, false, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, tokenAddress, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
         var market = new Market(19, "kN2kwXwmu3wuFYmPBWQ38k7iYnkfGPPGgM", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
 
         _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetMarketTokensWithFilterTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetMarketTokensWithFilterTests.cs
@@ -47,7 +47,7 @@ public class GetMarketTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenProvisionalFilter.NonProvisional,
+                                      TokenAttributeFilter.NonProvisional,
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -79,7 +79,7 @@ public class GetMarketTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenProvisionalFilter.NonProvisional,
+                                      TokenAttributeFilter.NonProvisional,
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -105,7 +105,7 @@ public class GetMarketTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenProvisionalFilter.NonProvisional,
+                                      TokenAttributeFilter.NonProvisional,
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -131,9 +131,9 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_TokensRetrieved_MapResults()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.Default,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.Default,
                                       SortDirectionType.ASC, 25, PagingDirection.Forward, ("50.00", 10));
-        var token = new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
+        var token = new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         var market = GetMarket();
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(market);
@@ -154,13 +154,13 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_LessThanLimitPlusOneResults_RemoveZero()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 4, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -193,13 +193,13 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingBackward_RemoveFirst()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 2, PagingDirection.Backward, ("50.00", 10));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -232,13 +232,13 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingForward_RemoveLast()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -271,14 +271,14 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_FirstRequestInPagedResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 2, PagingDirection.Forward, default);
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -312,14 +312,14 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingForwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -353,14 +353,14 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingBackwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.Symbol,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.Symbol,
                                       SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -394,12 +394,12 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingForwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.Name,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.Name,
                                       SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);
@@ -433,12 +433,12 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingBackwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, TokenOrderByType.PriceUsd,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.PriceUsd,
                                       SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveMarketByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(GetMarket);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetMarketTokensWithFilterTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetMarketTokensWithFilterTests.cs
@@ -47,7 +47,7 @@ public class GetMarketTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenAttributeFilter.NonProvisional,
+                                      new TokenAttributeFilter[] {TokenAttributeFilter.NonProvisional, TokenAttributeFilter.Staking},
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -79,7 +79,7 @@ public class GetMarketTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenAttributeFilter.NonProvisional,
+                                      new TokenAttributeFilter[] {TokenAttributeFilter.NonProvisional, TokenAttributeFilter.Staking},
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -105,7 +105,7 @@ public class GetMarketTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenAttributeFilter.NonProvisional,
+                                      new TokenAttributeFilter[] {TokenAttributeFilter.NonProvisional, TokenAttributeFilter.Staking},
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -131,7 +131,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_TokensRetrieved_MapResults()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.Default,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.Default,
                                       SortDirectionType.ASC, 25, PagingDirection.Forward, ("50.00", 10));
         var token = new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         var market = GetMarket();
@@ -154,7 +154,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_LessThanLimitPlusOneResults_RemoveZero()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 4, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
@@ -193,7 +193,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingBackward_RemoveFirst()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 2, PagingDirection.Backward, ("50.00", 10));
         var tokens = new[]
         {
@@ -232,7 +232,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingForward_RemoveLast()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
@@ -271,7 +271,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_FirstRequestInPagedResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 2, PagingDirection.Forward, default);
 
         var tokens = new[]
@@ -312,7 +312,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingForwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.DailyPriceChangePercent,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
 
         var tokens = new[]
@@ -353,7 +353,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingBackwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.Symbol,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.Symbol,
                                       SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
 
         var tokens = new[]
@@ -394,7 +394,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingForwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.Name,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.Name,
                                       SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
         var tokens = new[]
         {
@@ -433,7 +433,7 @@ public class GetMarketTokensWithFilterTests
     public async Task Handle_PagingBackwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, TokenOrderByType.PriceUsd,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, TokenOrderByType.PriceUsd,
                                       SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
         var tokens = new[]
         {

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetTokenByAddressQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetTokenByAddressQueryHandlerTests.cs
@@ -65,7 +65,7 @@ public class GetTokenByAddressQueryHandlerTests
     {
         // Arrange
         Address tokenAddress = "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm";
-        var token = new Token(1, tokenAddress, false, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var token = new Token(1, tokenAddress, "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
 
         _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetTokensWithFilterTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetTokensWithFilterTests.cs
@@ -54,7 +54,7 @@ public class GetTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenAttributeFilter.Provisional,
+                                      new TokenAttributeFilter[] {TokenAttributeFilter.Provisional},
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -78,7 +78,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_TokensRetrieved_MapResults()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 25, PagingDirection.Forward, ("50.00", 10));
         var token = new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         var tokens = new[] { token };
@@ -99,7 +99,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_LessThanLimitPlusOneResults_RemoveZero()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 4, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
@@ -137,7 +137,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingBackward_RemoveFirst()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.Default, SortDirectionType.ASC, 2, PagingDirection.Backward, ("50.00", 10));
         var tokens = new[]
         {
@@ -174,7 +174,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingForward_RemoveLast()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
@@ -211,7 +211,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_FirstRequestInPagedResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, default);
 
         var tokens = new[]
@@ -251,7 +251,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingForwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
 
         var tokens = new[]
@@ -291,7 +291,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingBackwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.Symbol, SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
 
         var tokens = new[]
@@ -331,7 +331,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingForwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.Name, SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
 
         var tokens = new[]
@@ -370,7 +370,7 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingBackwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false,
                                       TokenOrderByType.PriceUsd, SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
 
         var tokens = new[]

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetTokensWithFilterTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/GetTokensWithFilterTests.cs
@@ -54,7 +54,7 @@ public class GetTokensWithFilterTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenProvisionalFilter.Provisional,
+                                      TokenAttributeFilter.Provisional,
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -78,9 +78,9 @@ public class GetTokensWithFilterTests
     public async Task Handle_TokensRetrieved_MapResults()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 25, PagingDirection.Forward, ("50.00", 10));
-        var token = new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
+        var token = new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         var tokens = new[] { token };
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
 
@@ -99,13 +99,13 @@ public class GetTokensWithFilterTests
     public async Task Handle_LessThanLimitPlusOneResults_RemoveZero()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 4, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
@@ -137,13 +137,13 @@ public class GetTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingBackward_RemoveFirst()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.Default, SortDirectionType.ASC, 2, PagingDirection.Backward, ("50.00", 10));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
         int tokenAssembled = 0;
@@ -174,13 +174,13 @@ public class GetTokensWithFilterTests
     public async Task Handle_LimitPlusOneResultsPagingForward_RemoveLast()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, ("50.00", 10));
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
         int tokenAssembled = 0;
@@ -211,14 +211,14 @@ public class GetTokensWithFilterTests
     public async Task Handle_FirstRequestInPagedResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, default);
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
@@ -251,14 +251,14 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingForwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.DailyPriceChangePercent, SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
@@ -291,14 +291,14 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingBackwardWithMoreResults_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.Symbol, SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
-            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", true, "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10),
+            new Token(3, "fjjc9U4kqdrc4hYPeLPSqkCUMpPykkfL3X", "Binance", "BNB", 8, 100_000_000, 3_100_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
@@ -331,13 +331,13 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingForwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.Name, SortDirectionType.ASC, 2, PagingDirection.Forward, ("10.12", 2));
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);
@@ -370,13 +370,13 @@ public class GetTokensWithFilterTests
     public async Task Handle_PagingBackwardLastPage_ReturnCursor()
     {
         // Arrange
-        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false,
+        var cursor = new TokensCursor(null, Enumerable.Empty<Address>(), TokenAttributeFilter.All, false,
                                       TokenOrderByType.PriceUsd, SortDirectionType.ASC, 2, PagingDirection.Backward, ("10.12", 2));
 
         var tokens = new[]
         {
-            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
-            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", true, "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
+            new Token(1, "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10),
+            new Token(2, "Pefjjc9U4kqdrc4LPSqkCUMpPykkfL3XhY", "Ethereum", "ETH", 18, 1_000_000_000_000_000_000, 21_000_000_000_000_000, 9, 10)
         };
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokensWithFilterQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(tokens);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Quotes/CreateApproveAllowanceTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Quotes/CreateApproveAllowanceTransactionQuoteCommandHandlerTests.cs
@@ -127,7 +127,7 @@ public class CreateApproveAllowanceTransactionQuoteCommandHandlerTests
         var cancellationToken = new CancellationTokenSource().Token;
 
         _mediatorMock.Setup(callTo => callTo.Send(new RetrieveTokenByAddressQuery(token, true), cancellationToken))
-            .ReturnsAsync(new Token(1, token, false, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
+            .ReturnsAsync(new Token(1, token, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
 
         // Act
         try
@@ -156,7 +156,7 @@ public class CreateApproveAllowanceTransactionQuoteCommandHandlerTests
         var cancellationToken = new CancellationTokenSource().Token;
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(1, token, false, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
+            .ReturnsAsync(new Token(1, token, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveAddressAllowanceQuery>(), cancellationToken))
             .ReturnsAsync(new AddressAllowance(1, walletAddress, spender, UInt256.Zero, 1));
@@ -206,7 +206,7 @@ public class CreateApproveAllowanceTransactionQuoteCommandHandlerTests
         var expectedQuote = new TransactionQuote(null, null, 23800, null, expectedRequest);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(1, token, false, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
+            .ReturnsAsync(new Token(1, token, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveAddressAllowanceQuery>(), cancellationToken))
             .ReturnsAsync(new AddressAllowance(1, walletAddress, spender, UInt256.Zero, 1));

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Quotes/CreateDistributeTokensTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Quotes/CreateDistributeTokensTransactionQuoteCommandHandlerTests.cs
@@ -83,7 +83,7 @@ public class CreateDistributeTokensTransactionQuoteCommandHandlerTests
         var cancellationToken = new CancellationTokenSource().Token;
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(1, token, false, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
+            .ReturnsAsync(new Token(1, token, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
 
         // Act
         try
@@ -118,7 +118,7 @@ public class CreateDistributeTokensTransactionQuoteCommandHandlerTests
         var expectedQuote = new TransactionQuote(null, null, 23800, null, expectedRequest);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(1, token, false, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
+            .ReturnsAsync(new Token(1, token, "Bitcoin", "BTC", 8, 100_000_000, 0, 9, 10));
 
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<MakeTransactionQuoteCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedQuote);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Quotes/CreateSwapTransactionQuoteCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Quotes/CreateSwapTransactionQuoteCommandHandlerTests.cs
@@ -182,8 +182,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand();
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveTokenByAddressQuery>(p => p.Address == command.TokenIn), cancellationToken)).ReturnsAsync(tokenIn);
         _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveTokenByAddressQuery>(p => p.Address == command.TokenOut), cancellationToken)).ReturnsAsync(tokenOut);
@@ -207,8 +207,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand();
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         _mediatorMock.Setup(callTo => callTo.Send(It.Is<RetrieveTokenByAddressQuery>(p => p.Address == command.TokenIn), cancellationToken)).ReturnsAsync(tokenIn);
@@ -234,8 +234,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand();
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         var router = new MarketRouter(2, "Pz636HJgUK3jsy1XTenAyWcdTKU4jVFCDo", market.Id, true, 4, 5);
@@ -282,8 +282,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand(tokenInExactAmount: false);
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         var router = new MarketRouter(2, "Pz636HJgUK3jsy1XTenAyWcdTKU4jVFCDo", market.Id, true, 4, 5);
@@ -330,8 +330,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand(tokenIn: "CRS", tokenOut: "PoHJgWcdTKUz6UK3jsy1XTenAy364jVFCD");
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         var router = new MarketRouter(2, "Pz636HJgUK3jsy1XTenAyWcdTKU4jVFCDo", market.Id, true, 4, 5);
@@ -377,8 +377,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand(tokenIn: "CRS", tokenOut: "PoHJgWcdTKUz6UK3jsy1XTenAy364jVFCD", tokenInExactAmount: false);
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         var router = new MarketRouter(2, "Pz636HJgUK3jsy1XTenAyWcdTKU4jVFCDo", market.Id, true, 4, 5);
@@ -424,8 +424,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand(tokenIn: "PdTKUnAy36oHJgWc4jVFCDz6UK3jsy1XTe", tokenOut: "PoHJgWcdTKUz6UK3jsy1XTenAy364jVFCD");
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 100_000_000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 100_000_000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         var router = new MarketRouter(2, "Pz636HJgUK3jsy1XTenAyWcdTKU4jVFCDo", market.Id, true, 4, 5);
 
@@ -472,8 +472,8 @@ public class CreateSwapTransactionQuoteCommandHandlerTests
         var command = BuildCommand(tokenIn: "PdTKUnAy36oHJgWc4jVFCDz6UK3jsy1XTe", tokenOut: "PoHJgWcdTKUz6UK3jsy1XTenAy364jVFCD", tokenInExactAmount: false);
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var tokenIn = new Token(5, command.TokenIn, false, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
-        var tokenOut = new Token(5, command.TokenOut, false, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
+        var tokenIn = new Token(5, command.TokenIn, "Wrapped Bitcoin", "WBTC", 8, 2100000000000000, UInt256.Parse("21000000"), 5, 15);
+        var tokenOut = new Token(5, command.TokenOut, "Anything Else", "ANY", 18, 1_000_000_000_000_000_000, UInt256.Parse("210000000000000000"), 5, 15);
 
         var market = new Market(1, command.Market, 2, 3, Address.Empty, "Pz6364jVFCDoHJgUK3jsy1XTenAyWcdTKU", true, true, true, 3, true, 4, 5);
         var router = new MarketRouter(2, "Pz636HJgUK3jsy1XTenAyWcdTKU4jVFCDo", market.Id, true, 4, 5);

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Snapshots/CreateCrsTokenSnapshotsCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Snapshots/CreateCrsTokenSnapshotsCommandHandlerTests.cs
@@ -94,7 +94,6 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
 
         // Assert
         _mediator.Verify(callTo => callTo.Send(It.Is<MakeTokenCommand>(q => q.Token.Address == Address.Cirrus &&
-                                                                            q.Token.IsLpt == false &&
                                                                             q.Token.Symbol == TokenConstants.Cirrus.Symbol &&
                                                                             q.Token.Name == TokenConstants.Cirrus.Name &&
                                                                             q.Token.Decimals == TokenConstants.Cirrus.Decimals &&
@@ -124,7 +123,7 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
         // Arrange
         DateTime blockTime = DateTime.UtcNow;
         const ulong blockHeight = 10;
-        var token = new Token(1, Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+        var token = new Token(1, Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                               TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, blockHeight, blockHeight);
 
         _mediator.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), CancellationToken.None))
@@ -150,7 +149,7 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
         // Arrange
         DateTime blockTime = DateTime.UtcNow;
         const ulong blockHeight = 10;
-        var token = new Token(1, Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+        var token = new Token(1, Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                               TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, blockHeight, blockHeight);
         var latestSnapshot = new TokenSnapshot(1, 2, 3, new Ohlc<decimal>(), SnapshotType.Daily, DateTime.UtcNow, DateTime.UtcNow, DateTime.UtcNow);
 
@@ -175,7 +174,7 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
         DateTime blockTime = DateTime.UtcNow;
         DateTime latestSnapshotTime = blockTime.AddMinutes(-5);
         const ulong blockHeight = 10;
-        var token = new Token(1, Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+        var token = new Token(1, Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                               TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, blockHeight, blockHeight);
         var latestSnapshot = new TokenSnapshot(2, 3, SnapshotType.Daily, latestSnapshotTime);
 
@@ -203,7 +202,7 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
         DateTime blockTime = DateTime.UtcNow;
         DateTime latestSnapshotTime = blockTime.AddMinutes(-5);
         const ulong blockHeight = 10;
-        var token = new Token(1, Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+        var token = new Token(1, Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                               TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, blockHeight, blockHeight);
         var latestSnapshot = new TokenSnapshot(2, 3,SnapshotType.Daily, latestSnapshotTime);
 
@@ -228,7 +227,7 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
         DateTime blockTime = DateTime.UtcNow;
         DateTime latestSnapshotTime = blockTime.AddMinutes(-5);
         const ulong blockHeight = 10;
-        var token = new Token(1, Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+        var token = new Token(1, Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                               TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, blockHeight, blockHeight);
         var latestSnapshot = new TokenSnapshot(2, 3, SnapshotType.Minute, latestSnapshotTime);
         const decimal price = 1.1m;
@@ -269,7 +268,7 @@ public class CreateCrsTokenSnapshotsCommandHandlerTests
         DateTime blockTime = DateTime.UtcNow;
         DateTime latestSnapshotTime = blockTime.AddMinutes(-5);
         const ulong blockHeight = 10;
-        var token = new Token(1, Address.Cirrus, false, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
+        var token = new Token(1, Address.Cirrus, TokenConstants.Cirrus.Name, TokenConstants.Cirrus.Symbol, TokenConstants.Cirrus.Decimals,
                                  TokenConstants.Cirrus.Sats, TokenConstants.Cirrus.TotalSupply, blockHeight, blockHeight);
         var latestSnapshot = new TokenSnapshot(2, 3, SnapshotType.Daily, latestSnapshotTime);
         const decimal price = 1.1m;

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Snapshots/GetTokenSnapshotsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Tokens/Snapshots/GetTokenSnapshotsWithFilterQueryHandlerTests.cs
@@ -71,7 +71,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
 
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         // Act
@@ -95,7 +95,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 10, PagingDirection.Forward, default);
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -121,7 +121,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 3, PagingDirection.Forward, (DateTime.UtcNow, 10));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -148,7 +148,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 10));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -176,7 +176,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 10));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -204,7 +204,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, default);
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -232,7 +232,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 50));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -260,7 +260,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 50));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -288,7 +288,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Forward, (DateTime.UtcNow, 50));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]
@@ -315,7 +315,7 @@ public class GetTokenSnapshotsWithFilterQueryHandlerTests
         var cursor = new SnapshotCursor(Interval.OneHour, DateTime.UtcNow.AddDays(-5), DateTime.UtcNow, SortDirectionType.ASC, 2, PagingDirection.Backward, (DateTime.UtcNow, 50));
         var request = new GetTokenSnapshotsWithFilterQuery(tokenAddress, cursor);
 
-        var token = new Token(5, tokenAddress, false, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
+        var token = new Token(5, tokenAddress, "Governance", "GOV", 8, 100000000, UInt256.Parse("500000000000000000000"), 20, 25);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(token);
 
         var snapshots = new TokenSnapshot[]

--- a/test/Opdex.Platform.Application.Tests/Handlers/Addresses/Allowances/RetrieveAddressAllowanceQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Addresses/Allowances/RetrieveAddressAllowanceQueryHandlerTests.cs
@@ -103,7 +103,7 @@ public class RetrieveAddressAllowanceQueryHandlerTests
 
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var token = new Token(1, "PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", false, "Bitcoin", "wBTC", 8, 100_000_000, 100, 1, 1);
+        var token = new Token(1, "PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", "Bitcoin", "wBTC", 8, 100_000_000, 100, 1, 1);
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByAddressQuery>(), cancellationToken))
@@ -133,7 +133,7 @@ public class RetrieveAddressAllowanceQueryHandlerTests
 
         var cancellationToken = new CancellationTokenSource().Token;
 
-        var token = new Token(1, "PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", false, "Bitcoin", "wBTC", 8, 100_000_000, 100, 1, 1);
+        var token = new Token(1, "PHUzrtkLfffDZMd2v8QULRZvBCY5RwrrQK", "Bitcoin", "wBTC", 8, 100_000_000, 100, 1, 1);
 
         var allowance = new UInt256("10000");
 

--- a/test/Opdex.Platform.Application.Tests/Handlers/Addresses/Balances/RetrieveAddressBalanceByOwnerAndTokenQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Addresses/Balances/RetrieveAddressBalanceByOwnerAndTokenQueryHandlerTests.cs
@@ -133,7 +133,7 @@ public class RetrieveAddressBalanceByOwnerAndTokenQueryHandlerTests
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(tokenId, "PBSH3FTVne6gKiSgVBL4NRTJ31QmGShjMy", false, "name", "symbol", 8, 100_000_000, UInt256.Parse("100"), 1, 2));
+            .ReturnsAsync(new Token(tokenId, "PBSH3FTVne6gKiSgVBL4NRTJ31QmGShjMy", "name", "symbol", 8, 100_000_000, UInt256.Parse("100"), 1, 2));
 
         // Act
         await _handler.Handle(new RetrieveAddressBalanceByOwnerAndTokenQuery(address, tokenId, findOrThrow: findOrThrow), cancellationToken);
@@ -158,7 +158,7 @@ public class RetrieveAddressBalanceByOwnerAndTokenQueryHandlerTests
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(tokenId, "PBSH3FTVne6gKiSgVBL4NRTJ31QmGShjMy", false, "name", "symbol", 8, 100_000_000, UInt256.Parse("100"), 1, 2));
+            .ReturnsAsync(new Token(tokenId, "PBSH3FTVne6gKiSgVBL4NRTJ31QmGShjMy", "name", "symbol", 8, 100_000_000, UInt256.Parse("100"), 1, 2));
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<SelectAddressBalanceByOwnerAndTokenIdQuery>(), cancellationToken))
@@ -182,7 +182,7 @@ public class RetrieveAddressBalanceByOwnerAndTokenQueryHandlerTests
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(tokenId, Address.Cirrus, false, "name", "symbol", 8, 100_000_000, 100, 1, 2));
+            .ReturnsAsync(new Token(tokenId, Address.Cirrus, "name", "symbol", 8, 100_000_000, 100, 1, 2));
 
         // Act
         await _handler.Handle(new RetrieveAddressBalanceByOwnerAndTokenQuery(address, tokenId, findOrThrow: findOrThrow), cancellationToken);
@@ -207,7 +207,7 @@ public class RetrieveAddressBalanceByOwnerAndTokenQueryHandlerTests
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<RetrieveTokenByIdQuery>(), cancellationToken))
-            .ReturnsAsync(new Token(tokenId, Address.Cirrus, false, "name", "symbol", 8, 100_000_000, UInt256.Parse("100"), 1, 2));
+            .ReturnsAsync(new Token(tokenId, Address.Cirrus, "name", "symbol", 8, 100_000_000, UInt256.Parse("100"), 1, 2));
 
         _mediatorMock
             .Setup(callTo => callTo.Send(It.IsAny<CallCirrusGetAddressCrsBalanceQuery>(), cancellationToken))

--- a/test/Opdex.Platform.Application.Tests/Handlers/Routers/RetrieveSwapAmountInQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Routers/RetrieveSwapAmountInQueryHandlerTests.cs
@@ -36,8 +36,8 @@ public class RetrieveSwapAmountInQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountInQuery(router, tokenIn, tokenOut, 500000);
         var cancellationToken = new CancellationTokenSource().Token;
@@ -57,8 +57,8 @@ public class RetrieveSwapAmountInQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountInQuery(router, tokenIn, tokenOut, 500000);
         var cancellationToken = new CancellationTokenSource().Token;
@@ -77,8 +77,8 @@ public class RetrieveSwapAmountInQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), false, "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountInQuery(router, tokenIn, tokenOut, 500000);
         var cancellationToken = new CancellationTokenSource().Token;
@@ -98,8 +98,8 @@ public class RetrieveSwapAmountInQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), false, "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountInQuery(router, tokenIn, tokenOut, 500000);
         var cancellationToken = new CancellationTokenSource().Token;

--- a/test/Opdex.Platform.Application.Tests/Handlers/Routers/RetrieveSwapAmountOutQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Routers/RetrieveSwapAmountOutQueryHandlerTests.cs
@@ -36,8 +36,8 @@ public class RetrieveSwapAmountOutQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountOutQuery(router, tokenIn, 500000, tokenOut);
         var cancellationToken = new CancellationTokenSource().Token;
@@ -57,8 +57,8 @@ public class RetrieveSwapAmountOutQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, Address.Cirrus, false, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, Address.Cirrus, "Cirrus", "CRS", 8, 1000000000, 21000000000000000, 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountOutQuery(router, tokenIn, 500000, tokenOut);
         var cancellationToken = new CancellationTokenSource().Token;
@@ -77,8 +77,8 @@ public class RetrieveSwapAmountOutQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), false, "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountOutQuery(router, tokenIn, 500000, tokenOut);
         var cancellationToken = new CancellationTokenSource().Token;
@@ -98,8 +98,8 @@ public class RetrieveSwapAmountOutQueryHandlerTests
         SetupPools();
 
         var router = new MarketRouter(5, new Address("PEkFDLUw1aLjYCWoJ1jRehNfTXjgWuZsX3"), 5, true, 2, 200);
-        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), false, "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
-        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), false, "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
+        var tokenIn = new Token(5, new Address("PSxx8BBVDpB5qHKmm7RGLDVaEL8p9NWbZW"), "Britcoin", "XGBP", 18, 1000000000000000000, UInt256.Parse("1000000000000000000000000000000000000"), 10, 10);
+        var tokenOut = new Token(10, new Address("PBcSmxbEwFHegzPirfirViDjAedV8S2aVi"), "Salami", "LAMI", 8, 1000000000, 21000000000000000, 50, 50);
 
         var request = new RetrieveSwapAmountOutQuery(router, tokenIn, 500000, tokenOut);
         var cancellationToken = new CancellationTokenSource().Token;

--- a/test/Opdex.Platform.Application.Tests/Handlers/Tokens/MakeTokenCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Handlers/Tokens/MakeTokenCommandHandlerTests.cs
@@ -41,7 +41,7 @@ public class MakeTokenCommandHandlerTests
     public void MakeTokenCommand_InvalidBlockHeight_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
+        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         const ulong blockHeight = 0;
 
         // Act
@@ -55,7 +55,7 @@ public class MakeTokenCommandHandlerTests
     public async Task MakeTokenCommand_Sends_CallCirrusGetStandardTokenContractSummaryQuery()
     {
         // Arrange
-        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
+        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         const ulong blockHeight = 10;
 
         // Act
@@ -77,7 +77,7 @@ public class MakeTokenCommandHandlerTests
     public async Task MakeTokenCommand_Skips_CallCirrusGetStandardTokenContractSummaryQuery()
     {
         // Arrange
-        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
+        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         const ulong blockHeight = 10;
 
         // Act
@@ -95,7 +95,7 @@ public class MakeTokenCommandHandlerTests
     public async Task MakeTokenCommand_Sends_PersistTokenCommand()
     {
         // Arrange
-        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", true, "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
+        var token = new Token(1, "PNG9Xh2WU8q87nq2KGFTtoSPBDE7FiEUa8", "Bitcoin", "BTC", 8, 100_000_000, 2_100_000_000_000_000, 9, 10);
         const ulong blockHeight = 10;
 
         UInt256 updatedTotalSupply = 5000000;

--- a/test/Opdex.Platform.Domain.Tests/Models/Tokens/TokenTests.cs
+++ b/test/Opdex.Platform.Domain.Tests/Models/Tokens/TokenTests.cs
@@ -14,14 +14,13 @@ public class TokenTests
     {
         Address address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u";
         const string name = "Opdex Token";
-        const bool isLpt = true;
         const string symbol = "OPDX";
         const int decimals = 18;
         const ulong sats = 10000000000000000;
         UInt256 totalSupply = 987654321;
         const ulong createdBlock = 3;
 
-        var token = new Token(address, isLpt, name, symbol, decimals, sats, totalSupply, createdBlock);
+        var token = new Token(address, name, symbol, decimals, sats, totalSupply, createdBlock);
 
         token.Id.Should().Be(0);
         token.Address.Should().Be(address);
@@ -37,7 +36,7 @@ public class TokenTests
     {
         // Arrange
         // Act
-        static void Act() => new Token(Address.Empty, true, "name", "symbol", 8, 100_000_000, 100, 2);
+        static void Act() => new Token(Address.Empty, "name", "symbol", 8, 100_000_000, 100, 2);
 
         // Assert
         Assert.Throws<ArgumentNullException>(Act).Message.Should().Contain("Token address must be set.");
@@ -48,7 +47,7 @@ public class TokenTests
     {
         // Arrange
         // Act
-        static void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", true, "", "symbol", 8, 100_000_000, 100, 2);
+        static void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", "", "symbol", 8, 100_000_000, 100, 2);
 
         // Assert
         Assert.Throws<ArgumentNullException>(Act).Message.Should().Contain("Token name must be set.");
@@ -59,7 +58,7 @@ public class TokenTests
     {
         // Arrange
         // Act
-        static void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", true, "name", "", 8, 100_000_000, 100, 2);
+        static void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", "name", "", 8, 100_000_000, 100, 2);
 
         // Assert
         Assert.Throws<ArgumentNullException>(Act).Message.Should().Contain("Token symbol must be set.");
@@ -72,7 +71,7 @@ public class TokenTests
     {
         // Arrange
         // Act
-        void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", true, "name", "symbol", decimals, 100_000_000, 100, 2);
+        void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", "name", "symbol", decimals, 100_000_000, 100, 2);
 
         // Assert
         Assert.Throws<ArgumentOutOfRangeException>(Act).Message.Should().Contain("Token must have between 0 and 18 decimal denominations.");
@@ -83,7 +82,7 @@ public class TokenTests
     {
         // Arrange
         // Act
-        void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", true, "name", "symbol", 8, 0, 100, 2);
+        void Act() => new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", "name", "symbol", 8, 0, 100, 2);
 
         // Assert
         Assert.Throws<ArgumentOutOfRangeException>(Act).Message.Should().Contain("Sats must be greater than zero.");
@@ -95,7 +94,6 @@ public class TokenTests
         const ulong id = 1;
         Address address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u";
         const string name = "Opdex Token";
-        const bool isLpt = true;
         const string symbol = "OPDX";
         const int decimals = 18;
         const ulong sats = 10000000000000000;
@@ -104,7 +102,7 @@ public class TokenTests
         const ulong modifiedBlock = 4;
         TokenSummary summary = new TokenSummary(5, 10, 50);
 
-        var token = new Token(id, address, isLpt, name, symbol, decimals, sats, totalSupply, createdBlock, modifiedBlock);
+        var token = new Token(id, address, name, symbol, decimals, sats, totalSupply, createdBlock, modifiedBlock);
 
         token.Id.Should().Be(id);
         token.Address.Should().Be(address);
@@ -123,7 +121,7 @@ public class TokenTests
         UInt256 totalSupply = 200;
         const ulong updateBlock = 10;
 
-        var token = new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", true, "name", "symbol", 8, 100_000_000, 100, 2);
+        var token = new Token("PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u", "name", "symbol", 8, 100_000_000, 100, 2);
 
         token.UpdateTotalSupply(totalSupply, updateBlock);
 

--- a/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Addresses/AddressBalancesCursorTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Addresses/AddressBalancesCursorTests.cs
@@ -17,7 +17,7 @@ public class AddressBalancesCursorTests
     {
         // Arrange
         // Act
-        static void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, SortDirectionType.ASC, 50 + 1, PagingDirection.Forward, 0);
+        static void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, SortDirectionType.ASC, 50 + 1, PagingDirection.Forward, 0);
 
         // Assert
         Assert.Throws<ArgumentOutOfRangeException>("limit", Act);
@@ -29,7 +29,7 @@ public class AddressBalancesCursorTests
     {
         // Arrange
         // Act
-        void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), TokenProvisionalFilter.All, false, SortDirectionType.ASC, 25, pagingDirection, pointer);
+        void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, SortDirectionType.ASC, 25, pagingDirection, pointer);
 
         // Assert
         Assert.Throws<ArgumentException>("pointer", Act);
@@ -40,7 +40,7 @@ public class AddressBalancesCursorTests
     {
         // Arrange
         // Act
-        var cursor = new AddressBalancesCursor(null, TokenProvisionalFilter.All, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+        var cursor = new AddressBalancesCursor(null, TokenAttributeFilter.All, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
 
         // Assert
         cursor.Tokens.Should().BeEmpty();
@@ -50,7 +50,7 @@ public class AddressBalancesCursorTests
     public void ToString_StringifiesCursor_FormatCorrectly()
     {
         // Arrange
-        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "P8bB9yPr3vVByqfmM5KXftyGckAtAdu6f8" }, TokenProvisionalFilter.Provisional, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "P8bB9yPr3vVByqfmM5KXftyGckAtAdu6f8" }, TokenAttributeFilter.Provisional, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
 
         // Act
         var result = cursor.ToString();
@@ -70,7 +70,7 @@ public class AddressBalancesCursorTests
     public void Turn_NonIdenticalPointer_ReturnAnotherCursor()
     {
         // Arrange
-        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" }, TokenProvisionalFilter.Provisional, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" }, TokenAttributeFilter.Provisional, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
 
         // Act
         var result = cursor.Turn(PagingDirection.Backward, 567);
@@ -127,7 +127,7 @@ public class AddressBalancesCursorTests
         // Assert
         canParse.Should().Be(true);
         cursor.Tokens.Should().ContainSingle(token => token == "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L");
-        cursor.TokenType.Should().Be(TokenProvisionalFilter.NonProvisional);
+        cursor.TokenType.Should().Be(TokenAttributeFilter.NonProvisional);
         cursor.IncludeZeroBalances.Should().Be(false);
         cursor.SortDirection.Should().Be(SortDirectionType.ASC);
         cursor.Limit.Should().Be(50);

--- a/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Addresses/AddressBalancesCursorTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Addresses/AddressBalancesCursorTests.cs
@@ -17,7 +17,7 @@ public class AddressBalancesCursorTests
     {
         // Arrange
         // Act
-        static void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, SortDirectionType.ASC, 50 + 1, PagingDirection.Forward, 0);
+        static void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, SortDirectionType.ASC, 50 + 1, PagingDirection.Forward, 0);
 
         // Assert
         Assert.Throws<ArgumentOutOfRangeException>("limit", Act);
@@ -29,7 +29,7 @@ public class AddressBalancesCursorTests
     {
         // Arrange
         // Act
-        void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), TokenAttributeFilter.All, false, SortDirectionType.ASC, 25, pagingDirection, pointer);
+        void Act() => new AddressBalancesCursor(Enumerable.Empty<Address>(), Enumerable.Empty<TokenAttributeFilter>(), false, SortDirectionType.ASC, 25, pagingDirection, pointer);
 
         // Assert
         Assert.Throws<ArgumentException>("pointer", Act);
@@ -40,17 +40,30 @@ public class AddressBalancesCursorTests
     {
         // Arrange
         // Act
-        var cursor = new AddressBalancesCursor(null, TokenAttributeFilter.All, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+        var cursor = new AddressBalancesCursor(null, Enumerable.Empty<TokenAttributeFilter>(), false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
 
         // Assert
         cursor.Tokens.Should().BeEmpty();
     }
 
     [Fact]
+    public void Create_NullTokenAttributesProvided_SetToEmpty()
+    {
+        // Arrange
+        // Act
+        var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), null, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+
+        // Assert
+        cursor.TokenAttributes.Should().BeEmpty();
+    }
+
+    [Fact]
     public void ToString_StringifiesCursor_FormatCorrectly()
     {
         // Arrange
-        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "P8bB9yPr3vVByqfmM5KXftyGckAtAdu6f8" }, TokenAttributeFilter.Provisional, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+        var addresses = new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L", "P8bB9yPr3vVByqfmM5KXftyGckAtAdu6f8" };
+        var attributes = new[] { TokenAttributeFilter.Provisional, TokenAttributeFilter.Staking };
+        var cursor = new AddressBalancesCursor(addresses, attributes, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
 
         // Act
         var result = cursor.ToString();
@@ -58,7 +71,8 @@ public class AddressBalancesCursorTests
         // Assert
         result.Should().Contain("tokens:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;");
         result.Should().Contain("tokens:P8bB9yPr3vVByqfmM5KXftyGckAtAdu6f8;");
-        result.Should().Contain("tokenType:Provisional;");
+        result.Should().Contain("tokenAttributes:Provisional;");
+        result.Should().Contain("tokenAttributes:Staking;");
         result.Should().Contain("includeZeroBalances:False;");
         result.Should().Contain("direction:ASC;");
         result.Should().Contain("limit:25;");
@@ -70,7 +84,7 @@ public class AddressBalancesCursorTests
     public void Turn_NonIdenticalPointer_ReturnAnotherCursor()
     {
         // Arrange
-        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" }, TokenAttributeFilter.Provisional, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
+        var cursor = new AddressBalancesCursor(new Address[] { "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L" }, new [] {TokenAttributeFilter.Provisional}, false, SortDirectionType.ASC, 25, PagingDirection.Forward, 500);
 
         // Act
         var result = cursor.Turn(PagingDirection.Backward, 567);
@@ -79,7 +93,7 @@ public class AddressBalancesCursorTests
         result.Should().BeOfType<AddressBalancesCursor>();
         var adjacentCursor = (AddressBalancesCursor)result;
         adjacentCursor.Tokens.Should().BeEquivalentTo(cursor.Tokens);
-        adjacentCursor.TokenType.Should().Be(cursor.TokenType);
+        adjacentCursor.TokenAttributes.Should().BeEquivalentTo(cursor.TokenAttributes);
         adjacentCursor.IncludeZeroBalances.Should().Be(cursor.IncludeZeroBalances);
         adjacentCursor.SortDirection.Should().Be(cursor.SortDirection);
         adjacentCursor.Limit.Should().Be(cursor.Limit);
@@ -90,20 +104,18 @@ public class AddressBalancesCursorTests
     [Theory]
     [ClassData(typeof(NullOrWhitespaceStringData))]
     [InlineData(";:;;;;;::;;;:::;;;:::;;:::;;")]
-    [InlineData("tokenType:Unknown;includeZeroBalances:True;direction:ASC;limit:50;paging:Forward;pointer:NTAw;")] // invalid tokenType
-    [InlineData("includeZeroBalances:True;direction:ASC;limit:50;paging:Forward;pointer:NTAw;")] // missing tokenType
-    [InlineData("tokenType:All;includeZeroBalances:Maybe;direction:ASC;limit:50;paging:Forward;pointer:NTAw;")] // invalid includeZeroBalances
-    [InlineData("tokenType:All;direction:ASC;limit:50;paging:Forward;pointer:NTAw;")] // missing includeZeroBalances
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:Invalid;limit:50;paging:Forward;pointer:NTAw;")] // invalid orderBy
-    [InlineData("tokenType:All;includeZeroBalances:False;limit:50;paging:Forward;pointer:NTAw;")] // missing orderBy
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:51;paging:Forward;pointer:NTAw;")] // over max limit
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;paging:Forward;pointer:NTAw;")] // missing limit
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:50;paging:Invalid;pointer:NTAw;")] // invalid paging direction
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:50;pointer:NTAw;")] // missing paging direction
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:LTE=;")] // pointer: -1;
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:YWJj")] // pointer: abc;
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:10")] // pointer not valid base64
-    [InlineData("tokenType:All;includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;")] // pointer missing
+    [InlineData("includeZeroBalances:Maybe;direction:ASC;limit:50;paging:Forward;pointer:NTAw;")] // invalid includeZeroBalances
+    [InlineData("direction:ASC;limit:50;paging:Forward;pointer:NTAw;")] // missing includeZeroBalances
+    [InlineData("includeZeroBalances:False;direction:Invalid;limit:50;paging:Forward;pointer:NTAw;")] // invalid orderBy
+    [InlineData("includeZeroBalances:False;limit:50;paging:Forward;pointer:NTAw;")] // missing orderBy
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:51;paging:Forward;pointer:NTAw;")] // over max limit
+    [InlineData("includeZeroBalances:False;direction:ASC;paging:Forward;pointer:NTAw;")] // missing limit
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:50;paging:Invalid;pointer:NTAw;")] // invalid paging direction
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:50;pointer:NTAw;")] // missing paging direction
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:LTE=;")] // pointer: -1;
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:YWJj")] // pointer: abc;
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:10")] // pointer not valid base64
+    [InlineData("includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;")] // pointer missing
     public void TryParse_InvalidCursor_ReturnFalse(string stringified)
     {
         // Arrange
@@ -119,7 +131,7 @@ public class AddressBalancesCursorTests
     public void TryParse_ValidCursor_ReturnTrue()
     {
         // Arrange
-        var stringified = "tokens:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;tokenType:NonProvisional;includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:MTA=;"; // pointer: 10;
+        var stringified = "tokens:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;tokenAttributes:NonProvisional;includeZeroBalances:False;direction:ASC;limit:50;paging:Forward;pointer:MTA=;"; // pointer: 10;
 
         // Act
         var canParse = AddressBalancesCursor.TryParse(stringified, out var cursor);
@@ -127,7 +139,7 @@ public class AddressBalancesCursorTests
         // Assert
         canParse.Should().Be(true);
         cursor.Tokens.Should().ContainSingle(token => token == "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L");
-        cursor.TokenType.Should().Be(TokenAttributeFilter.NonProvisional);
+        cursor.TokenAttributes.Should().BeEquivalentTo(new [] {TokenAttributeFilter.NonProvisional});
         cursor.IncludeZeroBalances.Should().Be(false);
         cursor.SortDirection.Should().Be(SortDirectionType.ASC);
         cursor.Limit.Should().Be(50);

--- a/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Tokens/TokensCursorTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Tokens/TokensCursorTests.cs
@@ -18,7 +18,7 @@ public class TokensCursorTests
         // Act
         static void Act() => new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                               Enumerable.Empty<Address>(),
-                                              TokenProvisionalFilter.Provisional,
+                                              TokenAttributeFilter.Provisional,
                                               false,
                                               TokenOrderByType.PriceUsd,
                                               SortDirectionType.ASC,
@@ -38,7 +38,7 @@ public class TokensCursorTests
         // Act
         void Act() => new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                        Enumerable.Empty<Address>(),
-                                       TokenProvisionalFilter.NonProvisional,
+                                       TokenAttributeFilter.NonProvisional,
                                        false,
                                        TokenOrderByType.PriceUsd,
                                        SortDirectionType.ASC,
@@ -57,7 +57,7 @@ public class TokensCursorTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       null,
-                                      TokenProvisionalFilter.Provisional,
+                                      TokenAttributeFilter.Provisional,
                                       false,
                                       TokenOrderByType.PriceUsd,
                                       SortDirectionType.ASC,
@@ -75,7 +75,7 @@ public class TokensCursorTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenProvisionalFilter.Provisional,
+                                      TokenAttributeFilter.Provisional,
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -104,7 +104,7 @@ public class TokensCursorTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenProvisionalFilter.NonProvisional,
+                                      TokenAttributeFilter.NonProvisional,
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -119,7 +119,7 @@ public class TokensCursorTests
         result.Should().BeOfType<TokensCursor>();
         var adjacentCursor = (TokensCursor)result;
         adjacentCursor.Keyword.Should().Be(cursor.Keyword);
-        adjacentCursor.ProvisionalFilter.Should().Be(cursor.ProvisionalFilter);
+        adjacentCursor.AttributeFilter.Should().Be(cursor.AttributeFilter);
         adjacentCursor.Tokens.Should().BeEquivalentTo(cursor.Tokens);
         adjacentCursor.OrderBy.Should().Be(cursor.OrderBy);
         adjacentCursor.SortDirection.Should().Be(cursor.SortDirection);
@@ -166,7 +166,7 @@ public class TokensCursorTests
         cursor.Keyword.Should().Be("PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5");
         cursor.OrderBy.Should().Be(TokenOrderByType.PriceUsd);
         cursor.IncludeZeroLiquidity.Should().Be(true);
-        cursor.ProvisionalFilter.Should().Be(TokenProvisionalFilter.NonProvisional);
+        cursor.AttributeFilter.Should().Be(TokenAttributeFilter.NonProvisional);
         cursor.Tokens.Should().ContainSingle(t => t == "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L");
         cursor.SortDirection.Should().Be(SortDirectionType.ASC);
         cursor.Limit.Should().Be(50);

--- a/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Tokens/TokensCursorTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Abstractions.Tests/Data/Queries/Tokens/TokensCursorTests.cs
@@ -18,7 +18,7 @@ public class TokensCursorTests
         // Act
         static void Act() => new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                               Enumerable.Empty<Address>(),
-                                              TokenAttributeFilter.Provisional,
+                                              Enumerable.Empty<TokenAttributeFilter>(),
                                               false,
                                               TokenOrderByType.PriceUsd,
                                               SortDirectionType.ASC,
@@ -38,7 +38,7 @@ public class TokensCursorTests
         // Act
         void Act() => new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                        Enumerable.Empty<Address>(),
-                                       TokenAttributeFilter.NonProvisional,
+                                       Enumerable.Empty<TokenAttributeFilter>(),
                                        false,
                                        TokenOrderByType.PriceUsd,
                                        SortDirectionType.ASC,
@@ -57,7 +57,7 @@ public class TokensCursorTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       null,
-                                      TokenAttributeFilter.Provisional,
+                                      Enumerable.Empty<TokenAttributeFilter>(),
                                       false,
                                       TokenOrderByType.PriceUsd,
                                       SortDirectionType.ASC,
@@ -75,7 +75,7 @@ public class TokensCursorTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenAttributeFilter.Provisional,
+                                      new [] {TokenAttributeFilter.Provisional},
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -88,7 +88,7 @@ public class TokensCursorTests
 
         // Assert
         result.Should().Contain("keyword:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;");
-        result.Should().Contain("provisional:Provisional;");
+        result.Should().Contain("tokenAttributes:Provisional;");
         result.Should().Contain("tokens:PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5;");
         result.Should().Contain("tokens:PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u;");
         result.Should().Contain("orderBy:DailyPriceChangePercent;");
@@ -104,7 +104,7 @@ public class TokensCursorTests
         // Arrange
         var cursor = new TokensCursor("PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L",
                                       new Address[] { "PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5", "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u" },
-                                      TokenAttributeFilter.NonProvisional,
+                                      new [] {TokenAttributeFilter.NonProvisional},
                                       false,
                                       TokenOrderByType.DailyPriceChangePercent,
                                       SortDirectionType.ASC,
@@ -119,7 +119,7 @@ public class TokensCursorTests
         result.Should().BeOfType<TokensCursor>();
         var adjacentCursor = (TokensCursor)result;
         adjacentCursor.Keyword.Should().Be(cursor.Keyword);
-        adjacentCursor.AttributeFilter.Should().Be(cursor.AttributeFilter);
+        adjacentCursor.TokenAttributes.Should().BeEquivalentTo(new [] {TokenAttributeFilter.NonProvisional});
         adjacentCursor.Tokens.Should().BeEquivalentTo(cursor.Tokens);
         adjacentCursor.OrderBy.Should().Be(cursor.OrderBy);
         adjacentCursor.SortDirection.Should().Be(cursor.SortDirection);
@@ -156,7 +156,7 @@ public class TokensCursorTests
     public void TryParse_ValidCursor_ReturnTrue()
     {
         // Arrange
-        var stringified = "keyword:PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5;includeZeroLiquidity:true;orderBy:PriceUsd;provisional:NonProvisional;tokens:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;direction:ASC;limit:50;paging:Forward;pointer:KDUwLjAwLCAxMCk=;"; // pointer: 10;
+        var stringified = "keyword:PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5;includeZeroLiquidity:true;orderBy:PriceUsd;tokenAttributes:NonProvisional;tokens:PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L;direction:ASC;limit:50;paging:Forward;pointer:KDUwLjAwLCAxMCk=;"; // pointer: 10;
 
         // Act
         var canParse = TokensCursor.TryParse(stringified, out var cursor);
@@ -166,7 +166,7 @@ public class TokensCursorTests
         cursor.Keyword.Should().Be("PAmvCGQNeVVDMbgUkXKprGLzzUCPT9Wqu5");
         cursor.OrderBy.Should().Be(TokenOrderByType.PriceUsd);
         cursor.IncludeZeroLiquidity.Should().Be(true);
-        cursor.AttributeFilter.Should().Be(TokenAttributeFilter.NonProvisional);
+        cursor.TokenAttributes.Should().BeEquivalentTo(new [] {TokenAttributeFilter.NonProvisional});
         cursor.Tokens.Should().ContainSingle(t => t == "PSqkCUMpPykkfL3XhYPefjjc9U4kqdrc4L");
         cursor.SortDirection.Should().Be(SortDirectionType.ASC);
         cursor.Limit.Should().Be(50);

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
@@ -72,12 +72,12 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
     }
 
     [Fact]
-    public async Task SelectAddressBalancesWithFilter_OnlyProvisionalTokens()
+    public async Task SelectAddressBalancesWithFilter_FilterTokenAttributes()
     {
         // Arrange
         const SortDirectionType direction = SortDirectionType.ASC;
         Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
-        const TokenProvisionalFilter tokenType = TokenProvisionalFilter.Provisional;
+        const TokenAttributeFilter tokenType = TokenAttributeFilter.Provisional;
         const uint limit = 10;
 
         var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
@@ -91,30 +91,8 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
         _dbContext.Verify(callTo =>
                               callTo.ExecuteQueryAsync<AddressBalanceEntity>(
                                   It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
-                                                            q.Sql.Contains("t.IsLpt = true"))), Times.Once);
-    }
-
-    [Fact]
-    public async Task SelectAddressBalancesWithFilter_OnlyNonProvisionalTokens()
-    {
-        // Arrange
-        const SortDirectionType direction = SortDirectionType.ASC;
-        Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
-        const TokenProvisionalFilter tokenType = TokenProvisionalFilter.NonProvisional;
-        const uint limit = 10;
-
-        var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
-
-        var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
-
-        // Act
-        await _handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        _dbContext.Verify(callTo =>
-                              callTo.ExecuteQueryAsync<AddressBalanceEntity>(
-                                  It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
-                                                            q.Sql.Contains("t.IsLpt = false"))), Times.Once);
+                                                            q.Sql.Contains("LEFT JOIN token_attribute ta ON ta.TokenId = t.Id") &&
+                                                            q.Sql.Contains("AND ta.AttributeTypeId = @AttributeType"))), Times.Once);
     }
 
     [Fact]
@@ -123,7 +101,7 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
         // Arrange
         const SortDirectionType direction = SortDirectionType.ASC;
         Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
-        const TokenProvisionalFilter tokenType = TokenProvisionalFilter.All;
+        const TokenAttributeFilter tokenType = TokenAttributeFilter.All;
         const uint limit = 10;
 
         var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Addresses/Balances/SelectAddressBalancesWithFilterQueryHandlerTests.cs
@@ -8,6 +8,7 @@ using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Balances;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using Opdex.Platform.Infrastructure.Data.Handlers.Addresses.Balances;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -77,10 +78,10 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
         // Arrange
         const SortDirectionType direction = SortDirectionType.ASC;
         Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
-        const TokenAttributeFilter tokenType = TokenAttributeFilter.Provisional;
+        var tokenAttributes = new [] {TokenAttributeFilter.Provisional};
         const uint limit = 10;
 
-        var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
+        var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenAttributes, false, direction, limit, PagingDirection.Backward, 50);
 
         var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -92,7 +93,7 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
                               callTo.ExecuteQueryAsync<AddressBalanceEntity>(
                                   It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
                                                             q.Sql.Contains("LEFT JOIN token_attribute ta ON ta.TokenId = t.Id") &&
-                                                            q.Sql.Contains("AND ta.AttributeTypeId = @AttributeType"))), Times.Once);
+                                                            q.Sql.Contains("AND ta.AttributeTypeId IN @TokenAttributes"))), Times.Once);
     }
 
     [Fact]
@@ -101,10 +102,10 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
         // Arrange
         const SortDirectionType direction = SortDirectionType.ASC;
         Address wallet = "PBJPuCXfcNKdN28FQf5uJYUcmAsqAEgUXj";
-        const TokenAttributeFilter tokenType = TokenAttributeFilter.All;
+        var tokenAttributes = Array.Empty<TokenAttributeFilter>();
         const uint limit = 10;
 
-        var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenType, false, direction, limit, PagingDirection.Backward, 50);
+        var cursor = new AddressBalancesCursor(Enumerable.Empty<Address>(), tokenAttributes, false, direction, limit, PagingDirection.Backward, 50);
 
         var command = new SelectAddressBalancesWithFilterQuery(wallet, cursor);
 
@@ -114,8 +115,8 @@ public class SelectAddressBalancesWithFilterQueryHandlerTests
         // Assert
         _dbContext.Verify(callTo =>
                               callTo.ExecuteQueryAsync<AddressBalanceEntity>(
-                                  It.Is<DatabaseQuery>(q => !q.Sql.Contains("JOIN token t") &&
-                                                            !q.Sql.Contains("t.IsLpt = @IsLpt"))), Times.Once);
+                                  It.Is<DatabaseQuery>(q => q.Sql.Contains("JOIN token t") &&
+                                                            !q.Sql.Contains("LEFT JOIN token_attribute"))), Times.Once);
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Tokens/PersistTokenCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Tokens/PersistTokenCommandHandlerTests.cs
@@ -29,7 +29,7 @@ public class PersistTokenCommandHandlerTests
     [Fact]
     public async Task PersistsToken_Success()
     {
-        var token = new Token("PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", true, "TokenName", "TKN", 8, 100_000_000, 500000000, 1);
+        var token = new Token("PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", "TokenName", "TKN", 8, 100_000_000, 500000000, 1);
         var command = new PersistTokenCommand(token);
 
         _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))
@@ -43,7 +43,7 @@ public class PersistTokenCommandHandlerTests
     [Fact]
     public async Task PersistsToken_Fail()
     {
-        var token = new Token("PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", true, "TokenName", "TKN", 8, 100_000_000, 500000000, 1);
+        var token = new Token("PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM", "TokenName", "TKN", 8, 100_000_000, 500000000, 1);
         var command = new PersistTokenCommand(token);
 
         _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Tokens/SelectTokenByAddressQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Tokens/SelectTokenByAddressQueryHandlerTests.cs
@@ -36,7 +36,6 @@ public class SelectTokenByAddressQueryHandlerTests
         {
             Id = 123454,
             Address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u",
-            IsLpt = true,
             Name = "SomeName",
             Symbol = "SomeSymbol",
             Sats = 987689076,
@@ -55,7 +54,6 @@ public class SelectTokenByAddressQueryHandlerTests
 
         result.Id.Should().Be(expectedEntity.Id);
         result.Address.Should().Be(expectedEntity.Address);
-        result.IsLpt.Should().Be(expectedEntity.IsLpt);
         result.Name.Should().Be(expectedEntity.Name);
         result.Symbol.Should().Be(expectedEntity.Symbol);
         result.Sats.Should().Be(expectedEntity.Sats);

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Tokens/SelectTokenByIdQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Tokens/SelectTokenByIdQueryHandlerTests.cs
@@ -35,7 +35,6 @@ public class SelectTokenByIdQueryHandlerTests
         {
             Id = id,
             Address = "PGZPZpB4iW4LHVEPMKehXfJ6u1yzNPDw7u",
-            IsLpt = true,
             Name = "SomeName",
             Symbol = "SomeSymbol",
             Sats = 987689076,
@@ -54,7 +53,6 @@ public class SelectTokenByIdQueryHandlerTests
 
         result.Id.Should().Be(expectedEntity.Id);
         result.Address.Should().Be(expectedEntity.Address);
-        result.IsLpt.Should().Be(expectedEntity.IsLpt);
         result.Name.Should().Be(expectedEntity.Name);
         result.Symbol.Should().Be(expectedEntity.Symbol);
         result.Sats.Should().Be(expectedEntity.Sats);

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using Opdex.Platform.WebApi.Models.Requests.Wallets;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Opdex.Platform.WebApi.Tests.Models.Requests.Wallets;
@@ -19,7 +20,7 @@ public class AddressBalanceFilterParametersTests
 
         // Assert
         filters.Tokens.Should().BeEmpty();
-        filters.TokenType.Should().Be(TokenAttributeFilter.All);
+        filters.TokenAttributes.Should().BeEmpty();
         filters.IncludeZeroBalances.Should().Be(false);
         filters.Direction.Should().Be(default(SortDirectionType));
         filters.Limit.Should().Be(default);
@@ -32,7 +33,11 @@ public class AddressBalanceFilterParametersTests
         var filters = new AddressBalanceFilterParameters
         {
             Tokens = new Address[] { new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm") },
-            TokenType = TokenAttributeFilter.Provisional,
+            TokenAttributes = new List<TokenAttributeFilter>
+            {
+                TokenAttributeFilter.Provisional,
+                TokenAttributeFilter.Staking
+            },
             IncludeZeroBalances = true,
             Limit = 20,
             Direction = SortDirectionType.DESC
@@ -43,7 +48,7 @@ public class AddressBalanceFilterParametersTests
 
         // Assert
         cursor.Tokens.Should().BeEquivalentTo(filters.Tokens);
-        cursor.TokenType.Should().Be(filters.TokenType);
+        cursor.TokenAttributes.Should().BeEquivalentTo(filters.TokenAttributes);
         cursor.IncludeZeroBalances.Should().Be(filters.IncludeZeroBalances);
         cursor.SortDirection.Should().Be(filters.Direction);
         cursor.Limit.Should().Be(filters.Limit);

--- a/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Models/Requests/Wallets/AddressBalanceFilterParametersTests.cs
@@ -19,7 +19,7 @@ public class AddressBalanceFilterParametersTests
 
         // Assert
         filters.Tokens.Should().BeEmpty();
-        filters.TokenType.Should().Be(TokenProvisionalFilter.All);
+        filters.TokenType.Should().Be(TokenAttributeFilter.All);
         filters.IncludeZeroBalances.Should().Be(false);
         filters.Direction.Should().Be(default(SortDirectionType));
         filters.Limit.Should().Be(default);
@@ -32,7 +32,7 @@ public class AddressBalanceFilterParametersTests
         var filters = new AddressBalanceFilterParameters
         {
             Tokens = new Address[] { new Address("tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm") },
-            TokenType = TokenProvisionalFilter.Provisional,
+            TokenType = TokenAttributeFilter.Provisional,
             IncludeZeroBalances = true,
             Limit = 20,
             Direction = SortDirectionType.DESC

--- a/test/Opdex.Platform.WebApi.Tests/Validation/LiquidityPools/LiquidityPoolFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/LiquidityPools/LiquidityPoolFilterParametersValidatorTests.cs
@@ -202,7 +202,7 @@ public class LiquidityPoolFilterParametersValidatorTests
 
     [Theory]
     [InlineData((LiquidityPoolStakingStatusFilter)1000)]
-    public void ProvisionalFilter_StakingFilter_Invalid(LiquidityPoolStakingStatusFilter filter)
+    public void AttributeFilter_StakingFilter_Invalid(LiquidityPoolStakingStatusFilter filter)
     {
         // Arrange
         var request = new LiquidityPoolFilterParameters
@@ -221,7 +221,7 @@ public class LiquidityPoolFilterParametersValidatorTests
     [InlineData(LiquidityPoolStakingStatusFilter.Any)]
     [InlineData(LiquidityPoolStakingStatusFilter.Enabled)]
     [InlineData(LiquidityPoolStakingStatusFilter.Disabled)]
-    public void ProvisionalFilter_StakingFilterValid(LiquidityPoolStakingStatusFilter filter)
+    public void AttributeFilter_StakingFilterValid(LiquidityPoolStakingStatusFilter filter)
     {
         // Arrange
         var request = new LiquidityPoolFilterParameters
@@ -238,7 +238,7 @@ public class LiquidityPoolFilterParametersValidatorTests
 
     [Theory]
     [InlineData((LiquidityPoolNominationStatusFilter)1000)]
-    public void ProvisionalFilter_NominationFilter_Invalid(LiquidityPoolNominationStatusFilter filter)
+    public void AttributeFilter_NominationFilter_Invalid(LiquidityPoolNominationStatusFilter filter)
     {
         // Arrange
         var request = new LiquidityPoolFilterParameters
@@ -257,7 +257,7 @@ public class LiquidityPoolFilterParametersValidatorTests
     [InlineData(LiquidityPoolNominationStatusFilter.Any)]
     [InlineData(LiquidityPoolNominationStatusFilter.Nominated)]
     [InlineData(LiquidityPoolNominationStatusFilter.NonNominated)]
-    public void ProvisionalFilter_NominationFilterValid(LiquidityPoolNominationStatusFilter filter)
+    public void AttributeFilter_NominationFilterValid(LiquidityPoolNominationStatusFilter filter)
     {
         // Arrange
         var request = new LiquidityPoolFilterParameters
@@ -274,7 +274,7 @@ public class LiquidityPoolFilterParametersValidatorTests
 
     [Theory]
     [InlineData((LiquidityPoolMiningStatusFilter)1000)]
-    public void ProvisionalFilter_MiningFilter_Invalid(LiquidityPoolMiningStatusFilter filter)
+    public void AttributeFilter_MiningFilter_Invalid(LiquidityPoolMiningStatusFilter filter)
     {
         // Arrange
         var request = new LiquidityPoolFilterParameters
@@ -293,7 +293,7 @@ public class LiquidityPoolFilterParametersValidatorTests
     [InlineData(LiquidityPoolMiningStatusFilter.Any)]
     [InlineData(LiquidityPoolMiningStatusFilter.Enabled)]
     [InlineData(LiquidityPoolMiningStatusFilter.Disabled)]
-    public void ProvisionalFilter_MiningFilterValid(LiquidityPoolMiningStatusFilter filter)
+    public void AttributeFilter_MiningFilterValid(LiquidityPoolMiningStatusFilter filter)
     {
         // Arrange
         var request = new LiquidityPoolFilterParameters

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
@@ -129,8 +129,8 @@ public class TokenFilterParametersValidatorTests
     }
 
     [Theory]
-    [InlineData((TokenProvisionalFilter)1000)]
-    public void ProvisionalFilter_Item_Invalid(TokenProvisionalFilter filter)
+    [InlineData((TokenAttributeFilter)1000)]
+    public void AttributeFilter_Item_Invalid(TokenAttributeFilter filter)
     {
         // Arrange
         var request = new TokenFilterParameters
@@ -146,10 +146,10 @@ public class TokenFilterParametersValidatorTests
     }
 
     [Theory]
-    [InlineData(TokenProvisionalFilter.All)]
-    [InlineData(TokenProvisionalFilter.Provisional)]
-    [InlineData(TokenProvisionalFilter.NonProvisional)]
-    public void ProvisionalFilter_Item_Valid(TokenProvisionalFilter filter)
+    [InlineData(TokenAttributeFilter.All)]
+    [InlineData(TokenAttributeFilter.Provisional)]
+    [InlineData(TokenAttributeFilter.NonProvisional)]
+    public void AttributeFilter_Item_Valid(TokenAttributeFilter filter)
     {
         // Arrange
         var request = new TokenFilterParameters

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Tokens/TokenFilterParametersValidatorTests.cs
@@ -130,38 +130,38 @@ public class TokenFilterParametersValidatorTests
 
     [Theory]
     [InlineData((TokenAttributeFilter)1000)]
-    public void AttributeFilter_Item_Invalid(TokenAttributeFilter filter)
+    public void AttributeFilter_Items_Invalid(TokenAttributeFilter filter)
     {
         // Arrange
         var request = new TokenFilterParameters
         {
-            TokenType = filter
+            TokenAttributes = new List<TokenAttributeFilter> {filter}
         };
 
         // Act
         var result = _validator.TestValidate(request);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(r => r.TokenType);
+        result.ShouldHaveValidationErrorFor(r => r.TokenAttributes);
     }
 
     [Theory]
-    [InlineData(TokenAttributeFilter.All)]
-    [InlineData(TokenAttributeFilter.Provisional)]
-    [InlineData(TokenAttributeFilter.NonProvisional)]
-    public void AttributeFilter_Item_Valid(TokenAttributeFilter filter)
+    [InlineData(TokenAttributeFilter.Provisional, TokenAttributeFilter.NonProvisional)]
+    [InlineData(TokenAttributeFilter.NonProvisional, TokenAttributeFilter.NonProvisional)]
+    [InlineData(TokenAttributeFilter.Staking, TokenAttributeFilter.NonProvisional)]
+    public void AttributeFilter_Items_Valid(TokenAttributeFilter first, TokenAttributeFilter second)
     {
         // Arrange
         var request = new TokenFilterParameters
         {
-            TokenType = filter
+            TokenAttributes = new List<TokenAttributeFilter> {first, second}
         };
 
         // Act
         var result = _validator.TestValidate(request);
 
         // Assert
-        result.ShouldNotHaveValidationErrorFor(r => r.TokenType);
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenAttributes);
     }
 
     [Fact]

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Wallets/AddressBalanceFilterParametersValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Wallets/AddressBalanceFilterParametersValidatorTests.cs
@@ -1,8 +1,10 @@
 using FluentValidation.TestHelper;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 using Opdex.Platform.WebApi.Models.Requests.Wallets;
 using Opdex.Platform.WebApi.Validation.Wallets;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Opdex.Platform.WebApi.Tests.Validation.Wallets;
@@ -49,6 +51,42 @@ public class AddressBalanceFilterParametersValidatorTests
 
         // Assert
         result.ShouldNotHaveValidationErrorFor(request => request.Tokens);
+    }
+
+    [Theory]
+    [InlineData((TokenAttributeFilter)1000)]
+    public void TokenAttributes_Invalid(TokenAttributeFilter filter)
+    {
+        // Arrange
+        var request = new AddressBalanceFilterParameters
+        {
+            TokenAttributes = new List<TokenAttributeFilter> {filter}
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenAttributes);
+    }
+
+    [Theory]
+    [InlineData(TokenAttributeFilter.Provisional, TokenAttributeFilter.NonProvisional)]
+    [InlineData(TokenAttributeFilter.NonProvisional, TokenAttributeFilter.NonProvisional)]
+    [InlineData(TokenAttributeFilter.Staking, TokenAttributeFilter.NonProvisional)]
+    public void TokenAttributes_Valid(TokenAttributeFilter first, TokenAttributeFilter second)
+    {
+        // Arrange
+        var request = new AddressBalanceFilterParameters
+        {
+            TokenAttributes = new List<TokenAttributeFilter> {first, second}
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenAttributes);
     }
 
     [Fact]


### PR DESCRIPTION
- Remove `token.IsLpt` property
- Persist Token Attributes during token creation
    - NonProvisional, Provisional, and Staking attributes automatically inserted

Most changes are test fixes.

Related To: https://github.com/Opdex/opdex-v1-db/pull/33