### PR TITLE
[PAPI-317] Database call logs

### DIFF
--- a/src/Opdex.Platform.Infrastructure/Data/DbContext.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/DbContext.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dapper;
+using Microsoft.Extensions.Logging;
 using MySqlConnector;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using System.Diagnostics;
 
 namespace Opdex.Platform.Infrastructure.Data;
 
@@ -11,55 +13,72 @@ namespace Opdex.Platform.Infrastructure.Data;
 // Ref: https://stackoverflow.com/questions/538060/proper-use-of-the-idisposable-interface
 public class DbContext : IDbContext
 {
+    private readonly ILogger<DbContext> _logger;
     private readonly IDatabaseSettings<MySqlConnection> _databaseSettings;
 
-    public DbContext(DatabaseConfiguration databaseConfiguration)
+    public DbContext(DatabaseConfiguration databaseConfiguration, ILogger<DbContext> logger)
     {
         var configuration = databaseConfiguration ?? throw new ArgumentNullException(nameof(databaseConfiguration));
-        var connectionString = new MySqlConnectionStringBuilder(configuration.ConnectionString);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        _databaseSettings = new DatabaseSettings(connectionString.ConnectionString);
+        var connectionStringBuilder = new MySqlConnectionStringBuilder(configuration.ConnectionString);
+        _databaseSettings = new DatabaseSettings(connectionStringBuilder.ConnectionString);
     }
 
     public async Task<IEnumerable<TEntity>> ExecuteQueryAsync<TEntity>(DatabaseQuery query)
     {
-        var command = BuildCommandDefinition(query);
         await using var connection = _databaseSettings.Create();
-        return await connection.QueryAsync<TEntity>(command);
+        return await ExecuteAndLogQuery(query, async c => await connection.QueryAsync<TEntity>(c));
     }
 
     public async Task<IEnumerable<TReturn>> ExecuteQueryAsync<TFirst, TSecond, TReturn>(DatabaseQuery query,
                                                                                         Func<TFirst, TSecond, TReturn> map,
                                                                                         string splitOn)
     {
-        var command = BuildCommandDefinition(query);
         await using var connection = _databaseSettings.Create();
-        return await connection.QueryAsync(command, map, splitOn);
+        return await ExecuteAndLogQuery(query, async c => await connection.QueryAsync(c, map, splitOn));
     }
 
     public async Task<TEntity> ExecuteFindAsync<TEntity>(DatabaseQuery query)
     {
-        var command = BuildCommandDefinition(query);
         await using var connection = _databaseSettings.Create();
-        return await connection.QuerySingleOrDefaultAsync<TEntity>(command);
+        return await ExecuteAndLogQuery(query, async c => await connection.QuerySingleOrDefaultAsync<TEntity>(c));
     }
 
     public async Task<TEntity> ExecuteScalarAsync<TEntity>(DatabaseQuery query)
     {
-        var command = BuildCommandDefinition(query);
         await using var connection = _databaseSettings.Create();
-        return await connection.ExecuteScalarAsync<TEntity>(command);
+        return await ExecuteAndLogQuery(query, async c => await connection.ExecuteScalarAsync<TEntity>(c));
     }
 
     public async Task<int> ExecuteCommandAsync(DatabaseQuery query)
     {
-        var command = BuildCommandDefinition(query);
         await using var connection = _databaseSettings.Create();
-        return await connection.ExecuteAsync(command);
+        return await ExecuteAndLogQuery(query, async c => await connection.ExecuteAsync(c));
     }
 
     private static CommandDefinition BuildCommandDefinition(DatabaseQuery query)
     {
         return new CommandDefinition(query.Sql, query.Parameters, commandType: query.Type, cancellationToken: query.Token);
+    }
+
+    private async Task<TR> ExecuteAndLogQuery<TR>(DatabaseQuery query, Func<CommandDefinition, Task<TR>> action)
+    {
+        var command = BuildCommandDefinition(query);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        var result = await action.Invoke(command);
+        stopwatch.Stop();
+
+        using (_logger.BeginScope(new Dictionary<string, object>
+               {
+                   { "Command", command.CommandText }
+               }))
+        {
+            _logger.LogDebug("Executed database query in {ExecutionTimeMs} ms", stopwatch.ElapsedMilliseconds);
+        }
+
+        return result;
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/PersistAddressBalanceCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/PersistAddressBalanceCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Addresses;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using System;
 using System.Collections.Generic;
@@ -29,14 +30,14 @@ public class PersistAddressBalanceCommandHandler : IRequestHandler<PersistAddres
                 @{nameof(AddressBalanceEntity.CreatedBlock)},
                 @{nameof(AddressBalanceEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID()";
+              SELECT LAST_INSERT_ID()".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE address_balance
                 SET
                     {nameof(AddressBalanceEntity.Balance)} = @{nameof(AddressBalanceEntity.Balance)},
                     {nameof(AddressBalanceEntity.ModifiedBlock)} = @{nameof(AddressBalanceEntity.ModifiedBlock)}
-                WHERE {nameof(AddressBalanceEntity.Id)} = @{nameof(AddressBalanceEntity.Id)};";
+                WHERE {nameof(AddressBalanceEntity.Id)} = @{nameof(AddressBalanceEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Mining/PersistAddressMiningCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Mining/PersistAddressMiningCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Addresses;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using System;
 using System.Collections.Generic;
@@ -29,14 +30,14 @@ public class PersistAddressMiningCommandHandler : IRequestHandler<PersistAddress
                 @{nameof(AddressMiningEntity.CreatedBlock)},
                 @{nameof(AddressMiningEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID()";
+              SELECT LAST_INSERT_ID()".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE address_mining
                 SET
                     {nameof(AddressMiningEntity.Balance)} = @{nameof(AddressMiningEntity.Balance)},
                     {nameof(AddressMiningEntity.ModifiedBlock)} = @{nameof(AddressMiningEntity.ModifiedBlock)}
-                WHERE {nameof(AddressMiningEntity.Id)} = @{nameof(AddressMiningEntity.Id)};";
+                WHERE {nameof(AddressMiningEntity.Id)} = @{nameof(AddressMiningEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;
@@ -68,12 +69,12 @@ public class PersistAddressMiningCommandHandler : IRequestHandler<PersistAddress
         catch (Exception ex)
         {
             using (_logger.BeginScope(new Dictionary<string, object>
-                   {
-                       ["MiningPoolId"] = request.AddressMining.MiningPoolId,
-                       ["Owner"] = request.AddressMining.Owner,
-                       ["Balance"] = request.AddressMining.Balance,
-                       ["BlockHeight"] = request.AddressMining.ModifiedBlock
-                   }))
+            {
+                ["MiningPoolId"] = request.AddressMining.MiningPoolId,
+                ["Owner"] = request.AddressMining.Owner,
+                ["Balance"] = request.AddressMining.Balance,
+                ["BlockHeight"] = request.AddressMining.ModifiedBlock
+            }))
             {
                 _logger.LogError(ex, $"Failure persisting mining position.");
             }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Mining/SelectAddressMiningByMiningPoolIdAndOwnerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Mining/SelectAddressMiningByMiningPoolIdAndOwnerQueryHandler.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Mining;
@@ -27,7 +28,7 @@ public class SelectAddressMiningByMiningPoolIdAndOwnerQueryHandler
             FROM address_mining
             WHERE {nameof(AddressMiningEntity.Owner)} = @{nameof(SqlParams.Owner)}
                 AND {nameof(AddressMiningEntity.MiningPoolId)} = @{nameof(SqlParams.MiningPoolId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Staking/PersistAddressStakingCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Staking/PersistAddressStakingCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Addresses;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using System;
 using System.Collections.Generic;
@@ -29,14 +30,14 @@ public class PersistAddressStakingCommandHandler : IRequestHandler<PersistAddres
                 @{nameof(AddressStakingEntity.CreatedBlock)},
                 @{nameof(AddressStakingEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID()";
+              SELECT LAST_INSERT_ID()".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE address_staking
                 SET
                     {nameof(AddressStakingEntity.Weight)} = @{nameof(AddressStakingEntity.Weight)},
                     {nameof(AddressStakingEntity.ModifiedBlock)} = @{nameof(AddressStakingEntity.ModifiedBlock)}
-                WHERE {nameof(AddressStakingEntity.Id)} = @{nameof(AddressStakingEntity.Id)};";
+                WHERE {nameof(AddressStakingEntity.Id)} = @{nameof(AddressStakingEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;
@@ -68,12 +69,12 @@ public class PersistAddressStakingCommandHandler : IRequestHandler<PersistAddres
         catch (Exception ex)
         {
             using (_logger.BeginScope(new Dictionary<string, object>
-                   {
-                       ["LiquidityPoolId"] = request.AddressStaking.LiquidityPoolId,
-                       ["Owner"] = request.AddressStaking.Owner,
-                       ["Weight"] = request.AddressStaking.Weight,
-                       ["BlockHeight"] = request.AddressStaking.ModifiedBlock
-                   }))
+            {
+                ["LiquidityPoolId"] = request.AddressStaking.LiquidityPoolId,
+                ["Owner"] = request.AddressStaking.Owner,
+                ["Weight"] = request.AddressStaking.Weight,
+                ["BlockHeight"] = request.AddressStaking.ModifiedBlock
+            }))
             {
                 _logger.LogError(ex, $"Failure persisting staking position.");
             }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Staking/SelectAddressStakingByLiquidityPoolIdAndOwnerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Staking/SelectAddressStakingByLiquidityPoolIdAndOwnerQueryHandler.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Addresses.Staking;
@@ -27,7 +28,7 @@ public class SelectAddressStakingByLiquidityPoolIdAndOwnerQueryHandler
             FROM address_staking
             WHERE {nameof(AddressStakingEntity.Owner)} = @{nameof(SqlParams.Owner)}
                 AND {nameof(AddressStakingEntity.LiquidityPoolId)} = @{nameof(SqlParams.LiquidityPoolId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/PersistBlockCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/PersistBlockCommandHandler.cs
@@ -8,6 +8,7 @@ using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Blocks;
 using System.Collections.Generic;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Blocks;
 
@@ -24,7 +25,7 @@ public class PersistBlockCommandHandler : IRequestHandler<PersistBlockCommand, b
                 @{nameof(BlockEntity.Hash)},
                 @{nameof(BlockEntity.Time)},
                 @{nameof(BlockEntity.MedianTime)}
-              );";
+              );".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/SelectBlockByHeightQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/SelectBlockByHeightQueryHandler.cs
@@ -7,6 +7,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models;
 using Opdex.Platform.Domain.Models.Blocks;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Blocks;
 
@@ -14,7 +15,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Blocks;
 
 public class SelectBlockByHeightQueryHandler : IRequestHandler<SelectBlockByHeightQuery, Block>
 {
-    private static readonly string SqlQuery = 
+    private static readonly string SqlQuery =
         @$"SELECT 
                 {nameof(BlockEntity.Height)},
                 {nameof(BlockEntity.Hash)},
@@ -22,8 +23,8 @@ public class SelectBlockByHeightQueryHandler : IRequestHandler<SelectBlockByHeig
                 {nameof(BlockEntity.Time)}
             FROM block
             WHERE {nameof(BlockEntity.Height)} = @{nameof(SqlParams.Height)}
-            LIMIT 1;";
-                        
+            LIMIT 1;".RemoveExcessWhitespace();
+
     private readonly IDbContext _context;
     private readonly IMapper _mapper;
 
@@ -36,9 +37,9 @@ public class SelectBlockByHeightQueryHandler : IRequestHandler<SelectBlockByHeig
     public async Task<Block> Handle(SelectBlockByHeightQuery request, CancellationToken cancellationToken)
     {
         var sqlParams = new SqlParams(request.Height);
-            
+
         var query = DatabaseQuery.Create(SqlQuery, sqlParams, cancellationToken);
-            
+
         var result = await _context.ExecuteFindAsync<BlockEntity>(query);
 
         if (request.FindOrThrow && result == null)

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/SelectBlockByMedianTimeQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/SelectBlockByMedianTimeQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.Blocks;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Blocks;
 using System;
@@ -22,7 +23,7 @@ public class SelectBlockByMedianTimeQueryHandler : IRequestHandler<SelectBlockBy
             FROM block
             WHERE {nameof(BlockEntity.MedianTime)} <= @{nameof(SqlParams.MedianTime)}
             ORDER BY {nameof(BlockEntity.Height)} DESC
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/SelectLatestBlockQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Blocks/SelectLatestBlockQueryHandler.cs
@@ -4,17 +4,17 @@ using System.Threading.Tasks;
 using AutoMapper;
 using MediatR;
 using Opdex.Platform.Common.Exceptions;
-using Opdex.Platform.Domain.Models;
 using Opdex.Platform.Domain.Models.Blocks;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Blocks;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Blocks;
 
-public class SelectLatestBlockQueryHandler: IRequestHandler<SelectLatestBlockQuery, Block>
+public class SelectLatestBlockQueryHandler : IRequestHandler<SelectLatestBlockQuery, Block>
 {
-    private static readonly string SqlQuery = 
+    private static readonly string SqlQuery =
         @$"SELECT 
                 {nameof(BlockEntity.Height)},
                 {nameof(BlockEntity.Hash)},
@@ -22,8 +22,8 @@ public class SelectLatestBlockQueryHandler: IRequestHandler<SelectLatestBlockQue
                 {nameof(BlockEntity.Time)}
             FROM block
             ORDER BY {nameof(BlockEntity.Height)} DESC
-            LIMIT 1;";
-                        
+            LIMIT 1;".RemoveExcessWhitespace();
+
     private readonly IDbContext _context;
     private readonly IMapper _mapper;
 
@@ -36,7 +36,7 @@ public class SelectLatestBlockQueryHandler: IRequestHandler<SelectLatestBlockQue
     public async Task<Block> Handle(SelectLatestBlockQuery request, CancellationToken cancellationToken)
     {
         var query = DatabaseQuery.Create(SqlQuery, token: cancellationToken);
-            
+
         var result = await _context.ExecuteFindAsync<BlockEntity>(query);
 
         if (request.FindOrThrow && result == null)

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Deployers/PersistDeployerCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Deployers/PersistDeployerCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Deployers;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Deployers;
@@ -29,7 +30,7 @@ public class PersistDeployerCommandHandler : IRequestHandler<PersistDeployerComm
                 @{nameof(DeployerEntity.CreatedBlock)},
                 @{nameof(DeployerEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE market_deployer
@@ -38,7 +39,7 @@ public class PersistDeployerCommandHandler : IRequestHandler<PersistDeployerComm
                     {nameof(DeployerEntity.Owner)} = @{nameof(DeployerEntity.Owner)},
                     {nameof(DeployerEntity.IsActive)} = @{nameof(DeployerEntity.IsActive)},
                     {nameof(DeployerEntity.ModifiedBlock)} = @{nameof(DeployerEntity.ModifiedBlock)}
-                WHERE {nameof(DeployerEntity.Id)} = @{nameof(DeployerEntity.Id)};";
+                WHERE {nameof(DeployerEntity.Id)} = @{nameof(DeployerEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Deployers/SelectActiveDeployerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Deployers/SelectActiveDeployerQueryHandler.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using MediatR;
 using Opdex.Platform.Domain.Models.Deployers;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Deployers;
 using System;
@@ -21,7 +22,7 @@ public class SelectActiveDeployerQueryHandler : IRequestHandler<SelectActiveDepl
                 {nameof(DeployerEntity.CreatedBlock)},
                 {nameof(DeployerEntity.ModifiedBlock)}
             FROM market_deployer
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Deployers/SelectDeployerByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Deployers/SelectDeployerByAddressQueryHandler.cs
@@ -7,6 +7,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Deployers;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Deployers;
 
@@ -24,7 +25,7 @@ public class SelectDeployerByAddressQueryHandler : IRequestHandler<SelectDeploye
                 {nameof(DeployerEntity.ModifiedBlock)}
             FROM market_deployer
             WHERE {nameof(DeployerEntity.Address)} = @{nameof(SqlParams.Address)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/PersistIndexerLockCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/PersistIndexerLockCommandHandler.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Domain.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Indexer;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using System;
 using System.Collections.Generic;
@@ -21,7 +22,7 @@ public class PersistIndexerLockCommandHandler : IRequestHandler<PersistIndexerLo
                     {nameof(IndexLockEntity.ModifiedDate)} = UTC_TIMESTAMP(),
                     {nameof(IndexLockEntity.InstanceId)} = @{nameof(SqlParams.InstanceId)},
                     {nameof(IndexLockEntity.Reason)} = @{nameof(SqlParams.Reason)}
-                WHERE {nameof(IndexLockEntity.Locked)} = 0;";
+                WHERE {nameof(IndexLockEntity.Locked)} = 0;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly ILogger<PersistIndexerLockCommandHandler> _logger;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/SelectIndexerLockQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/SelectIndexerLockQueryHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Indexer;
 using System;
@@ -20,7 +21,7 @@ public class SelectIndexerLockQueryHandler : IRequestHandler<SelectIndexerLockQu
                 {nameof(IndexLockEntity.Reason)},
                 {nameof(IndexLockEntity.ModifiedDate)}
             FROM index_lock
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
 

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/PersistLiquidityPoolCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/PersistLiquidityPoolCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.LiquidityPools;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ public class PersistLiquidityPoolCommandHandler : IRequestHandler<PersistLiquidi
                 @{nameof(LiquidityPoolEntity.CreatedBlock)},
                 @{nameof(LiquidityPoolEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByAddressQueryHandler.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using System;
@@ -25,7 +26,7 @@ public class SelectLiquidityPoolByAddressQueryHandler : IRequestHandler<SelectLi
                 {nameof(LiquidityPoolEntity.CreatedBlock)},
                 {nameof(LiquidityPoolEntity.ModifiedBlock)}
             FROM pool_liquidity
-            WHERE {nameof(LiquidityPoolEntity.Address)} = @{nameof(SqlParams.Address)};";
+            WHERE {nameof(LiquidityPoolEntity.Address)} = @{nameof(SqlParams.Address)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using System;
@@ -25,7 +26,7 @@ public class SelectLiquidityPoolByIdQueryHandler : IRequestHandler<SelectLiquidi
                 {nameof(LiquidityPoolEntity.ModifiedBlock)}
             FROM pool_liquidity
             WHERE {nameof(LiquidityPoolEntity.Id)} = @{nameof(SqlParams.LiquidityPoolId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools;
 using System;
@@ -26,7 +27,7 @@ public class SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler : IRequestHa
             FROM pool_liquidity
             WHERE {nameof(LiquidityPoolEntity.SrcTokenId)} = @{nameof(SqlParams.SrcTokenId)}
                 AND {nameof(LiquidityPoolEntity.MarketId)} = @{nameof(SqlParams.MarketId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Snapshots/PersistLiquidityPoolSnapshotCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Snapshots/PersistLiquidityPoolSnapshotCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.LiquidityPools;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools.Snapshots;
 using System;
 using System.Collections.Generic;
@@ -30,7 +31,7 @@ public class PersistLiquidityPoolSnapshotCommandHandler : IRequestHandler<Persis
                 @{nameof(LiquidityPoolSnapshotEntity.EndDate)},
                 @{nameof(LiquidityPoolSnapshotEntity.Details)},
                 UTC_TIMESTAMP()
-              );";
+              );".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE pool_liquidity_snapshot
@@ -38,7 +39,7 @@ public class PersistLiquidityPoolSnapshotCommandHandler : IRequestHandler<Persis
                     {nameof(LiquidityPoolSnapshotEntity.TransactionCount)} = @{nameof(LiquidityPoolSnapshotEntity.TransactionCount)},
                     {nameof(LiquidityPoolSnapshotEntity.Details)} = @{nameof(LiquidityPoolSnapshotEntity.Details)},
                     {nameof(LiquidityPoolSnapshotEntity.ModifiedDate)} = UTC_TIMESTAMP()
-                WHERE {nameof(LiquidityPoolSnapshotEntity.Id)} = @{nameof(LiquidityPoolSnapshotEntity.Id)};";
+                WHERE {nameof(LiquidityPoolSnapshotEntity.Id)} = @{nameof(LiquidityPoolSnapshotEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Snapshots/SelectLiquidityPoolSnapshotWithFilterQueryHandler.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using MediatR;
 using Opdex.Platform.Domain.Models.LiquidityPools.Snapshots;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools.Snapshots;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools.Snapshots;
 using System;
@@ -33,7 +34,7 @@ public class SelectLiquidityPoolSnapshotWithFilterQueryHandler
                     )
                 AND {nameof(LiquidityPoolSnapshotEntity.SnapshotTypeId)} = @{nameof(SqlParams.SnapshotTypeId)}
             ORDER BY {nameof(LiquidityPoolSnapshotEntity.EndDate)} DESC
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Summaries/SelectLiquidityPoolSummaryByLiquidityPoolIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Summaries/SelectLiquidityPoolSummaryByLiquidityPoolIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.LiquidityPools.Summaries;
 using System;
@@ -29,7 +30,7 @@ public class SelectLiquidityPoolSummaryByLiquidityPoolIdQueryHandler
                 {nameof(LiquidityPoolSummaryEntity.ModifiedBlock)}
             FROM pool_liquidity_summary
             WHERE {nameof(LiquidityPoolSummaryEntity.LiquidityPoolId)} = @{nameof(SqlParams.LiquidityPoolId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/PersistMarketPermissionCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/PersistMarketPermissionCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ public class PersistMarketPermissionCommandHandler : IRequestHandler<PersistMark
                 @{nameof(MarketPermissionEntity.CreatedBlock)},
                 @{nameof(MarketPermissionEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE market_permission
@@ -39,7 +40,7 @@ public class PersistMarketPermissionCommandHandler : IRequestHandler<PersistMark
                     {nameof(MarketPermissionEntity.IsAuthorized)} = @{nameof(MarketPermissionEntity.IsAuthorized)},
                     {nameof(MarketPermissionEntity.Blame)} = @{nameof(MarketPermissionEntity.Blame)},
                     {nameof(MarketPermissionEntity.ModifiedBlock)} = @{nameof(MarketPermissionEntity.ModifiedBlock)}
-                WHERE {nameof(MarketPermissionEntity.Id)} = @{nameof(MarketPermissionEntity.Id)};";
+                WHERE {nameof(MarketPermissionEntity.Id)} = @{nameof(MarketPermissionEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/SelectMarketPermissionQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/SelectMarketPermissionQueryHandler.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets.Permissions;
 using System;
@@ -28,7 +29,7 @@ public class SelectMarketPermissionQueryHandler : IRequestHandler<SelectMarketPe
             WHERE {nameof(MarketPermissionEntity.MarketId)} = @{nameof(SqlParams.MarketId)}
                 AND {nameof(MarketPermissionEntity.User)} = @{nameof(SqlParams.User)}
                 AND {nameof(MarketPermissionEntity.Permission)} = @{nameof(SqlParams.Permission)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;
@@ -38,8 +39,6 @@ public class SelectMarketPermissionQueryHandler : IRequestHandler<SelectMarketPe
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
-
-
     public async Task<MarketPermission> Handle(SelectMarketPermissionQuery request, CancellationToken cancellationToken)
     {
         var queryParams = new SqlParams(request.MarketId, request.Address, (int)request.Permission);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/SelectMarketPermissionsByUserQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/SelectMarketPermissionsByUserQueryHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets.Permissions;
 using System;
@@ -20,7 +21,7 @@ public class SelectMarketPermissionsByUserQueryHandler : IRequestHandler<SelectM
             WHERE {nameof(MarketPermissionEntity.MarketId)} = @{nameof(SqlParams.MarketId)}
                 AND {nameof(MarketPermissionEntity.User)} = @{nameof(SqlParams.User)}
                 AND {nameof(MarketPermissionEntity.IsAuthorized)} = true
-            LIMIT 4;";
+            LIMIT 4;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
 

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/PersistMarketCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/PersistMarketCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Markets;
@@ -41,7 +42,7 @@ public class PersistMarketCommandHandler : IRequestHandler<PersistMarketCommand,
                 @{nameof(MarketEntity.CreatedBlock)},
                 @{nameof(MarketEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE market
@@ -49,7 +50,7 @@ public class PersistMarketCommandHandler : IRequestHandler<PersistMarketCommand,
                     {nameof(MarketEntity.PendingOwner)} = @{nameof(MarketEntity.PendingOwner)},
                     {nameof(MarketEntity.Owner)} = @{nameof(MarketEntity.Owner)},
                     {nameof(MarketEntity.ModifiedBlock)} = @{nameof(MarketEntity.ModifiedBlock)}
-                WHERE {nameof(MarketEntity.Id)} = @{nameof(MarketEntity.Id)};";
+                WHERE {nameof(MarketEntity.Id)} = @{nameof(MarketEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/PersistMarketRouterCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/PersistMarketRouterCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Markets;
@@ -26,14 +27,14 @@ public class PersistMarketRouterCommandHandler : IRequestHandler<PersistMarketRo
                 @{nameof(MarketRouterEntity.IsActive)},
                 @{nameof(MarketRouterEntity.CreatedBlock)},
                 @{nameof(MarketRouterEntity.ModifiedBlock)}
-              );";
+              );".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE market_router
                 SET 
                     {nameof(MarketRouterEntity.IsActive)} = @{nameof(MarketRouterEntity.IsActive)},
                     {nameof(MarketRouterEntity.ModifiedBlock)} = @{nameof(MarketRouterEntity.ModifiedBlock)}
-                WHERE {nameof(MarketRouterEntity.Id)} = @{nameof(MarketRouterEntity.Id)};";
+                WHERE {nameof(MarketRouterEntity.Id)} = @{nameof(MarketRouterEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectActiveMarketRouterByMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectActiveMarketRouterByMarketIdQueryHandler.cs
@@ -6,6 +6,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets;
 
@@ -24,7 +25,7 @@ public class SelectActiveMarketRouterByMarketIdQueryHandler : IRequestHandler<Se
             FROM market_router
             WHERE {nameof(MarketRouterEntity.MarketId)} = @{nameof(SqlParams.MarketId)}
                 AND {nameof(MarketRouterEntity.IsActive)} = true
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;
@@ -41,7 +42,7 @@ public class SelectActiveMarketRouterByMarketIdQueryHandler : IRequestHandler<Se
 
         var command = DatabaseQuery.Create(SqlCommand, queryParams, cancellationToken);
 
-        var result =  await _context.ExecuteFindAsync<MarketRouterEntity>(command);
+        var result = await _context.ExecuteFindAsync<MarketRouterEntity>(command);
 
         if (request.FindOrThrow && result == null)
         {

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectAllMarketsQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectAllMarketsQueryHandler.cs
@@ -6,6 +6,7 @@ using AutoMapper;
 using MediatR;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets;
 
@@ -28,7 +29,7 @@ public class SelectAllMarketsQueryHandler : IRequestHandler<SelectAllMarketsQuer
                 {nameof(MarketEntity.MarketFeeEnabled)},
                 {nameof(MarketEntity.CreatedBlock)},
                 {nameof(MarketEntity.ModifiedBlock)}
-            FROM market;";
+            FROM market;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketByAddressQueryHandler.cs
@@ -8,6 +8,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets;
 
@@ -32,7 +33,7 @@ public class SelectMarketByAddressQueryHandler : IRequestHandler<SelectMarketByA
                 {nameof(MarketEntity.ModifiedBlock)}
             FROM market
             WHERE {nameof(MarketEntity.Address)} = @{nameof(SqlParams.Address)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketByIdQueryHandler.cs
@@ -3,10 +3,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using MediatR;
-using Microsoft.Extensions.Logging;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets;
 
@@ -31,7 +31,7 @@ public class SelectMarketByIdQueryHandler : IRequestHandler<SelectMarketByIdQuer
                 {nameof(MarketEntity.ModifiedBlock)}
             FROM market
             WHERE {nameof(MarketEntity.Id)} = @{nameof(SqlParams.MarketId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketRouterByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketRouterByAddressQueryHandler.cs
@@ -7,6 +7,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets;
 
@@ -24,7 +25,7 @@ public class SelectMarketRouterByAddressQueryHandler : IRequestHandler<SelectMar
                 {nameof(MarketRouterEntity.ModifiedBlock)}
             FROM market_router
             WHERE {nameof(MarketRouterEntity.Address)} = @{nameof(SqlParams.Address)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketsWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/SelectMarketsWithFilterQueryHandler.cs
@@ -64,7 +64,7 @@ public class SelectMarketsWithFilterQueryHandler : IRequestHandler<SelectMarkets
                 {nameof(MarketEntity.MarketFeeEnabled)},
                 {nameof(MarketEntity.CreatedBlock)},
                 {nameof(MarketEntity.ModifiedBlock)}
-            FROM ({InnerQuery}) r {OrderBySort};";
+            FROM ({InnerQuery}) r {OrderBySort};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Snapshots/PersistMarketSnapshotCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Snapshots/PersistMarketSnapshotCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using System;
 using System.Collections.Generic;
@@ -28,14 +29,14 @@ public class PersistMarketSnapshotCommandHandler : IRequestHandler<PersistMarket
                 @{nameof(MarketSnapshotEntity.StartDate)},
                 @{nameof(MarketSnapshotEntity.EndDate)},
                 UTC_TIMESTAMP()
-              );";
+              );".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE market_snapshot
                 SET
                     {nameof(MarketSnapshotEntity.Details)} = @{nameof(MarketSnapshotEntity.Details)},
                     {nameof(MarketSnapshotEntity.ModifiedDate)} = UTC_TIMESTAMP()
-                WHERE {nameof(MarketSnapshotEntity.Id)} = @{nameof(MarketSnapshotEntity.Id)};";
+                WHERE {nameof(MarketSnapshotEntity.Id)} = @{nameof(MarketSnapshotEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Snapshots/SelectMarketSnapshotWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Snapshots/SelectMarketSnapshotWithFilterQueryHandler.cs
@@ -7,6 +7,7 @@ using Opdex.Platform.Domain.Models.Markets;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Markets.Snapshots;
 
@@ -31,7 +32,7 @@ public class SelectMarketSnapshotWithFilterQueryHandler
                     )
                 AND {nameof(MarketSnapshotEntity.SnapshotTypeId)} = @{nameof(SqlParams.SnapshotTypeId)}
             ORDER BY {nameof(MarketSnapshotEntity.EndDate)} DESC
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Markets;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Markets.Summaries;
 using System;
@@ -31,7 +32,7 @@ public class SelectMarketSummaryByMarketIdQueryHandler
                 {nameof(MarketSummaryEntity.ModifiedBlock)}
             FROM market_summary
             WHERE {nameof(MarketSummaryEntity.MarketId)} = @{nameof(SqlParams.MarketId)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/PersistMiningGovernanceNominationCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/PersistMiningGovernanceNominationCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.MiningGovernances;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.MiningGovernances;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ public class PersistMiningGovernanceNominationCommandHandler : IRequestHandler<P
                 @{nameof(MiningGovernanceNominationEntity.CreatedBlock)},
                 @{nameof(MiningGovernanceNominationEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE mining_governance_nomination
@@ -39,7 +40,7 @@ public class PersistMiningGovernanceNominationCommandHandler : IRequestHandler<P
                     {nameof(MiningGovernanceNominationEntity.Weight)} = @{nameof(MiningGovernanceNominationEntity.Weight)},
                     {nameof(MiningGovernanceNominationEntity.IsNominated)} = @{nameof(MiningGovernanceNominationEntity.IsNominated)},
                     {nameof(MiningGovernanceNominationEntity.ModifiedBlock)} = @{nameof(MiningGovernanceNominationEntity.ModifiedBlock)}
-                WHERE {nameof(MiningGovernanceNominationEntity.Id)} = @{nameof(MiningGovernanceNominationEntity.Id)};";
+                WHERE {nameof(MiningGovernanceNominationEntity.Id)} = @{nameof(MiningGovernanceNominationEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/SelectActiveGovernanceNominationsByMiningGovernanceIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/SelectActiveGovernanceNominationsByMiningGovernanceIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Constants.SmartContracts;
 using Opdex.Platform.Domain.Models.MiningGovernances;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.MiningGovernances;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.MiningGovernances.Nominations;
 using System;
@@ -28,7 +29,7 @@ public class SelectActiveMiningGovernanceNominationsByMiningGovernanceIdQueryHan
             FROM mining_governance_nomination
             WHERE {nameof(MiningGovernanceNominationEntity.IsNominated)} = true AND
                   {nameof(MiningGovernanceNominationEntity.MiningGovernanceId)} = @{nameof(SqlParams.MiningGovernanceId)}
-            LIMIT {MiningGovernanceConstants.MaxNominations};";
+            LIMIT {MiningGovernanceConstants.MaxNominations};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/SelectMiningGovernanceNominationByLiquidityAndMiningPoolIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/SelectMiningGovernanceNominationByLiquidityAndMiningPoolIdQueryHandler.cs
@@ -48,7 +48,7 @@ public class SelectMiningGovernanceNominationByLiquidityAndMiningPoolIdQueryHand
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(MiningGovernanceNomination)} not found.");
+            throw new NotFoundException($"Mining governance nomination not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningGovernanceNomination>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/PersistMiningGovernanceCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/PersistMiningGovernanceCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.MiningGovernances;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.MiningGovernances;
 using System;
 using System.Collections.Generic;
@@ -33,7 +34,7 @@ public class PersistMiningGovernanceCommandHandler : IRequestHandler<PersistMini
                 @{nameof(MiningGovernanceEntity.CreatedBlock)},
                 @{nameof(MiningGovernanceEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE mining_governance
@@ -42,7 +43,7 @@ public class PersistMiningGovernanceCommandHandler : IRequestHandler<PersistMini
                     {nameof(MiningGovernanceEntity.MiningPoolsFunded)} = @{nameof(MiningGovernanceEntity.MiningPoolsFunded)},
                     {nameof(MiningGovernanceEntity.MiningPoolReward)} = @{nameof(MiningGovernanceEntity.MiningPoolReward)},
                     {nameof(MiningGovernanceEntity.ModifiedBlock)} = @{nameof(MiningGovernanceEntity.ModifiedBlock)}
-                WHERE {nameof(MiningGovernanceEntity.Id)} = @{nameof(MiningGovernanceEntity.Id)};";
+                WHERE {nameof(MiningGovernanceEntity.Id)} = @{nameof(MiningGovernanceEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/PersistMiningPoolCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/PersistMiningPoolCommandHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.MiningPools;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.MiningPools;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ public class PersistMiningPoolCommandHandler : IRequestHandler<PersistMiningPool
                 @{nameof(MiningPoolEntity.CreatedBlock)},
                 @{nameof(MiningPoolEntity.ModifiedBlock)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE pool_mining
@@ -41,7 +42,7 @@ public class PersistMiningPoolCommandHandler : IRequestHandler<PersistMiningPool
                   {nameof(MiningPoolEntity.MiningPeriodEndBlock)} = @{nameof(MiningPoolEntity.MiningPeriodEndBlock)},
                   {nameof(MiningPoolEntity.ModifiedBlock)} = @{nameof(MiningPoolEntity.ModifiedBlock)}
                 WHERE
-                  {nameof(MiningPoolEntity.Id)} = @{nameof(MiningPoolEntity.Id)};";
+                  {nameof(MiningPoolEntity.Id)} = @{nameof(MiningPoolEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByAddressQueryHandler.cs
@@ -4,6 +4,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.MiningPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.MiningPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.MiningPools;
 using System;
@@ -25,7 +26,7 @@ public class SelectMiningPoolByAddressQueryHandler : IRequestHandler<SelectMinin
                 {nameof(MiningPoolEntity.ModifiedBlock)},
                 {nameof(MiningPoolEntity.CreatedBlock)}
             FROM pool_mining
-            WHERE {nameof(MiningPoolEntity.Address)} = @{nameof(SqlParams.Address)} LIMIT 1;";
+            WHERE {nameof(MiningPoolEntity.Address)} = @{nameof(SqlParams.Address)} LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByLiquidityPoolIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByLiquidityPoolIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.MiningPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.MiningPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.MiningPools;
 using System;
@@ -24,7 +25,7 @@ public class SelectMiningPoolByLiquidityPoolIdQueryHandler : IRequestHandler<Sel
                 {nameof(MiningPoolEntity.ModifiedBlock)},
                 {nameof(MiningPoolEntity.CreatedBlock)}
             FROM pool_mining
-            WHERE {nameof(MiningPoolEntity.LiquidityPoolId)} = @{nameof(SqlParams.LiquidityPoolId)};";
+            WHERE {nameof(MiningPoolEntity.LiquidityPoolId)} = @{nameof(SqlParams.LiquidityPoolId)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Attributes/PersistTokenAttributeCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Attributes/PersistTokenAttributeCommandHandler.cs
@@ -1,9 +1,9 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 using System;
 using System.Collections.Generic;
@@ -21,7 +21,7 @@ public class PersistTokenAttributeCommandHandler : IRequestHandler<PersistTokenA
               ) VALUES (
                 @{nameof(TokenAttributeEntity.TokenId)},
                 @{nameof(TokenAttributeEntity.AttributeTypeId)}
-              );";
+              );".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Distribution/PersistTokenDistributionCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Distribution/PersistTokenDistributionCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Distribution;
@@ -32,7 +33,7 @@ public class PersistTokenDistributionCommandHandler : IRequestHandler<PersistTok
                 @{nameof(TokenDistributionEntity.NextDistributionBlock)},
                 @{nameof(TokenDistributionEntity.CreatedBlock)},
                 @{nameof(TokenDistributionEntity.ModifiedBlock)}
-              );";
+              );".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Distribution/SelectLatestTokenDistributionByTokenIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Distribution/SelectLatestTokenDistributionByTokenIdQueryHandler.cs
@@ -6,6 +6,7 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens.Distribution;
 
@@ -27,7 +28,7 @@ public class SelectLatestTokenDistributionByTokenIdQueryHandler : IRequestHandle
             FROM token_distribution
             WHERE {nameof(TokenDistributionEntity.TokenId)} = @{nameof(SqlParams.TokenId)}
             ORDER BY {nameof(TokenDistributionEntity.NextDistributionBlock)} DESC
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/PersistTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/PersistTokenCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens;
@@ -33,7 +34,7 @@ public class PersistTokenCommandHandler : IRequestHandler<PersistTokenCommand, u
                 @{nameof(TokenEntity.CreatedBlock)},
                 @{nameof(TokenEntity.ModifiedBlock)}
               );
-            SELECT LAST_INSERT_ID();";
+            SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE token

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByAddressQueryHandler.cs
@@ -7,6 +7,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 
@@ -15,7 +16,7 @@ namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens;
 public class SelectTokenByAddressQueryHandler : IRequestHandler<SelectTokenByAddressQuery, Token>
 {
     private static readonly string SqlQuery =
-        @$"Select
+        @$"SELECT
                 {nameof(TokenEntity.Id)},
                 {nameof(TokenEntity.Address)},
                 {nameof(TokenEntity.Name)},
@@ -27,7 +28,7 @@ public class SelectTokenByAddressQueryHandler : IRequestHandler<SelectTokenByAdd
                 {nameof(TokenEntity.ModifiedBlock)}
             FROM token
             WHERE {nameof(TokenEntity.Address)} = @{nameof(SqlParams.Address)}
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/SelectTokenByIdQueryHandler.cs
@@ -6,15 +6,16 @@ using MediatR;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens;
 
-public class SelectTokenByIdQueryHandler: IRequestHandler<SelectTokenByIdQuery, Token>
+public class SelectTokenByIdQueryHandler : IRequestHandler<SelectTokenByIdQuery, Token>
 {
     private static readonly string SqlQuery =
-        @$"Select
+        @$"SELECT
                 {nameof(TokenEntity.Id)},
                 {nameof(TokenEntity.Address)},
                 {nameof(TokenEntity.Name)},
@@ -25,7 +26,7 @@ public class SelectTokenByIdQueryHandler: IRequestHandler<SelectTokenByIdQuery, 
                 {nameof(TokenEntity.CreatedBlock)},
                 {nameof(TokenEntity.ModifiedBlock)}
             FROM token
-            WHERE {nameof(TokenEntity.Id)} = @{nameof(SqlParams.Id)};";
+            WHERE {nameof(TokenEntity.Id)} = @{nameof(SqlParams.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/PersistTokenSnapshotCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/PersistTokenSnapshotCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Tokens;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Tokens.Snapshots;
@@ -30,14 +31,14 @@ public class PersistTokenSnapshotCommandHandler : IRequestHandler<PersistTokenSn
                 @{nameof(TokenSnapshotEntity.StartDate)},
                 @{nameof(TokenSnapshotEntity.EndDate)},
                 UTC_TIMESTAMP()
-              );";
+              );".RemoveExcessWhitespace();
 
     private static readonly string UpdateSqlCommand =
         $@"UPDATE token_snapshot 
                 SET 
                     {nameof(TokenSnapshotEntity.Details)} = @{nameof(TokenSnapshotEntity.Details)},
                     {nameof(TokenSnapshotEntity.ModifiedDate)} = UTC_TIMESTAMP()
-                WHERE {nameof(TokenSnapshotEntity.Id)} = @{nameof(TokenSnapshotEntity.Id)};";
+                WHERE {nameof(TokenSnapshotEntity.Id)} = @{nameof(TokenSnapshotEntity.Id)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/SelectTokenSnapshotWithFilterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Snapshots/SelectTokenSnapshotWithFilterQueryHandler.cs
@@ -5,6 +5,7 @@ using AutoMapper;
 using MediatR;
 using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Tokens.Snapshots;
 
@@ -31,7 +32,7 @@ public class SelectTokenSnapshotWithFilterQueryHandler : IRequestHandler<SelectT
                 )
                 AND {nameof(TokenSnapshotEntity.SnapshotTypeId)} = @{nameof(SqlParams.SnapshotTypeId)}
             ORDER BY {nameof(TokenSnapshotEntity.EndDate)} DESC
-            LIMIT 1;";
+            LIMIT 1;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/PersistTransactionCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/PersistTransactionCommandHandler.cs
@@ -7,6 +7,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Transactions;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Transactions;
@@ -33,7 +34,7 @@ public class PersistTransactionCommandHandler : IRequestHandler<PersistTransacti
                 @{nameof(TransactionEntity.Error)},
                 @{nameof(TransactionEntity.Block)}
               );
-              SELECT LAST_INSERT_ID();";
+              SELECT LAST_INSERT_ID();".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/SelectTransactionByHashQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/SelectTransactionByHashQueryHandler.cs
@@ -7,6 +7,7 @@ using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Domain.Models.Transactions;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Transactions;
 
@@ -26,7 +27,7 @@ public class SelectTransactionByHashQueryHandler : IRequestHandler<SelectTransac
                 {nameof(TransactionEntity.Success)},
                 {nameof(TransactionEntity.Error)}
             FROM transaction
-            WHERE {nameof(TransactionEntity.Hash)} = @{nameof(SqlParams.Hash)};";
+            WHERE {nameof(TransactionEntity.Hash)} = @{nameof(SqlParams.Hash)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/SelectTransactionsForSnapshotRewindQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/SelectTransactionsForSnapshotRewindQueryHandler.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Opdex.Platform.Domain.Models.TransactionLogs;
 using Opdex.Platform.Domain.Models.Transactions;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions.TransactionLogs;
@@ -43,7 +44,7 @@ public class SelectTransactionsForSnapshotRewindQueryHandler
             LEFT JOIN transaction_log tl
                 ON t.{nameof(TransactionEntity.Id)} = tl.{nameof(TransactionLogEntity.TransactionId)}
             WHERE b.{nameof(BlockEntity.MedianTime)} >= @{nameof(SqlParams.DateTime)}
-            ORDER BY t.{nameof(TransactionEntity.Id)} ASC;";
+            ORDER BY t.{nameof(TransactionEntity.Id)} ASC;".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/TransactionLogs/SelectTransactionLogsByTransactionIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Transactions/TransactionLogs/SelectTransactionLogsByTransactionIdQueryHandler.cs
@@ -7,6 +7,7 @@ using AutoMapper;
 using MediatR;
 using Opdex.Platform.Domain.Models.TransactionLogs;
 using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Models.Transactions.TransactionLogs;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries.Transactions.TransactionLogs;
 
@@ -24,7 +25,7 @@ public class SelectTransactionLogsByTransactionIdQueryHandler
                 {nameof(TransactionLogEntity.Contract)},
                 {nameof(TransactionLogEntity.Details)}
             FROM transaction_log
-            WHERE {nameof(TransactionLogEntity.TransactionId)} = @{nameof(SqlParams.TransactionId)};";
+            WHERE {nameof(TransactionLogEntity.TransactionId)} = @{nameof(SqlParams.TransactionId)};".RemoveExcessWhitespace();
 
     private readonly IDbContext _context;
     private readonly IMapper _mapper;


### PR DESCRIPTION
Pretty must just adding `RemoveExcessWhitespace` apart from the changes within `DbContext`

Example:
![image](https://user-images.githubusercontent.com/39023939/150395387-71b2122b-6797-49ae-9f8c-3cb0fba796fc.png)
