### PR TITLE
[PAPI-292] Additional Auth Methods

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2767,13 +2767,33 @@ components:
           description: Whether the vote is in favor of the proposal
 paths:
   /auth:
+    get:
+      tags:
+        - Authentication
+      summary: Get Stratis Id
+      description: >
+        Returns a new Stratis Id to sign and authenticate.
+        See the [specification](https://github.com/Opdex/SSAS) for further detail.
+      operationId: getStratisId
+      responses:
+        200:
+          description: Signature was validated successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: sid:test-app.opdex.com/v1/auth?uid=nd0ZT7yrMpLPa207v1uGk0uu9NNcKILgn0HLJXpLQxGKuI9RKnugLdZPz_05a2tX-rCuN0tHM6z3_Qs1yi0Lyg&exp=1643082000
+        429:
+          $ref: "#/components/responses/TooManyRequests"
+        500:
+          $ref: "#/components/responses/InternalServerError"
     post:
       tags:
         - Authentication
       summary: Stratis Signature Auth
       description: >
-        Responds to a request from a Stratis Signature Auth Signer.
-        See the [specification](https://github.com/Opdex/SSAS) for futher detail.
+        Responds to a request from a Stratis Signature Auth signer directly.
+        See the [specification](https://github.com/Opdex/SSAS) for further detail.
       operationId: authenticate
       parameters:
         - name: uid
@@ -2786,6 +2806,71 @@ paths:
         - name: exp
           in: query
           description: Unix timestamp indicating when the signature expires
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+            maximum: 273402300799
+          example: 1641220000
+      requestBody:
+        description: The Stratis Signature Auth body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/stratisSignatureAuthRequest"
+            example:
+              signature: H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc=
+              publicKey: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+      responses:
+        200:
+          description: Signature was validated successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3YWxsZXQiOiJQUFFkZVhkaldEQnpWTFVqZ1d3aTRtRlA0WTFtaHVOY1J1IiwibmJmIjoxNjQzMDgxNzM5LCJleHAiOjE2NDMxNjgxMzcsImlhdCI6MTY0MzA4MTczN30.xjiwjPxzgYbQlP6ON2-Mg3S7m-dWww41FISVXhOGEFY
+        400:
+          description: The request is not valid
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/validationProblemDetails"
+              example:
+                type: https://httpstatuses.com/400
+                title: One or more validation errors occurred.
+                status: 400
+                errors:
+                  exp:
+                    - Expiration date must be a unix timestamp.
+                extensions:
+                  traceId: 00-00000000000000000000000000000000-0000000000000000-00
+        429:
+          $ref: "#/components/responses/TooManyRequests"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+  /auth/callback:
+    post:
+      tags:
+        - Authentication
+      summary: Stratis Signature Auth Callback
+      description: >
+        Responds to a request from a Stratis Signature Auth signer's wallet.
+        See the [specification](https://github.com/Opdex/SSAS) for further detail.
+      operationId: authenticate callback
+      parameters:
+        - name: uid
+          in: query
+          description: Unique identifier for the Stratis ID
+          required: true
+          schema:
+            type: string
+          example: Lf5t5J-oAn3CZ9YY27JnK5XtpbjIOD3BxyvHhd80AQ4fsJ7o0J8i5uSjzHZ9jeS3
+        - name: exp
+          in: query
+          description: Unix timestamp indicating when the signature expires
+          required: true
           schema:
             type: integer
             format: int64

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2777,7 +2777,7 @@ paths:
       operationId: getStratisId
       responses:
         200:
-          description: Signature was validated successfully
+          description: Stratis Id was created
           content:
             text/plain:
               schema:

--- a/src/Opdex.Platform.Infrastructure/Clients/SignalR/PlatformHub.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/SignalR/PlatformHub.cs
@@ -15,7 +15,7 @@ public class PlatformHub : Hub<IPlatformClient>
     public PlatformHub(ITwoWayEncryptionProvider twoWayEncryptionProvider, AuthConfiguration authConfiguration, OpdexConfiguration opdexConfiguration)
     {
         _twoWayEncryptionProvider = twoWayEncryptionProvider ?? throw new ArgumentNullException(nameof(twoWayEncryptionProvider));
-        var created = Uri.TryCreate($"{opdexConfiguration.ApiUrl}/{authConfiguration.StratisSignatureAuth.CallbackPath}", UriKind.Absolute, out var uri);
+        var created = Uri.TryCreate($"{opdexConfiguration.ApiUrl}/{authConfiguration.StratisSignatureAuth.CallbackPath}/callback", UriKind.Absolute, out var uri);
         if (!created) throw new Exception("Unable to create callback URI");
         _authCallback = $"{uri.Authority}{uri.AbsolutePath}";
     }

--- a/src/Opdex.Platform.WebApi/Controllers/AuthController.cs
+++ b/src/Opdex.Platform.WebApi/Controllers/AuthController.cs
@@ -14,7 +14,6 @@ using Opdex.Platform.Common.Encryption;
 using Opdex.Platform.Common.Exceptions;
 using Opdex.Platform.Common.Configurations;
 using Opdex.Platform.Common.Extensions;
-using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using SSAS.NET;
 
@@ -25,35 +24,90 @@ namespace Opdex.Platform.WebApi.Controllers;
 [ApiVersion("1")]
 public class AuthController : ControllerBase
 {
-    private readonly OpdexConfiguration _opdexConfiguration;
     private readonly AuthConfiguration _authConfiguration;
     private readonly ILogger<AuthController> _logger;
     private readonly IMediator _mediator;
     private readonly ITwoWayEncryptionProvider _twoWayEncryptionProvider;
+    private readonly string _baseUri;
 
     public AuthController(OpdexConfiguration opdexConfiguration, AuthConfiguration authConfiguration, ILogger<AuthController> logger,
                           IMediator mediator, ITwoWayEncryptionProvider twoWayEncryptionProvider)
     {
-        _opdexConfiguration = opdexConfiguration ?? throw new ArgumentNullException(nameof(opdexConfiguration));
+        if (opdexConfiguration == null || !opdexConfiguration.ApiUrl.HasValue()) throw new ArgumentNullException(nameof(opdexConfiguration));
         _authConfiguration = authConfiguration ?? throw new ArgumentNullException(nameof(authConfiguration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _twoWayEncryptionProvider = twoWayEncryptionProvider ?? throw new ArgumentNullException(nameof(twoWayEncryptionProvider));
+        _baseUri = $"{opdexConfiguration.ApiUrl}/{_authConfiguration.StratisSignatureAuth.CallbackPath}";
     }
 
     /// <summary>
-    /// Stratis Signature Auth
+    /// Get a new Stratis Id message to sign for authentication without web sockets.
+    /// </summary>
+    /// <returns>Stratis Id</returns>
+    [HttpGet]
+    public ActionResult<string> GetStratisId()
+    {
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds();
+        var uid = Base64Extensions.UrlSafeBase64Encode(_twoWayEncryptionProvider.Encrypt($"{Guid.NewGuid()}{expiry}"));
+        var created = Uri.TryCreate(_baseUri, UriKind.Absolute, out var uri);
+
+        if (!created) throw new Exception("Unable to create callback URI");
+
+        var authCallback = $"{uri.Authority}{uri.AbsolutePath}";
+        var stratisId = new StratisId(authCallback, uid, expiry);
+
+        return Ok(stratisId.ToString());
+    }
+
+    /// <summary>
+    /// Stratis signature auth endpoint for client authentication without web socket.
+    /// </summary>
+    /// <param name="query">The UID and Expiration query parameters.</param>
+    /// <param name="body">The Stratis Id signature.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Bearer token</returns>
+    [HttpPost]
+    public async Task<ActionResult<string>> StratisSignatureAuth([FromQuery] StratisSignatureAuthCallbackQuery query,
+                                                                 [FromBody] StratisSignatureAuthCallbackBody body,
+                                                                 CancellationToken cancellationToken)
+    {
+        var created = Uri.TryCreate(_baseUri, UriKind.Absolute, out var callbackUri);
+
+        if (!created) throw new Exception("Unable to create callback URI");
+
+        (string _, string bearerToken) = await ValidateStratisSignature(callbackUri, query, body, cancellationToken);
+
+        return Ok(bearerToken);
+    }
+
+    /// <summary>
+    /// Stratis signature auth callback for client user authentication with web socket.
     /// </summary>
     /// <remarks>Responds to a request from a Stratis Signature Auth Signer.</remarks>
     /// <param name="query">Tne Stratis Signature Auth query string.</param>
     /// <param name="body">The Stratis Signature Auth body.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     [HttpPost]
+    [Route("callback")]
     public async Task<IActionResult> StratisSignatureAuthCallback([FromQuery] StratisSignatureAuthCallbackQuery query,
-                                                                  [FromBody] StratisSignatureAuthCallbackBody body, CancellationToken cancellationToken)
+                                                                  [FromBody] StratisSignatureAuthCallbackBody body,
+                                                                  CancellationToken cancellationToken)
     {
-        var created = Uri.TryCreate($"{_opdexConfiguration.ApiUrl}/{_authConfiguration.StratisSignatureAuth.CallbackPath}", UriKind.Absolute, out var callbackUri);
+        var created = Uri.TryCreate($"{_baseUri}/callback", UriKind.Absolute, out var callbackUri);
+
         if (!created) throw new Exception("Unable to create callback URI");
+
+        (string connectionId, string bearerToken) = await ValidateStratisSignature(callbackUri, query, body, cancellationToken);
+
+        await _mediator.Send(new NotifyUserOfSuccessfulAuthenticationCommand(connectionId, bearerToken), cancellationToken);
+
+        return NoContent();
+    }
+
+    private async Task<(string, string)> ValidateStratisSignature(Uri callbackUri, StratisSignatureAuthCallbackQuery query,
+                                                                  StratisSignatureAuthCallbackBody body, CancellationToken cancellationToken)
+    {
         var expectedCallbackPath = $"{callbackUri.Authority}{callbackUri.AbsolutePath}";
         var expectedId = new StratisId(expectedCallbackPath, query.Uid, query.Exp);
 
@@ -67,12 +121,13 @@ public class AuthController : ControllerBase
         var tokenDescriptor = new SecurityTokenDescriptor
         {
             Subject = new ClaimsIdentity(),
+            // Todo: This should technically be much lower once refresh tokens are implemented, maybe back to 1 hour.
             Expires = DateTime.UtcNow.AddHours(24),
             IssuedAt = DateTime.UtcNow,
             SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature)
         };
 
-        tokenDescriptor.Subject.AddClaim(new Claim("wallet", body.PublicKey.ToString()));
+        tokenDescriptor.Subject.AddClaim(new Claim("wallet", body.PublicKey));
         var admin = await _mediator.Send(new GetAdminByAddressQuery(body.PublicKey, findOrThrow: false), cancellationToken);
         if (admin != null) tokenDescriptor.Subject.AddClaim(new Claim("admin", "true"));
 
@@ -81,6 +136,7 @@ public class AuthController : ControllerBase
 
         string connectionId;
         long expiration;
+
         try
         {
             var uid = _twoWayEncryptionProvider.Decrypt(Base64Extensions.UrlSafeBase64Decode(expectedId.Uid));
@@ -96,8 +152,6 @@ public class AuthController : ControllerBase
 
         if (expiration != query.Exp) throw new InvalidDataException("exp", "Invalid expiration.");
 
-        await _mediator.Send(new NotifyUserOfSuccessfulAuthenticationCommand(connectionId, bearerToken), cancellationToken);
-
-        return NoContent();
+        return (connectionId, bearerToken);
     }
 }

--- a/test/Opdex.Platform.WebApi.Tests/Controllers/AuthControllerTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Controllers/AuthControllerTests.cs
@@ -75,6 +75,37 @@ public class AuthControllerTests
     }
 
     [Fact]
+    public async Task StratisSignatureAuth_CallCirrusVerifyMessageQuery_Send()
+    {
+        // Arrange
+        var query = new StratisSignatureAuthCallbackQuery
+        {
+            Uid = Guid.NewGuid().ToString(),
+            Exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds()
+        };
+        var body = new StratisSignatureAuthCallbackBody
+        {
+            PublicKey = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV",
+            Signature = "H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc="
+        };
+
+        var cancellationToken = CancellationToken.None;
+        using (var cts = new CancellationTokenSource()) { cancellationToken = cts.Token; }
+
+        // Act
+        try
+        {
+            await _controller.StratisSignatureAuth(query, body, cancellationToken);
+        }
+        catch (Exception) { }
+
+        // Assert
+        _mediatorMock.Verify(callTo => callTo.Send(It.Is<CallCirrusVerifyMessageQuery>(call => call.Message == $"api.opdex.com:44392/auth?uid={query.Uid}&exp={query.Exp}"
+                                                                                               && call.Signer == body.PublicKey
+                                                                                               && call.Signature == body.Signature), cancellationToken), Times.Once);
+    }
+
+    [Fact]
     public async Task StratisSignatureAuthCallback_CallCirrusVerifyMessageQuery_Send()
     {
         // Arrange
@@ -100,9 +131,34 @@ public class AuthControllerTests
         catch (Exception) { }
 
         // Assert
-        _mediatorMock.Verify(callTo => callTo.Send(It.Is<CallCirrusVerifyMessageQuery>(call => call.Message == $"api.opdex.com:44392/auth?uid={query.Uid}&exp={query.Exp}"
+        _mediatorMock.Verify(callTo => callTo.Send(It.Is<CallCirrusVerifyMessageQuery>(call => call.Message == $"api.opdex.com:44392/auth/callback?uid={query.Uid}&exp={query.Exp}"
                                                                                                && call.Signer == body.PublicKey
                                                                                                && call.Signature == body.Signature), cancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task StratisSignatureAuth_InvalidSignature_ThrowInvalidDataException()
+    {
+        // Arrange
+        var query = new StratisSignatureAuthCallbackQuery
+        {
+            Uid = Guid.NewGuid().ToString(),
+            Exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds()
+        };
+        var body = new StratisSignatureAuthCallbackBody
+        {
+            PublicKey = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV",
+            Signature = "H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc="
+        };
+
+        _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<CallCirrusVerifyMessageQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        // Act
+        Task Act() => _controller.StratisSignatureAuth(query, body, CancellationToken.None);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(Act);
+        exception.PropertyName.Should().Be("signature");
     }
 
     [Fact]
@@ -131,6 +187,33 @@ public class AuthControllerTests
     }
 
     [Fact]
+    public async Task StratisSignatureAuth_Uid_Decrypt()
+    {
+        // Arrange
+        var query = new StratisSignatureAuthCallbackQuery
+        {
+            Uid = Guid.NewGuid().ToString(),
+            Exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds()
+        };
+        var body = new StratisSignatureAuthCallbackBody
+        {
+            PublicKey = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV",
+            Signature = "H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc="
+        };
+
+        var connectionId = "CONNECTION_ID";
+        _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<CallCirrusVerifyMessageQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _fakeTwoWayEncryptionProvider.WhenDecryptCalled(() => $"{connectionId}{query.Exp}");
+
+        // Act
+        await _controller.StratisSignatureAuth(query, body, CancellationToken.None);
+
+        // Assert
+        _fakeTwoWayEncryptionProvider.DecryptCalls.Count.Should().Be(1);
+        _fakeTwoWayEncryptionProvider.DecryptCalls.Dequeue().Should().BeEquivalentTo(Base64Extensions.UrlSafeBase64Decode(query.Uid).ToArray());
+    }
+
+    [Fact]
     public async Task StratisSignatureAuthCallback_Uid_Decrypt()
     {
         // Arrange
@@ -155,6 +238,32 @@ public class AuthControllerTests
         // Assert
         _fakeTwoWayEncryptionProvider.DecryptCalls.Count.Should().Be(1);
         _fakeTwoWayEncryptionProvider.DecryptCalls.Dequeue().Should().BeEquivalentTo(Base64Extensions.UrlSafeBase64Decode(query.Uid).ToArray());
+    }
+
+    [Fact]
+    public async Task StratisSignatureAuth_DecryptionError_ThrowInvalidDataException()
+    {
+        // Arrange
+        var query = new StratisSignatureAuthCallbackQuery
+        {
+            Uid = Guid.NewGuid().ToString(),
+            Exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds()
+        };
+        var body = new StratisSignatureAuthCallbackBody
+        {
+            PublicKey = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV",
+            Signature = "H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc="
+        };
+
+        _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<CallCirrusVerifyMessageQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _fakeTwoWayEncryptionProvider.WhenDecryptCalled(() => throw new CryptographicException("Invalid key."));
+
+        // Act
+        Task Act() => _controller.StratisSignatureAuth(query, body, CancellationToken.None);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(Act);
+        exception.PropertyName.Should().Be("uid");
     }
 
     [Fact]
@@ -215,6 +324,32 @@ public class AuthControllerTests
     }
 
     [Fact]
+    public async Task StratisSignatureAuth_InvalidExp_ThrowInvalidDataException()
+    {
+        // Arrange
+        var query = new StratisSignatureAuthCallbackQuery
+        {
+            Uid = Guid.NewGuid().ToString(),
+            Exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds()
+        };
+        var body = new StratisSignatureAuthCallbackBody
+        {
+            PublicKey = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV",
+            Signature = "H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc="
+        };
+
+        var connectionId = "CONNECTION_ID";
+        _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<CallCirrusVerifyMessageQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _fakeTwoWayEncryptionProvider.WhenDecryptCalled(() => $"{connectionId}{query.Exp + 1}");
+
+        // Act
+        await _controller
+            .Invoking(c => c.StratisSignatureAuth(query, body, CancellationToken.None))
+            .Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*Invalid expiration.*");
+    }
+
+    [Fact]
     public async Task StratisSignatureAuthCallback_InvalidExp_ThrowInvalidDataException()
     {
         // Arrange
@@ -238,6 +373,34 @@ public class AuthControllerTests
             .Invoking(c => c.StratisSignatureAuthCallback(query, body, CancellationToken.None))
             .Should().ThrowAsync<InvalidDataException>()
             .WithMessage("*Invalid expiration.*");
+    }
+
+    [Fact]
+    public async Task StratisSignatureAuth_OnSuccess_ReturnsJwt()
+    {
+        // Arrange
+        var query = new StratisSignatureAuthCallbackQuery
+        {
+            Uid = Guid.NewGuid().ToString(),
+            Exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds()
+        };
+        var body = new StratisSignatureAuthCallbackBody
+        {
+            PublicKey = "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV",
+            Signature = "H9xjfnvqucCmi3sfEKUes0qL4mD9PrZ/al78+Ka440t6WH5Qh0AIgl5YlxPa2cyuXdwwDa2OYUWR/0ocL6jRZLc="
+        };
+
+        var connectionId = "CONNECTION_ID";
+
+        _mediatorMock.Setup(callTo => callTo.Send(It.IsAny<CallCirrusVerifyMessageQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _fakeTwoWayEncryptionProvider.WhenDecryptCalled(() => $"{connectionId}{query.Exp}");
+
+        // Act
+        var response = await _controller.StratisSignatureAuth(query, body, CancellationToken.None);
+
+        // Assert
+        response.Result.Should().BeOfType<OkObjectResult>();
+        ((OkObjectResult)response.Result).Value.Should().NotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
- Adds **GET** `/auth` endpoint to get a new StratisId to sign
- Migrated **POST** `/auth` to **POST** `/auth/callback` for default SSAS flows with sockets
- Adjusts **POST** `/auth` to validate signatures and return JWT directly

---

The additional endpoints provide a way for API based clients to authenticate themselves rather than their users such as within Postman, or a bot based API for example for retrieving transaction quotes and acting upon the results.

Naming probably could be better, the new auth routes could add `Direct` to the naming and the socket based flows `Socket` or `Callback` etc. or leave as is. More of a nit, but could clarify the differences more for clients.