### PR TITLE
[PAPI-331] Notify Broadcasted Transaction Improvements

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -6432,6 +6432,18 @@ paths:
                     - Invalid transaction state.
                 extensions:
                   traceId: 00-00000000000000000000000000000000-0000000000000000-00
+        404:
+          description: Raw transaction not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/validationProblemDetails"
+              example:
+                type: https://httpstatuses.com/404
+                title: Not Found
+                status: 404
+                extensions:
+                  traceId: 00-00000000000000000000000000000000-0000000000000000-00
         429:
           $ref: "#/components/responses/TooManyRequests"
         500:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1578,6 +1578,9 @@ components:
         transactionHash:
           $ref: "#/components/schemas/sha256"
           description: SHA-256 hash of the transaction
+        publicKey:
+          $ref: "#/components/schemas/address"
+          description:  The transaction sender's public key
     replayQuoteRequest:
       type: object
       description: Request to replay a previous quote at the current point in time
@@ -6410,6 +6413,7 @@ paths:
               $ref: "#/components/schemas/notifyBroadcastRequest"
             example:
               transactionHash: 402aa2241adb7b04d07d4dbc89f8aae72fa1c11f9bd2bd9013222cd774ed39fe
+              publicKey: tHYHem7cLKgoLkeb792yn4WayqKzLrjJak
       responses:
         204:
           description: The broadcast notification was sent
@@ -6425,7 +6429,7 @@ paths:
                 status: 400
                 errors:
                   transactionHash:
-                    - Transaction already mined.
+                    - Invalid transaction state.
                 extensions:
                   traceId: 00-00000000000000000000000000000000-0000000000000000-00
         429:

--- a/src/Opdex.Platform.Application.Abstractions/EntryCommands/Transactions/CreateNotifyUserOfTransactionBroadcastCommand.cs
+++ b/src/Opdex.Platform.Application.Abstractions/EntryCommands/Transactions/CreateNotifyUserOfTransactionBroadcastCommand.cs
@@ -1,16 +1,17 @@
 using MediatR;
 using Opdex.Platform.Common.Models;
-using System;
 
 namespace Opdex.Platform.Application.Abstractions.EntryCommands.Transactions;
 
 /// <summary>Attempts to notify a user of a transaction which has been broadcast.</summary>
 public class CreateNotifyUserOfTransactionBroadcastCommand : IRequest<bool>
 {
-    public CreateNotifyUserOfTransactionBroadcastCommand(Sha256 transactionHash)
+    public CreateNotifyUserOfTransactionBroadcastCommand(Sha256 transactionHash, Address sender)
     {
         TransactionHash = transactionHash;
+        Sender = sender;
     }
 
     public Sha256 TransactionHash { get; }
+    public Address Sender { get; }
 }

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/CreateNotifyUserOfTransactionBroadcastCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/CreateNotifyUserOfTransactionBroadcastCommandHandler.cs
@@ -1,11 +1,9 @@
 using MediatR;
 using Opdex.Platform.Application.Abstractions.Commands.Transactions;
 using Opdex.Platform.Application.Abstractions.EntryCommands.Transactions;
-using Opdex.Platform.Application.Abstractions.Queries.Blocks;
 using Opdex.Platform.Application.Abstractions.Queries.Transactions;
 using Opdex.Platform.Common.Models;
 using System;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Opdex.Platform.Application/Handlers/Transactions/RetrieveCirrusUnverifiedTransactionSenderByHashQueryHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Transactions/RetrieveCirrusUnverifiedTransactionSenderByHashQueryHandler.cs
@@ -3,6 +3,7 @@ using Opdex.Platform.Application.Abstractions.Queries.Transactions;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.Transactions;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,9 +31,9 @@ public class RetrieveCirrusUnverifiedTransactionSenderByHashQueryHandler : IRequ
             if (attempt > 1) await Task.Delay(TimeSpan.FromSeconds(Backoff), cancellationToken);
             var transaction = await _mediator.Send(new CallCirrusGetRawTransactionQuery(request.TransactionHash), cancellationToken);
 
-            if (transaction is null || transaction.Vout?.Length == 0 || transaction.Vout?[0].ScriptPubKey?.Addresses?.Length != 1) continue;
+            if (transaction is null) continue;
 
-            return transaction.Vout[0].ScriptPubKey.Addresses[0];
+            return transaction.Vout.SelectMany(vOut => vOut?.ScriptPubKey.Addresses).FirstOrDefault();
         }
 
         return Address.Empty;

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Models/RawTransactionDto.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Models/RawTransactionDto.cs
@@ -1,9 +1,15 @@
 using Opdex.Platform.Common.Models;
+using System;
 
 namespace Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Models;
 
 public class RawTransactionDto
 {
+    public RawTransactionDto()
+    {
+        Vout = Array.Empty<VOutDto>();
+    }
+
     public VOutDto[] Vout { get; set; }
 }
 
@@ -14,5 +20,10 @@ public class VOutDto
 
 public class ScriptPubKeyDto
 {
+    public ScriptPubKeyDto()
+    {
+        Addresses = Array.Empty<Address>();
+    }
+
     public Address[] Addresses { get; set; }
 }

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Queries/Transactions/CallCirrusGetRawTransactionQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Queries/Transactions/CallCirrusGetRawTransactionQuery.cs
@@ -1,4 +1,3 @@
-using MediatR;
 using Opdex.Platform.Common.Models;
 using Opdex.Platform.Common.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Models;

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Queries/Transactions/CallCirrusGetRawTransactionQuery.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Clients/CirrusFullNodeApi/Queries/Transactions/CallCirrusGetRawTransactionQuery.cs
@@ -1,18 +1,20 @@
 using MediatR;
 using Opdex.Platform.Common.Models;
+using Opdex.Platform.Common.Queries;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Models;
 
 namespace Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.Transactions;
 
 /// <summary>Query the retrieve a raw transaction from the node.</summary>
 /// <remarks>Transactions get looked up from the mempool and from those which have been broadcast.</remarks>
-public class CallCirrusGetRawTransactionQuery : IRequest<RawTransactionDto>
+public class CallCirrusGetRawTransactionQuery : FindQuery<RawTransactionDto>
 {
     /// <summary>
     /// Creates a query to retrieve the raw transaction from the node.
     /// </summary>
     /// <param name="transactionHash">The hash of the transaction.</param>
-    public CallCirrusGetRawTransactionQuery(Sha256 transactionHash)
+    /// <param name="findOrThrow">Flag determining if the handler should throw a not found exception for requests not found.</param>
+    public CallCirrusGetRawTransactionQuery(Sha256 transactionHash, bool findOrThrow = true) : base(findOrThrow)
     {
         TransactionHash = transactionHash;
     }

--- a/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Handlers/Transactions/CallCirrusGetRawTransactionQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Handlers/Transactions/CallCirrusGetRawTransactionQueryHandler.cs
@@ -1,7 +1,9 @@
 using MediatR;
+using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Models;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Modules;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.Transactions;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +11,8 @@ namespace Opdex.Platform.Infrastructure.Clients.CirrusFullNodeApi.Handlers.Trans
 
 public class CallCirrusGetRawTransactionQueryHandler : IRequestHandler<CallCirrusGetRawTransactionQuery, RawTransactionDto>
 {
+    private const int MaxRetries = 5;
+    private const int Backoff = 3;
     private readonly INodeModule _nodeModule;
 
     public CallCirrusGetRawTransactionQueryHandler(INodeModule nodeModule)
@@ -18,6 +22,29 @@ public class CallCirrusGetRawTransactionQueryHandler : IRequestHandler<CallCirru
 
     public async Task<RawTransactionDto> Handle(CallCirrusGetRawTransactionQuery request, CancellationToken cancellationToken)
     {
-        return await _nodeModule.GetRawTransactionAsync(request.TransactionHash, cancellationToken);
+        int attempt = 0;
+        RawTransactionDto rawTransaction = null;
+
+        // Retry up to MaxRetries times with the configured Backoff in seconds in between attempts
+        while (rawTransaction == null && ++attempt <= MaxRetries && !cancellationToken.IsCancellationRequested)
+        {
+            if (attempt > 1) await Task.Delay(TimeSpan.FromSeconds(Backoff), cancellationToken);
+
+            try
+            {
+                rawTransaction = await _nodeModule.GetRawTransactionAsync(request.TransactionHash, cancellationToken);
+            }
+            catch (Exception)
+            {
+                // Nothing to do here, logs may not really be useful
+            }
+        }
+
+        if (rawTransaction == null && request.FindOrThrow)
+        {
+            throw new NotFoundException("Raw transaction not found.");
+        }
+
+        return rawTransaction;
     }
 }

--- a/src/Opdex.Platform.WebApi/Controllers/TransactionsController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/TransactionsController.cs
@@ -61,7 +61,7 @@ public class TransactionsController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> NotifyBroadcasted([FromBody] TransactionBroadcastNotificationRequest request, CancellationToken cancellationToken)
     {
-        var notified = await _mediator.Send(new CreateNotifyUserOfTransactionBroadcastCommand(request.TransactionHash), cancellationToken);
+        var notified = await _mediator.Send(new CreateNotifyUserOfTransactionBroadcastCommand(request.TransactionHash, request.PublicKey), cancellationToken);
         if (!notified) throw new InvalidDataException(nameof(request.TransactionHash), "Invalid transaction state.");
         return NoContent();
     }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionBroadcastNotificationRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionBroadcastNotificationRequest.cs
@@ -12,4 +12,6 @@ public class TransactionBroadcastNotificationRequest
     /// </summary>
     /// <example>402aa2241adb7b04d07d4dbc89f8aae72fa1c11f9bd2bd9013222cd774ed39fe</example>
     public Sha256 TransactionHash { get; set; }
+
+    public Address PublicKey { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionBroadcastNotificationRequest.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/Transactions/TransactionBroadcastNotificationRequest.cs
@@ -13,5 +13,9 @@ public class TransactionBroadcastNotificationRequest
     /// <example>402aa2241adb7b04d07d4dbc89f8aae72fa1c11f9bd2bd9013222cd774ed39fe</example>
     public Sha256 TransactionHash { get; set; }
 
+    /// <summary>
+    /// The transaction sender's public key
+    /// </summary>
+    /// <example>tHYHem7cLKgoLkeb792yn4WayqKzLrjJak</example>
     public Address PublicKey { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Validation/Transactions/TransactionBroadcastNotificationValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Transactions/TransactionBroadcastNotificationValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.Transactions;
+
+namespace Opdex.Platform.WebApi.Validation.Transactions;
+
+public class TransactionBroadcastNotificationValidator : AbstractValidator<TransactionBroadcastNotificationRequest>
+{
+    public TransactionBroadcastNotificationValidator()
+    {
+        RuleFor(request => request.TransactionHash)
+            .NotEmpty().WithMessage("Transaction hash must not be empty.")
+            .NotEqual(new Sha256()).WithMessage("Transaction hash must be valid.");
+
+        RuleFor(request => request.PublicKey)
+            .MustBeNetworkAddress().WithMessage("Public key must be a valid network address.");
+    }
+}

--- a/src/Opdex.Platform.WebApi/Validation/Transactions/TransactionBroadcastNotificationValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/Transactions/TransactionBroadcastNotificationValidator.cs
@@ -1,5 +1,4 @@
 using FluentValidation;
-using Opdex.Platform.Common.Models;
 using Opdex.Platform.WebApi.Models.Requests.Transactions;
 
 namespace Opdex.Platform.WebApi.Validation.Transactions;
@@ -8,10 +7,6 @@ public class TransactionBroadcastNotificationValidator : AbstractValidator<Trans
 {
     public TransactionBroadcastNotificationValidator()
     {
-        RuleFor(request => request.TransactionHash)
-            .NotEmpty().WithMessage("Transaction hash must not be empty.")
-            .NotEqual(new Sha256()).WithMessage("Transaction hash must be valid.");
-
         RuleFor(request => request.PublicKey)
             .MustBeNetworkAddress().WithMessage("Public key must be a valid network address.");
     }

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Transactions/CreateNotifyUserOfTransactionBroadcastCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Transactions/CreateNotifyUserOfTransactionBroadcastCommandHandlerTests.cs
@@ -29,10 +29,11 @@ public class CreateNotifyUserOfTransactionBroadcastCommandHandlerTests
     public async Task Handle_RetrieveTransactionByHashQuery_Send()
     {
         // Arrange
+        var sender = new Address("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh");
         using var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
 
-        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829));
+        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829), sender);
 
         // Act
         await _handler.Handle(request, cancellationToken);
@@ -46,7 +47,8 @@ public class CreateNotifyUserOfTransactionBroadcastCommandHandlerTests
     public async Task Handle_TransactionAlreadyIndexed_DoNotNotify()
     {
         // Arrange
-        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829));
+        var sender = new Address("PFrSHgtz2khDuciJdLAZtR2uKwgyXryMjM");
+        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829), sender);
         var transaction = new Transaction(1, new Sha256(5340958239), 2, 3, "PFrSHgtz2khDuciJdLAZtR2uKwgyXryMjM", "PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", true, null, "PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM");
         _mediatorMock.Setup(callTo =>
                 callTo.Send(It.IsAny<RetrieveTransactionByHashQuery>(), It.IsAny<CancellationToken>()))
@@ -64,13 +66,14 @@ public class CreateNotifyUserOfTransactionBroadcastCommandHandlerTests
     public async Task Handle_RetrieveCirrusUnverifiedTransactionSenderByHashQuery_Send()
     {
         // Arrange
+        var sender = new Address("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh");
         using var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
         _mediatorMock.Setup(callTo =>
                 callTo.Send(It.IsAny<RetrieveTransactionByHashQuery>(), It.IsAny<CancellationToken>()))
                      .ReturnsAsync((Transaction)null);
 
-        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829));
+        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829), sender);
 
         // Act
         await _handler.Handle(request, cancellationToken);
@@ -81,16 +84,18 @@ public class CreateNotifyUserOfTransactionBroadcastCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SenderNotFound_DoNotNotify()
+    public async Task Handle_SenderDoesNotMatchChangeAddress_DoNotNotify()
     {
         // Arrange
+        var sender = new Address("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh");
+        var changeAddress = new Address("PFrSHgtz2khDuciJdLAZtR2uKwgyXryMjM");
         _mediatorMock.Setup(callTo =>
-                callTo.Send(It.IsAny<RetrieveTransactionByHashQuery>(), It.IsAny<CancellationToken>()))
+                                callTo.Send(It.IsAny<RetrieveTransactionByHashQuery>(), It.IsAny<CancellationToken>()))
                      .ReturnsAsync((Transaction)null);
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveCirrusUnverifiedTransactionSenderByHashQuery>(), It.IsAny<CancellationToken>()))
-                     .ReturnsAsync(Address.Empty);
+                     .ReturnsAsync(changeAddress);
 
-        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829));
+        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829), sender);
 
         // Act
         var notified = await _handler.Handle(request, CancellationToken.None);
@@ -115,7 +120,7 @@ public class CreateNotifyUserOfTransactionBroadcastCommandHandlerTests
         _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveCirrusUnverifiedTransactionSenderByHashQuery>(), It.IsAny<CancellationToken>()))
                      .ReturnsAsync(sender);
 
-        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829));
+        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829), sender);
 
         // Act
         var notified = await _handler.Handle(request, cancellationToken);
@@ -124,5 +129,31 @@ public class CreateNotifyUserOfTransactionBroadcastCommandHandlerTests
         notified.Should().Be(true);
         _mediatorMock.Verify(callTo => callTo.Send(It.Is<MakeNotifyUserOfTransactionBroadcastCommand>(
             c => c.User == sender && c.TransactionHash == request.TransactionHash), cancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SenderNotFound_Notify()
+    {
+        // Arrange
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = cancellationTokenSource.Token;
+
+        var sender = new Address("PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh");
+
+        _mediatorMock.Setup(callTo =>
+                                callTo.Send(It.IsAny<RetrieveTransactionByHashQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Transaction)null);
+        _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<RetrieveCirrusUnverifiedTransactionSenderByHashQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Address.Empty);
+
+        var request = new CreateNotifyUserOfTransactionBroadcastCommand(new Sha256(34283925829), sender);
+
+        // Act
+        var notified = await _handler.Handle(request, cancellationToken);
+
+        // Assert
+        notified.Should().Be(true);
+        _mediatorMock.Verify(callTo => callTo.Send(It.Is<MakeNotifyUserOfTransactionBroadcastCommand>(
+                                                       c => c.User == sender && c.TransactionHash == request.TransactionHash), cancellationToken), Times.Once);
     }
 }

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Transactions/TransactionBroadcastNotificationValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Transactions/TransactionBroadcastNotificationValidatorTests.cs
@@ -1,0 +1,56 @@
+using FluentValidation.TestHelper;
+using Opdex.Platform.Common.Models;
+using Opdex.Platform.WebApi.Models.Requests.Transactions;
+using Opdex.Platform.WebApi.Validation.Transactions;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Validation.Transactions;
+
+public class TransactionBroadcastNotificationValidatorTests
+{
+    private readonly TransactionBroadcastNotificationValidator _validator;
+
+    public TransactionBroadcastNotificationValidatorTests()
+    {
+        _validator = new TransactionBroadcastNotificationValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    public void TransactionHash_Invalid(ulong sha)
+    {
+        // Arrange
+        var publicKey = new Address("tVfGTqrToiTU9bfnvD5UDC5ZQVY4oj4jrc");
+        var request = new TransactionBroadcastNotificationRequest
+        {
+            TransactionHash = new Sha256(sha),
+            PublicKey = publicKey
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(request => request.TransactionHash);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("  ")]
+    public void PublicKey_Invalid(string publicKey)
+    {
+        // Arrange
+        var request = new TransactionBroadcastNotificationRequest
+        {
+            TransactionHash = new Sha256(34283925829),
+            PublicKey = publicKey
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(request => request.PublicKey);
+    }
+}

--- a/test/Opdex.Platform.WebApi.Tests/Validation/Transactions/TransactionBroadcastNotificationValidatorTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Validation/Transactions/TransactionBroadcastNotificationValidatorTests.cs
@@ -16,25 +16,6 @@ public class TransactionBroadcastNotificationValidatorTests
     }
 
     [Theory]
-    [InlineData(0)]
-    public void TransactionHash_Invalid(ulong sha)
-    {
-        // Arrange
-        var publicKey = new Address("tVfGTqrToiTU9bfnvD5UDC5ZQVY4oj4jrc");
-        var request = new TransactionBroadcastNotificationRequest
-        {
-            TransactionHash = new Sha256(sha),
-            PublicKey = publicKey
-        };
-
-        // Act
-        var result = _validator.TestValidate(request);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(request => request.TransactionHash);
-    }
-
-    [Theory]
     [InlineData("")]
     [InlineData(null)]
     [InlineData("  ")]


### PR DESCRIPTION
- Checks for raw transaction change address
    - Attempt to find raw transaction, 5 retries, 3 seconds in between, not found after retries throws `NotFoundException`
    - If change address is found, validates the requests public key matches change address
        - On success, notify
        - On failure, don't notify
    - If change address is not found, uses the requests public key for notification

Ultimately a shorter term fix until we work into deserializing the raw transaction in API or via FN, to notify the _actual_ transaction sender.