### PR TITLE
[PAPI-336] Inject Swagger Configi

### DIFF
--- a/docs/openapi.js
+++ b/docs/openapi.js
@@ -4,6 +4,7 @@ function setSwaggerUI() {
     const domainOrigin = window.location.origin;
 
     // this is a full override of Swagger UI
+    // Docs: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
     window.ui = new SwaggerUIBundle({
         urls: [{ url: `${domainOrigin}/swagger/v1/openapi.yml`, name: 'Opdex Platform API V1' }],
         dom_id: '#swagger-ui',

--- a/docs/openapi.js
+++ b/docs/openapi.js
@@ -1,41 +1,46 @@
-// (function() {
-//     const checkExists = setInterval(function() {
-//         const servers = document.getElementsByClassName('servers');
-//
-//         if (!!servers && servers.length > 0) {
-//             const server = servers[0];
-//             replaceServerRoutes(server);
-//             clearInterval(checkExists);
-//         }
-//     }, 100);
-// })();
-//
-// // Find and replace server routes from default to the hosted domain of the current swagger instance
-// function replaceServerRoutes(server) {
-//     const domain = new URL(document.location.href);
-//     const domainReplacement = `${domain.origin}/v1`;
-//
-//     // Loop through each server
-//     for(let i = 0; i < server.childNodes.length; i++) {
-//         const serverLabel = server.childNodes[i];
-//
-//         // Loop through each server label
-//         if (serverLabel.childNodes.length) {
-//             for(let j = 0; j < serverLabel.childNodes.length; j++) {
-//                 const serverLabelSelect = serverLabel.childNodes[j];
-//                 serverLabelSelect.value = domainReplacement;
-//
-//                 // Loop through each server label's select dropdown (should only have 1)
-//                 for(let t = 0; t < serverLabelSelect.childNodes.length; t++) {
-//                     const severLabelSelectOption = serverLabelSelect.childNodes[j];
-//
-//                     // Loop through each select option and change to the current host
-//                     if (!severLabelSelectOption.value.includes(domainReplacement)) {
-//                         severLabelSelectOption.value = domainReplacement;
-//                         severLabelSelectOption.text = domainReplacement;
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
+window.addEventListener('load', () => setTimeout(setSwaggerUI, 100));
+
+function setSwaggerUI() {
+    const domainOrigin = window.location.origin;
+
+    // this is a full override of Swagger UI
+    window.ui = new SwaggerUIBundle({
+        urls: [{ url: `${domainOrigin}/swagger/v1/openapi.yml`, name: 'Opdex Platform API V1' }],
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        requestInterceptor: function (request) {
+            // request interceptor
+            // add custom headers here
+            return request;
+        },
+        onComplete: function () {
+            // on complete callback
+        },
+        presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+        ],
+        plugins: [
+            SwaggerUIBundle.plugins.DownloadUrl,
+
+            // Custom plugin that replaces the server list with the current url
+            function () {
+                return {
+                    statePlugins: {
+                        spec: {
+                            wrapActions: {
+                                updateJsonSpec: function (oriAction, system) {
+                                    return (spec) => {
+                                        spec.servers = [{url: `${domainOrigin}/v1`}]
+                                        return oriAction(spec)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        layout: "StandaloneLayout",
+    });
+}

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -10,7 +10,7 @@ info:
     name: MIT
     url: https://github.com/Opdex/opdex-v1-api/blob/main/LICENSE
 servers:
-  - url: /v1
+  - url: https://v1-test-api.opdex.com/v1
 tags:
   - name: Authentication
     description: Authenticate with the API

--- a/src/Opdex.Platform.WebApi/Startup.cs
+++ b/src/Opdex.Platform.WebApi/Startup.cs
@@ -275,16 +275,12 @@ public class Startup
             RequestPath = "/swagger/v1"
         });
 
-        // var url = Configuration["OpdexConfiguration:ApiUrl"];
-        // var requestInterceptor = @$"(request) => {{ if (!request.url.includes('swagger')) {{ var parts = request.url.split('/v1/'); request.url = '{url}/' + parts[1]; }} return request; }}";
-
         app.UseSwaggerUI(options =>
         {
             options.RoutePrefix = "swagger";
-            options.SwaggerEndpoint("v1/openapi.yml", "Opdex Platform API V1");
-            // options.UseRequestInterceptor(requestInterceptor);
-            // options.InjectJavascript("v1/openapi.js");
+            options.InjectJavascript("v1/openapi.js");
         });
+
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapHub<PlatformHub>("/v1/socket");


### PR DESCRIPTION
Inject swagger config within a JS file allowing for dynamic server urls when running the project vs static server urls within `openapi.yml`.

Now swagger environments will load correctly and openapi.yml imports default to testnet