### PR TITLE
[PAPI-319] Market token request validation

### DIFF
--- a/src/Opdex.Platform.WebApi/Validation/MarketTokens/SwapAmountInQuoteRequestModelValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/MarketTokens/SwapAmountInQuoteRequestModelValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.MarketTokens;
+
+namespace Opdex.Platform.WebApi.Validation.MarketTokens;
+
+public class SwapAmountInQuoteRequestModelValidator : AbstractValidator<SwapAmountInQuoteRequestModel>
+{
+    public SwapAmountInQuoteRequestModelValidator()
+    {
+        RuleFor(r => r.TokenOut)
+            .MustBeNetworkAddressOrCrs().WithMessage("Token out must be valid address or CRS.");
+        RuleFor(r => r.TokenOutAmount)
+            .MustBeValidSrcValue().WithMessage("Token out amount must contain 18 decimal places or less.")
+            .GreaterThan(FixedDecimal.Zero).WithMessage("Token out amount must be greater than zero.");
+    }
+}

--- a/src/Opdex.Platform.WebApi/Validation/MarketTokens/SwapAmountOutQuoteRequestModelValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/MarketTokens/SwapAmountOutQuoteRequestModelValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.MarketTokens;
+
+namespace Opdex.Platform.WebApi.Validation.MarketTokens;
+
+public class SwapAmountOutQuoteRequestModelValidator : AbstractValidator<SwapAmountOutQuoteRequestModel>
+{
+    public SwapAmountOutQuoteRequestModelValidator()
+    {
+        RuleFor(r => r.TokenIn)
+            .MustBeNetworkAddressOrCrs().WithMessage("Token in must be valid address or CRS.");
+        RuleFor(r => r.TokenInAmount)
+            .MustBeValidSrcValue().WithMessage("Token in amount must contain 18 decimal places or less.")
+            .GreaterThan(FixedDecimal.Zero).WithMessage("Token in amount must be greater than zero.");
+    }
+}

--- a/src/Opdex.Platform.WebApi/Validation/MarketTokens/SwapRequestValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/MarketTokens/SwapRequestValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.MarketTokens;
+
+namespace Opdex.Platform.WebApi.Validation.MarketTokens;
+
+public class SwapRequestValidator : AbstractValidator<SwapRequest>
+{
+    public SwapRequestValidator()
+    {
+        RuleFor(r => r.TokenOut)
+            .MustBeNetworkAddressOrCrs().WithMessage("Token out must be valid address or CRS.");
+        RuleFor(r => r.TokenInAmount)
+            .MustBeValidSrcValue().WithMessage("Token in amount must contain 18 decimal places or less.")
+            .GreaterThan(FixedDecimal.Zero).WithMessage("Token in amount must be greater than zero.");
+        RuleFor(r => r.TokenOutAmount)
+            .MustBeValidSrcValue().WithMessage("Token out amount must contain 18 decimal places or less.")
+            .GreaterThan(FixedDecimal.Zero).WithMessage("Token out amount must be greater than zero.");
+        RuleFor(r => r.TokenInMaximumAmount)
+            .MustBeValidSrcValue().WithMessage("Token in maximum amount must contain 18 decimal places or less.")
+            .GreaterThanOrEqualTo(req => req.TokenInAmount).WithMessage("Token in maximum amount cannot be less than token in amount.");
+        When(r => r.TokenInExactAmount, () =>
+        {
+            RuleFor(r => r.TokenInMaximumAmount).Must((req, tokenInMaximumAmount) => tokenInMaximumAmount == req.TokenInAmount)
+                                                .WithMessage("Token in maximum amount must equal token in amount, since exact amount is specified.");
+        });
+        RuleFor(r => r.TokenOutMinimumAmount)
+            .MustBeValidSrcValue().WithMessage("Token out minimum amount must contain 18 decimal places or less.")
+            .GreaterThan(FixedDecimal.Zero).WithMessage("Token out minimum amount must be greater than zero.")
+            .LessThanOrEqualTo(req => req.TokenOutAmount).WithMessage("Token out minimum amount cannot be greater than token out amount.");
+        RuleFor(r => r.Recipient)
+            .MustBeNetworkAddress().WithMessage("Recipient must be valid address.");
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Validation/MarketTokens/SwapAmountInQuoteRequestModelValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/MarketTokens/SwapAmountInQuoteRequestModelValidatorTests.cs
@@ -1,0 +1,85 @@
+using FluentValidation.TestHelper;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.MarketTokens;
+using Opdex.Platform.WebApi.Validation.MarketTokens;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Validation.MarketTokens;
+
+public class SwapAmountInQuoteRequestModelValidatorTests
+{
+    private readonly SwapAmountInQuoteRequestModelValidator _validator;
+
+    public SwapAmountInQuoteRequestModelValidatorTests()
+    {
+        _validator = new SwapAmountInQuoteRequestModelValidator();
+    }
+
+    [Fact]
+    public void TokenOut_Invalid()
+    {
+        // Arrange
+        var request = new SwapAmountInQuoteRequestModel
+        {
+            TokenOut = Address.Empty
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(request => request.TokenOut);
+    }
+
+    [Theory]
+    [ClassData(typeof(NonNetworkAddressData))]
+    [ClassData(typeof(ValidNetworkAddressData))]
+    public void TokenOut_Valid(Address token)
+    {
+        // Arrange
+        var request = new SwapAmountInQuoteRequestModel
+        {
+            TokenOut = token
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(request => request.TokenOut);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSRCAmountData))]
+    [ClassData(typeof(ZeroSRCAmountData))]
+    public void TokenOutAmount_Invalid(FixedDecimal amount)
+    {
+        // Arrange
+        var request = new SwapAmountInQuoteRequestModel
+        {
+            TokenOutAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(request => request.TokenOutAmount);
+    }
+
+    [Fact]
+    public void TokenOutAmount_Valid()
+    {
+        // Arrange
+        var request = new SwapAmountInQuoteRequestModel
+        {
+            TokenOutAmount = FixedDecimal.Parse("0.000000000000000001")
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(request => request.TokenOutAmount);
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Validation/MarketTokens/SwapAmountOutQuoteRequestModelValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/MarketTokens/SwapAmountOutQuoteRequestModelValidatorTests.cs
@@ -1,0 +1,85 @@
+using FluentValidation.TestHelper;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.MarketTokens;
+using Opdex.Platform.WebApi.Validation.MarketTokens;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Validation.MarketTokens;
+
+public class SwapAmountOutQuoteRequestModelValidatorTests
+{
+    private readonly SwapAmountOutQuoteRequestModelValidator _validator;
+
+    public SwapAmountOutQuoteRequestModelValidatorTests()
+    {
+        _validator = new SwapAmountOutQuoteRequestModelValidator();
+    }
+
+    [Fact]
+    public void TokenIn_Invalid()
+    {
+        // Arrange
+        var request = new SwapAmountOutQuoteRequestModel
+        {
+            TokenIn = Address.Empty
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(request => request.TokenIn);
+    }
+
+    [Theory]
+    [ClassData(typeof(NonNetworkAddressData))]
+    [ClassData(typeof(ValidNetworkAddressData))]
+    public void TokenIn_Valid(Address token)
+    {
+        // Arrange
+        var request = new SwapAmountOutQuoteRequestModel
+        {
+            TokenIn = token
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(request => request.TokenIn);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSRCAmountData))]
+    [ClassData(typeof(ZeroSRCAmountData))]
+    public void TokenInAmount_Invalid(FixedDecimal amount)
+    {
+        // Arrange
+        var request = new SwapAmountOutQuoteRequestModel
+        {
+            TokenInAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(request => request.TokenInAmount);
+    }
+
+    [Fact]
+    public void TokenInAmount_Valid()
+    {
+        // Arrange
+        var request = new SwapAmountOutQuoteRequestModel
+        {
+            TokenInAmount = FixedDecimal.Parse("0.000000000000000001")
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(request => request.TokenInAmount);
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Validation/MarketTokens/SwapRequestValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/MarketTokens/SwapRequestValidatorTests.cs
@@ -1,0 +1,264 @@
+using FluentValidation.TestHelper;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.MarketTokens;
+using Opdex.Platform.WebApi.Validation.MarketTokens;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Validation.MarketTokens;
+
+public class SwapRequestValidatorTests
+{
+    private readonly SwapRequestValidator _validator;
+
+    public SwapRequestValidatorTests()
+    {
+        _validator = new SwapRequestValidator();
+    }
+
+    [Fact]
+    public void TokenOut_Invalid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenOut = Address.Empty
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenOut);
+    }
+
+    [Theory]
+    [ClassData(typeof(NonNetworkAddressData))]
+    [ClassData(typeof(ValidNetworkAddressData))]
+    public void TokenOut_Valid(Address token)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenOut = token
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenOut);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSRCAmountData))]
+    [ClassData(typeof(ZeroSRCAmountData))]
+    public void TokenInAmount_Invalid(FixedDecimal amount)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenInAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenInAmount);
+    }
+
+    [Fact]
+    public void TokenInAmount_Valid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenInAmount = FixedDecimal.Parse("0.000000000000000001")
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenInAmount);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSRCAmountData))]
+    [ClassData(typeof(ZeroSRCAmountData))]
+    public void TokenOutAmount_Invalid(FixedDecimal amount)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenOutAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenOutAmount);
+    }
+
+    [Fact]
+    public void TokenOutAmount_Valid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenOutAmount = FixedDecimal.Parse("0.000000000000000001")
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenOutAmount);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSRCAmountData))]
+    [ClassData(typeof(ZeroSRCAmountData))]
+    [ClassData(typeof(FiveHundredCRSAmountData))]
+    public void TokenInMaximumAmount_Invalid(FixedDecimal amount)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenInAmount = FixedDecimal.Parse("500.00000001"),
+            TokenInMaximumAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenInMaximumAmount);
+    }
+
+    [Fact]
+    public void TokenInMaximumAmount_Valid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenInAmount = FixedDecimal.Parse("0.000000000000000001"),
+            TokenInMaximumAmount = FixedDecimal.Parse("0.000000000000000001")
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenInMaximumAmount);
+    }
+
+    [Fact]
+    public void TokenInMaximumAmount_Exact_Invalid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenInAmount = FixedDecimal.Parse("500.00000000"),
+            TokenInMaximumAmount = FixedDecimal.Parse("505.00000000"),
+            TokenInExactAmount = true
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenInMaximumAmount);
+    }
+
+    [Fact]
+    public void TokenInMaximumAmount_Exact_Valid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenInAmount = FixedDecimal.Parse("505.00000000"),
+            TokenInMaximumAmount = FixedDecimal.Parse("505.00000000"),
+            TokenInExactAmount = true
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenInMaximumAmount);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSRCAmountData))]
+    [ClassData(typeof(ZeroSRCAmountData))]
+    [ClassData(typeof(FiveHundredCRSAmountData))]
+    public void TokenOutMinimumAmount_Invalid(FixedDecimal amount)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenOutAmount = FixedDecimal.Parse("499.99999999"),
+            TokenOutMinimumAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.TokenOutMinimumAmount);
+    }
+
+    [Fact]
+    public void TokenOutMinimumAmount_Valid()
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            TokenOutAmount = FixedDecimal.Parse("0.000000000000000001"),
+            TokenOutMinimumAmount = FixedDecimal.Parse("0.000000000000000001")
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.TokenOutMinimumAmount);
+    }
+
+    [Theory]
+    [ClassData(typeof(EmptyAddressData))]
+    [ClassData(typeof(NonNetworkAddressData))]
+    public void Recipient_Invalid(Address address)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            Recipient = address
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.Recipient);
+    }
+
+    [Theory]
+    [ClassData(typeof(ValidNetworkAddressData))]
+    public void Recipient_Valid(Address address)
+    {
+        // Arrange
+        var request = new SwapRequest
+        {
+            Recipient = address
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(r => r.Recipient);
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Validation/TokenAmountData.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/TokenAmountData.cs
@@ -35,6 +35,19 @@ public class ZeroCRSAmountData : IEnumerable<object[]>
 }
 
 /// <summary>
+/// Data for a 500 CRS amount.
+/// </summary>
+public class FiveHundredCRSAmountData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return new object[] { FixedDecimal.Parse("500.00000000") };
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <summary>
 /// Data for a 0 SRC amount.
 /// </summary>
 public class ZeroSRCAmountData : ZeroCRSAmountData { }


### PR DESCRIPTION
Resolves bug where swaps with zero amounts were returning a 500 Internal Server Error, instead they will return 400 Bad Request.