### PR TITLE
[PAPI-342] Return Created and Modified block numbers in API responses

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1857,6 +1857,16 @@ components:
         tokens:
           $ref: "#/components/schemas/liquidityPoolTokenBreakdown"
           description: Breakdown of tokens tied to the pool
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
         summary:
           $ref: "#/components/schemas/liquidityPoolSummary"
     liquidityPoolTokenBreakdown:
@@ -1881,6 +1891,11 @@ components:
           $ref: "#/components/schemas/costSummary"
         staking:
           $ref: "#/components/schemas/liquidityPoolStakingSummary"
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     reservesSummary:
       type: object
       properties:
@@ -2061,6 +2076,16 @@ components:
           minimum: 0.0
           maximum: 1.0
           description: Percentage fee for a trade
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
         summary:
           $ref: "#/components/schemas/marketSummary"
           description: Financial summary for the market
@@ -2085,6 +2110,11 @@ components:
         rewards:
           $ref: "#/components/schemas/rewardSummary"
           description: Rewards summary
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     marketStakingSummary:
       type: object
       properties:
@@ -2176,6 +2206,16 @@ components:
         isActive:
           type: boolean
           description: True if liquidity mining is active, otherwise false
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     marketSnapshotsResponse:
       type: object
       properties:
@@ -2263,9 +2303,19 @@ components:
           items:
             $ref: "#/components/schemas/tokenAttribute"
           description: Attributes applied to the token
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
         summary:
-          $ref: "#/components/schemas/tokenSummaryResponse"
-    tokenSummaryResponse:
+          $ref: "#/components/schemas/tokenSummary"
+    tokenSummary:
       type: object
       description: Point in time pricing summary for a token
       properties:
@@ -2592,6 +2642,16 @@ components:
         minedToken:
           $ref: "#/components/schemas/address"
           description: Address of governance token that is mined
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     indexerStatusResponse:
       type: object
       description: Status of the Opdex transaction indexer
@@ -2667,6 +2727,16 @@ components:
           format: uint64
           minimum: 0
           description: Number of blocks that a certificate is vested for, before it can be redeemed
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     certificatesResponse:
       type: object
       properties:
@@ -2708,6 +2778,16 @@ components:
             type: integer
             format: uint64
             minimum: 1
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     pledgesResponse:
       type: object
       properties:
@@ -2737,6 +2817,16 @@ components:
         balance:
           $ref: "#/components/schemas/fixedDecimal"
           description: Currently pledged CRS balance
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     proposalsResponse:
       type: object
       properties:
@@ -2796,9 +2886,16 @@ components:
         approved:
           type: boolean
           description: Whether the proposal has been approved
-        certificate:
-          $ref: "#/components/schemas/certificateResponse"
-          description: The certificate either created or revoked by the proposal, if it exists
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     votesResponse:
       type: object
       properties:
@@ -2831,6 +2928,16 @@ components:
         inFavor:
           type: boolean
           description: Whether the vote is in favor of the proposal
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
 paths:
   /auth:
     get:
@@ -3150,8 +3257,8 @@ paths:
               $ref: "#/components/schemas/address"
               description: Address of a liquidity pool
           example:
-            - tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
-            - tLrMcU1csbN7RxGjBMEnJeLoae3PxmQ9cr
+            - tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
+            - tFCyMPURX9pVWXuXQqYY2hJmRcCrhmBPfY
         - name: tokens
           in: query
           description: Addresses of SRC tokens paired in pools
@@ -3221,14 +3328,6 @@ paths:
                     name: TBTC-TCRS
                     transactionFeePercent: 0.3
                     market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                    miningPool:
-                      address: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
-                      liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
-                      miningPeriodEndBlock: 0
-                      rewardPerBlock: "0.00000000"
-                      rewardPerLpt: "0.00000000"
-                      tokensMining: "4.14831968"
-                      isActive: false
                     tokens:
                       crs:
                         address: CRS
@@ -3238,10 +3337,12 @@ paths:
                         sats: 100000000
                         totalSupply: "100000000.00000000"
                         attributes: []
-                        summmary:
-                          priceUsd: 1.36598319
-                          dailyPriceChangePercent: 0.00000000
-                          modifiedBlock: 2988890
+                        createdBlock: 2988890
+                        modifiedBlock: 2988890
+                        summary:
+                          priceUsd: 0.95057037
+                          dailyPriceChangePercent: 0.63000000
+                          modifiedBlock: 3043278
                       src:
                         address: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
                         name: Bitcoin (Wrapped)
@@ -3251,10 +3352,12 @@ paths:
                         totalSupply: "21000000.00000000"
                         attributes:
                           - NonProvisional
-                        summmary:
-                          priceUsd: 42633.71834591
-                          dailyPriceChangePercent: -0.04000000
-                          modifiedBlock: 2991118
+                        createdBlock: 2988918
+                        modifiedBlock: 2988918
+                        summary:
+                          priceUsd: 27698.36556351
+                          dailyPriceChangePercent: 0.21000000
+                          modifiedBlock: 3043250
                       lp:
                         address: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                         name: Opdex Liquidity Pool Token
@@ -3264,10 +3367,22 @@ paths:
                         totalSupply: "94.39473361"
                         attributes:
                           - Provisional
-                        summmary:
-                          priceUsd: 482.64677779
-                          dailyPriceChangePercent: -0.02000000
-                          modifiedBlock: 2991118
+                        createdBlock: 2988918
+                        modifiedBlock: 2989382
+                        summary:
+                          priceUsd: 323.92670749
+                          dailyPriceChangePercent: 0.21000000
+                          modifiedBlock: 3043250
+                    miningPool:
+                      address: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
+                      liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
+                      miningPeriodEndBlock: 0
+                      rewardPerBlock: "0.00000000"
+                      rewardPerLpt: "0.00000000"
+                      tokensMining: "4.14831968"
+                      isActive: false
+                      createdBlock: 2988918
+                      modifiedBlock: 2992621
                     summary:
                       reserves:
                         crs: "16676.38165376"
@@ -3296,14 +3411,17 @@ paths:
                           attributes:
                             - NonProvisional
                             - Staking
+                          createdBlock: 2988890
+                          modifiedBlock: 2989018
                           summary:
                             priceUsd: 0.00000000
                             dailyPriceChangePercent: 0.00000000
-                            modifiedBlock: 2989456
+                            modifiedBlock: 3043278
                         weight: "0.00000000"
                         usd: 0.00000000
                         dailyWeightChangePercent: 0.00000000
                         nominated: true
+                      modifiedBlock: 3043296
                 paging: {}
         400:
           description: The request is not valid
@@ -3400,7 +3518,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       responses:
         200:
           description: Liquidity pool found
@@ -3413,14 +3531,6 @@ paths:
                 name: TBTC-TCRS
                 transactionFeePercent: 0.3
                 market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                miningPool:
-                  address: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
-                  liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
-                  miningPeriodEndBlock: 0
-                  rewardPerBlock: "0.00000000"
-                  rewardPerLpt: "0.00000000"
-                  tokensMining: "4.14831968"
-                  isActive: false
                 tokens:
                   crs:
                     address: CRS
@@ -3430,10 +3540,12 @@ paths:
                     sats: 100000000
                     totalSupply: "100000000.00000000"
                     attributes: []
-                    summmary:
-                      priceUsd: 1.36598319
-                      dailyPriceChangePercent: 0.00000000
-                      modifiedBlock: 2988890
+                    createdBlock: 2988890
+                    modifiedBlock: 2988890
+                    summary:
+                      priceUsd: 0.95057037
+                      dailyPriceChangePercent: 0.63000000
+                      modifiedBlock: 3043278
                   src:
                     address: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
                     name: Bitcoin (Wrapped)
@@ -3443,10 +3555,12 @@ paths:
                     totalSupply: "21000000.00000000"
                     attributes:
                       - NonProvisional
-                    summmary:
-                      priceUsd: 42633.71834591
-                      dailyPriceChangePercent: -0.04000000
-                      modifiedBlock: 2991118
+                    createdBlock: 2988918
+                    modifiedBlock: 2988918
+                    summary:
+                      priceUsd: 27698.36556351
+                      dailyPriceChangePercent: 0.21000000
+                      modifiedBlock: 3043250
                   lp:
                     address: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                     name: Opdex Liquidity Pool Token
@@ -3456,10 +3570,22 @@ paths:
                     totalSupply: "94.39473361"
                     attributes:
                       - Provisional
-                    summmary:
-                      priceUsd: 482.64677779
-                      dailyPriceChangePercent: -0.02000000
-                      modifiedBlock: 2991118
+                    createdBlock: 2988918
+                    modifiedBlock: 2989382
+                    summary:
+                      priceUsd: 323.92670749
+                      dailyPriceChangePercent: 0.21000000
+                      modifiedBlock: 3043250
+                miningPool:
+                  address: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
+                  liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
+                  miningPeriodEndBlock: 0
+                  rewardPerBlock: "0.00000000"
+                  rewardPerLpt: "0.00000000"
+                  tokensMining: "4.14831968"
+                  isActive: false
+                  createdBlock: 2988918
+                  modifiedBlock: 2992621
                 summary:
                   reserves:
                     crs: "16676.38165376"
@@ -3488,14 +3614,17 @@ paths:
                       attributes:
                         - NonProvisional
                         - Staking
+                      createdBlock: 2988890
+                      modifiedBlock: 2989018
                       summary:
                         priceUsd: 0.00000000
                         dailyPriceChangePercent: 0.00000000
-                        modifiedBlock: 2989456
+                        modifiedBlock: 3043278
                     weight: "0.00000000"
                     usd: 0.00000000
                     dailyWeightChangePercent: 0.00000000
                     nominated: true
+                  modifiedBlock: 3043296
         400:
           description: The request is not valid
           content:
@@ -3531,7 +3660,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
         - name: interval
           in: query
           description: Time range between each snapshot
@@ -3716,7 +3845,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       requestBody:
         required: true
         content:
@@ -3823,7 +3952,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       requestBody:
         required: true
         content:
@@ -3877,7 +4006,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       requestBody:
         required: true
         content:
@@ -3988,7 +4117,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       security:
         - opdexAuth: []
       responses:
@@ -4045,7 +4174,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       requestBody:
         required: true
         content:
@@ -4118,7 +4247,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       requestBody:
         required: true
         content:
@@ -4188,7 +4317,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       requestBody:
         required: true
         content:
@@ -4261,7 +4390,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/address"
-          example: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+          example: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
       security:
         - opdexAuth: []
       requestBody:
@@ -4378,6 +4507,13 @@ paths:
                       decimals: 8
                       sats: 100000000
                       totalSupply: "130000000.00000000"
+                      attributes: []
+                      createdBlock: 2988890
+                      modifiedBlock: 2988890
+                      summary:
+                        priceUsd: 0.95057037
+                        dailyPriceChangePercent: 0.63000000
+                        modifiedBlock: 3043278
                     stakingToken:
                       address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
                       name: Testnet Opdex Token
@@ -4385,6 +4521,17 @@ paths:
                       decimals: 8
                       sats: 100000000
                       totalSupply: "40000000000000000.00000000"
+                      attributes:
+                        - NonProvisional
+                        - Staking
+                      createdBlock: 2988890
+                      modifiedBlock: 2989018
+                      summary:
+                        priceUsd: 0.00000000
+                        dailyPriceChangePercent: 0.00000000
+                        modifiedBlock: 3043278
+                    createdBlock: 2988898
+                    modifiedBlock: 2988898
                     summary:
                       liquidityUsd: 2490080.59003948
                       dailyLiquidityUsdChangePercent: 4.32891108
@@ -4398,6 +4545,7 @@ paths:
                         providerDailyUsd: 1205.00639582
                         marketDailyUsd: 241.00127916
                         totalDailyUsd: 1446.00767498
+                      modifiedBlock: 3042951
                 paging: {}
         400:
           description: The request is not valid
@@ -4456,6 +4604,13 @@ paths:
                   decimals: 8
                   sats: 100000000
                   totalSupply: "130000000.00000000"
+                  attributes: []
+                  createdBlock: 2988890
+                  modifiedBlock: 2988890
+                  summary:
+                    priceUsd: 0.95057037
+                    dailyPriceChangePercent: 0.63000000
+                    modifiedBlock: 3043278
                 stakingToken:
                   address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
                   name: Testnet Opdex Token
@@ -4463,6 +4618,17 @@ paths:
                   decimals: 8
                   sats: 100000000
                   totalSupply: "40000000000000000.00000000"
+                  attributes:
+                    - NonProvisional
+                    - Staking
+                  createdBlock: 2988890
+                  modifiedBlock: 2989018
+                  summary:
+                    priceUsd: 0.00000000
+                    dailyPriceChangePercent: 0.00000000
+                    modifiedBlock: 3043278
+                createdBlock: 2988898
+                modifiedBlock: 2988898
                 summary:
                   liquidityUsd: 2490080.59003948
                   dailyLiquidityUsdChangePercent: 4.32891108
@@ -4476,6 +4642,7 @@ paths:
                     providerDailyUsd: 1205.00639582
                     marketDailyUsd: 241.00127916
                     totalDailyUsd: 1446.00767498
+                  modifiedBlock: 3042951
         400:
           description: The request is not valid
           content:
@@ -5201,7 +5368,7 @@ paths:
               example:
                 results:
                   - market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                    liqudityPool: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+                    liqudityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                     address: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
                     name: Bitcoin (Wrapped)
                     symbol: TBTC
@@ -5210,12 +5377,14 @@ paths:
                     totalSupply: "21000000.00000000"
                     attributes:
                       - NonProvisional
+                    createdBlock: 2988918
+                    modifiedBlock: 2988918
                     summary:
-                      priceUsd: 54827.48328399
-                      dailyPriceChangePercent: 2.42090338
-                      modifiedBlock: 2963822
+                      priceUsd: 27852.57795481
+                      dailyPriceChangePercent: 0.77000000
+                      modifiedBlock: 3043250
                   - market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                    liqudityPool: tLrMcU1csbN7RxGjBMEnJeLoae3PxmQ9cr
+                    liqudityPool: tFCyMPURX9pVWXuXQqYY2hJmRcCrhmBPfY
                     address: tF83sdXXt2nTkL7UyEYDVFMK4jTuYMbmR3
                     name: ETH (Wrapped)
                     symbol: TETH
@@ -5224,12 +5393,14 @@ paths:
                     totalSupply: "100000000.000000000000000000"
                     attributes:
                       - NonProvisional
+                    createdBlock: 2988919
+                    modifiedBlock: 2988919
                     summary:
-                      priceUsd: 3822.23819994
-                      dailyPriceChangePercent: 1.98192833
-                      modifiedBlock: 2963691
+                      priceUsd: 2294.33407690
+                      dailyPriceChangePercent: 0.77000000
+                      modifiedBlock: 3043250
                 paging:
-                  next: ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MTA7cGFnaW5nOkZvcndhcmQ7cHJvdmlzaW9uYWw6QWxsO2tleXdvcmQ6O29yZGVyQnk6UHJpY2VVc2Q7cG9pbnRlcjpLREF1TkRBMk1ETXpPREFzSURRcDs=
+                  next: ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDt0b2tlbkF0dHJpYnV0ZXM6Tm9uUHJvdmlzaW9uYWw7aW5jbHVkZVplcm9MaXF1aWRpdHk6VHJ1ZTtrZXl3b3JkOjtvcmRlckJ5OlByaWNlVXNkO3BvaW50ZXI6S0RJeU56UXVOVFkxTmprM09EUXNJRFlwOw==
         400:
           description: The request is not valid
           content:
@@ -5282,7 +5453,7 @@ paths:
                 $ref: "#/components/schemas/marketTokenResponse"
               example:
                 market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                liqudityPool: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+                liqudityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                 address: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
                 name: Bitcoin (Wrapped)
                 symbol: TBTC
@@ -5291,10 +5462,12 @@ paths:
                 totalSupply: "21000000.00000000"
                 attributes:
                   - NonProvisional
+                createdBlock: 2988918
+                modifiedBlock: 2988918
                 summary:
-                  priceUsd: 54827.48328399
-                  dailyPriceChangePercent: 2.42580923
-                  modifiedBlock: 2963822
+                  priceUsd: 27852.57795481
+                  dailyPriceChangePercent: 0.77000000
+                  modifiedBlock: 3043250
         400:
           description: The request is not valid
           content:
@@ -5488,7 +5661,7 @@ paths:
                 gasUsed: 60139
                 events:
                   - from: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-                    to: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+                    to: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                     amount: "0.00250000"
                     eventType: TransferEvent
                     contract: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
@@ -5501,7 +5674,7 @@ paths:
                     amountSrcOut: "0.00000000"
                     srcToken: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
                     eventType: SwapEvent
-                    contract: tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L
+                    contract: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                     sortOrder: 2
                 request:
                   sender: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
@@ -5715,6 +5888,8 @@ paths:
                     miningPoolRewardPerPeriod: "6250000.00000000"
                     totalRewardsPerPeriod: "25000000.00000000"
                     minedToken: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                    createdBlock: 2988890
+                    modifiedBlock: 2989018
                 paging: {}
         400:
           description: The request is not valid
@@ -5767,6 +5942,8 @@ paths:
                 miningPoolRewardPerPeriod: "6250000.00000000"
                 totalRewardsPerPeriod: "25000000.00000000"
                 minedToken: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                createdBlock: 2988890
+                modifiedBlock: 2989018
         400:
           description: The request is not valid
           content:
@@ -5914,6 +6091,8 @@ paths:
                     rewardPerLpt: "0.00000000"
                     tokensMining: "0.00000000"
                     isActive: false
+                    createdBlock: 2991252
+                    modifiedBlock: 2991252
                   - address: tJL3GQFf2xupWKvgXHuQBuMiAuutLs3Q4j
                     liquidityPool: tCE8LfkCj9HJUZu3dtgERNFfquMVJVe4sh
                     miningPeriodEndBlock: 0
@@ -5921,6 +6100,8 @@ paths:
                     rewardPerLpt: "0.00000000"
                     tokensMining: "0.00000000"
                     isActive: false
+                    createdBlock: 2988927
+                    modifiedBlock: 2988927
                   - address: t9V19aoUakGooM8hXDCrR52NmTS7ZnmN31
                     liquidityPool: tCorSgPVt6pF5Q4gzcrZWDZ8f7ERVxhwAd
                     miningPeriodEndBlock: 0
@@ -5928,6 +6109,8 @@ paths:
                     rewardPerLpt: "0.00000000"
                     tokensMining: "2314.82289849"
                     isActive: false
+                    createdBlock: 2988925
+                    modifiedBlock: 2992615
                 paging: {}
         400:
           description: The request is not valid
@@ -5978,6 +6161,8 @@ paths:
                 rewardPerLpt: "0.00000000"
                 tokensMining: "8.80764531"
                 isActive: false
+                createdBlock: 2988918
+                modifiedBlock: 2992621
         400:
           description: The request is not valid
           content:
@@ -6312,10 +6497,12 @@ paths:
                     totalSupply: "21000000.00000000"
                     attributes:
                       - NonProvisional
+                    createdBlock: 2988918
+                    modifiedBlock: 2988918
                     summary:
-                      priceUsd: 54911.53361129
-                      dailyPriceChangePercent: 2.37290288
-                      modifiedBlock: 2963825
+                      priceUsd: 27852.57795481
+                      dailyPriceChangePercent: 0.77000000
+                      modifiedBlock: 3043250
                   - address: tF83sdXXt2nTkL7UyEYDVFMK4jTuYMbmR3
                     name: ETH (Wrapped)
                     symbol: TETH
@@ -6324,12 +6511,14 @@ paths:
                     totalSupply: "100000000.000000000000000000"
                     attributes:
                       - NonProvisional
+                    createdBlock: 2988919
+                    modifiedBlock: 2988919
                     summary:
-                      priceUsd: 3827.34621953
-                      dailyPriceChangePercent: 2.01006408
-                      modifiedBlock: 2963712
+                      priceUsd: 2294.33407690
+                      dailyPriceChangePercent: 0.77000000
+                      modifiedBlock: 3043250
                 paging:
-                  next: ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MTA7cGFnaW5nOkZvcndhcmQ7cHJvdmlzaW9uYWw6QWxsO2tleXdvcmQ6O29yZGVyQnk6UHJpY2VVc2Q7cG9pbnRlcjpLREF1TkRBMk1ETXpPREFzSURRcDs=
+                  next: ZGlyZWN0aW9uOkRFU0M7bGltaXQ6MjtwYWdpbmc6Rm9yd2FyZDt0b2tlbkF0dHJpYnV0ZXM6Tm9uUHJvdmlzaW9uYWw7aW5jbHVkZVplcm9MaXF1aWRpdHk6VHJ1ZTtrZXl3b3JkOjtvcmRlckJ5OlByaWNlVXNkO3BvaW50ZXI6S0RFeE16Y3VNamd5T0RRNE9USXNJRFlwOw==
         400:
           description: The request is not valid
           content:
@@ -6446,10 +6635,12 @@ paths:
                 totalSupply: "21000000.00000000"
                 attributes:
                   - NonProvisional
+                createdBlock: 2988918
+                modifiedBlock: 2988918
                 summary:
-                  priceUsd: 54911.53361129
-                  dailyPriceChangePercent: 2.37290288
-                  modifiedBlock: 2963825
+                  priceUsd: 27852.57795481
+                  dailyPriceChangePercent: 0.77000000
+                  modifiedBlock: 3043250
         400:
           description: The request is not valid
           content:
@@ -7141,6 +7332,8 @@ paths:
                     totalPledgeMinimum: "1000.00000000"
                     totalVoteMinimum: "2000.00000000"
                     vestingDuration: 1080000
+                    createdBlock: 2988890
+                    modifiedBlock: 3012470
                 paging: {}
         400:
           description: The request is not valid
@@ -7192,6 +7385,8 @@ paths:
                 totalPledgeMinimum: "1000.00000000"
                 totalVoteMinimum: "2000.00000000"
                 vestingDuration: 1080000
+                createdBlock: 2988890
+                modifiedBlock: 3012470
         400:
           description: The request is not valid
           content:
@@ -7279,6 +7474,8 @@ paths:
                     vestingEndBlock: 1905020
                     redeemed: false
                     revoked: false
+                    createdBlock: 3012470
+                    modifiedBlock: 3012470
                     proposals:
                       - 1
                 paging: {}
@@ -7434,11 +7631,15 @@ paths:
                     pledger: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                     pledge: "2000.00000000"
                     balance: "2000.00000000"
+                    createdBlock: 3965259
+                    modifiedBlock: 3965259
                   - vault: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
                     proposalId: 1
                     pledger: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                     pledge: "10000.00000000"
                     balance: "10000.00000000"
+                    createdBlock: 3012570
+                    modifiedBlock: 3012570
                 paging: {}
         400:
           description: The request is not valid
@@ -7527,31 +7728,35 @@ paths:
                   - vault: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
                     token: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
                     proposalId: 2
-                    creator: tTJuvSKZ7bMJwKNmC6vGYyVQUPUpiPTW5p
-                    wallet: tEtBQhXDFo5yWR1WizqXSbrZzMq6sBmhSU
-                    amount: "100000.00000000"
-                    description: "OVP-2: This person should have their certificate revoked."
+                    creator: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+                    wallet: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+                    amount: "50000.00000000"
+                    description: "OVP-2: Request to revoke certificate. As the recipient, I wish to revoke this certificate."
                     type: Revoke
-                    status: Complete
-                    expiration: 1025889
-                    yesAmount: "15000.34338002"
-                    noAmount: "37900.00009881"
-                    pledgeAmount: "10200.00540309"
+                    status: Pledge
+                    expiration: 3081041
+                    yesAmount: "0.00000000"
+                    noAmount: "0.00000000"
+                    pledgeAmount: "0.00000000"
                     approved: false
+                    createdBlock: 3043241
+                    modifiedBlock: 3043241
                   - vault: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
                     token: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
                     proposalId: 1
-                    creator: tJyppxPeKs9rbsidSi3pqCYitkdGYjo57r
-                    wallet: tEtBQhXDFo5yWR1WizqXSbrZzMq6sBmhSU
-                    amount: "5000000.00000000"
-                    description: "OVP-1: Request for certificate. View details at: https://example.com."
+                    creator: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+                    wallet: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+                    amount: "50000.00000000"
+                    description: "OVP-1: Request for a 50000 TODX certificate. See ipfs:QmPYH5K4q3WphaRMe7zv6196NryXgj5m7uY53Jkgym2ube for details."
                     type: Create
                     status: Complete
-                    expiration: 945889
-                    yesAmount: "200600.4932824"
-                    noAmount: "17534.53831111"
+                    expiration: 3005585
+                    yesAmount: "20000.00000000"
+                    noAmount: "0.00000000"
                     pledgeAmount: "10000.00000000"
                     approved: true
+                    createdBlock: 2989374
+                    modifiedBlock: 3015519
                 paging: {}
         400:
           description: The request is not valid
@@ -7579,7 +7784,7 @@ paths:
       tags:
         - Vaults
       summary: Build Propose Create Certificate Transaction Quote
-      description: Builds a quote for a transaction to create a proposal for creating a vault certificate. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
+      description: Builds a quote for a transaction to create a proposal for creating a vault certificate. Creating a proposal requires a deposit of 500 CRS, which is returned upon completion of the proposal. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
       operationId: buildProposeCreateCertificateQuote
       parameters:
         - name: vault
@@ -7664,7 +7869,7 @@ paths:
       tags:
         - Vaults
       summary: Build Propose Revoke Certificate Transaction Quote
-      description: Builds a quote for a transaction to create a proposal for revoking a vault certificate. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
+      description: Builds a quote for a transaction to create a proposal for revoking a vault certificate. Creating a proposal requires a deposit of 500 CRS, which is returned upon completion of the proposal. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
       operationId: buildProposeRevokeCertificateQuote
       parameters:
         - name: vault
@@ -7683,7 +7888,7 @@ paths:
               $ref: "#/components/schemas/quoteProposeRevokeCertificateRequest"
             example:
               owner: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-              description: "OVP-2: Request to revoke certificate. See https://www.example.com for details."
+              description: "OVP-2: Request to revoke certificate. As the recipient, I wish to revoke this certificate."
       security:
         - opdexAuth: []
       responses:
@@ -7694,21 +7899,29 @@ paths:
               schema:
                 $ref: "#/components/schemas/transactionQuoteResponse"
               example:
-                error:
-                  friendly: Unable to propose revoking certificate, invalid certificate.
-                  raw:
-                gasUsed: 10164
-                events: []
+                result: 2
+                gasUsed: 14498
+                events:
+                  - proposalId: 2
+                    wallet: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+                    amount: "50000.00000000"
+                    type: Revoke
+                    status: Pledge
+                    expiration: 3081026
+                    description: "OVP-2: Request to revoke certificate. As the recipient, I wish to revoke this certificate."
+                    eventType: CreateVaultProposalEvent
+                    contract: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
+                    sortOrder: 0
                 request:
                   sender: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                   to: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
-                  amount: "0.00000000"
+                  amount: "500.00000000"
                   method: CreateRevokeCertificateProposal
                   parameters:
                     - label: Recipient
                       value: 9#tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                     - label: Description
-                      value: "4#OVP-2: Request to revoke certificate. See https://www.example.com for details."
+                      value: "4#OVP-2: Request to revoke certificate. As the recipient, I wish to revoke this certificate."
                   callback: https://v1-test-api.opdex.com/v1/transactions
         400:
           description: The request is not valid
@@ -7738,7 +7951,7 @@ paths:
       tags:
         - Vaults
       summary: Build Propose Change Minimum Pledge Transaction Quote
-      description: Builds a quote for a transaction to create a proposal for changing the minimum pledge amount. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
+      description: Builds a quote for a transaction to create a proposal for changing the minimum pledge amount. Creating a proposal requires a deposit of 500 CRS, which is returned upon completion of the proposal. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
       operationId: buildProposeChangeMinimumPledgeQuote
       parameters:
         - name: vault
@@ -7820,7 +8033,7 @@ paths:
       tags:
         - Vaults
       summary: Build Propose Change Minimum Vote Transaction Quote
-      description: Builds a quote for a transaction to create a proposal for changing the minimum vote threshold. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
+      description: Builds a quote for a transaction to create a proposal for changing the minimum vote threshold. Creating a proposal requires a deposit of 500 CRS, which is returned upon completion of the proposal. The quote can be broadcast by a Stratis Transaction Handoff Broadcastor. See the [specification](https://github.com/Opdex/STHS) for further details.
       operationId: buildProposeChangeMinimumVoteQuote
       parameters:
         - name: vault
@@ -7932,26 +8145,19 @@ paths:
                 vault: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
                 token: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
                 proposalId: 1
-                creator: tJyppxPeKs9rbsidSi3pqCYitkdGYjo57r
+                creator: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                 wallet: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-                amount: "5000000.00000000"
-                description: "OVP-1: Request for certificate. View details at: https://example.com."
+                amount: "50000.00000000"
+                description: "OVP-1: Request for a 50000 TODX certificate. See ipfs:QmPYH5K4q3WphaRMe7zv6196NryXgj5m7uY53Jkgym2ube for details."
                 type: Create
                 status: Complete
-                expiration: 945889
-                yesAmount: "200600.4932824"
-                noAmount: "17534.53831111"
+                expiration: 3005585
+                yesAmount: "20000.00000000"
+                noAmount: "0.00000000"
                 pledgeAmount: "10000.00000000"
                 approved: true
-                certificate:
-                  owner: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-                  amount: "5000000.00000000"
-                  vestingStartBlock: 945889
-                  vestingEndBlock: 2025889
-                  redeemed: false
-                  revoked: false
-                  proposals:
-                    - 1
+                createdBlock: 2989374
+                modifiedBlock: 3015519
         400:
           description: The request is not valid
           content:
@@ -8256,6 +8462,8 @@ paths:
                 pledger: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                 pledge: "10000.00000000"
                 balance: "10000.00000000"
+                createdBlock: 3012570
+                modifiedBlock: 3012570
         400:
           description: The request is not valid
           content:
@@ -8497,6 +8705,8 @@ paths:
                 vote: "30000.00000000"
                 balance: "30000.00000000"
                 inFavor: true
+                createdBlock: 3026455
+                modifiedBlock: 3026455
         400:
           description: The request is not valid
           content:
@@ -8600,12 +8810,16 @@ paths:
                     vote: "8000.00000000"
                     balance: "8000.00000000"
                     inFavor: false
+                    createdBlock: 4001059
+                    modifiedBlock: 4001059
                   - vault: t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G
                     proposalId: 1
                     voter: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                     vote: "30000.00000000"
                     balance: "0.00000000"
                     inFavor: true
+                    createdBlock: 3026455
+                    modifiedBlock: 3725314
                 paging: {}
         400:
           description: The request is not valid

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2430,6 +2430,16 @@ components:
         token:
           $ref: "#/components/schemas/address"
           description: Address of the SRC token
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     miningPositionsResponse:
       type: object
       properties:
@@ -2455,6 +2465,16 @@ components:
         miningToken:
           $ref: "#/components/schemas/address"
           description: Address of the liquidity pool token
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     stakingPositionsResponse:
       type: object
       properties:
@@ -2480,6 +2500,16 @@ components:
         stakingToken:
           $ref: "#/components/schemas/address"
           description: Address of the token used for staking
+        createdBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity was created
+        modifiedBlock:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Block number at which the entity state was last modified
     blocksResponse:
       type: object
       properties:
@@ -8973,18 +9003,31 @@ paths:
                 $ref: "#/components/schemas/addressBalancesResponse"
               example:
                 results:
-                  - balance: "238.83796109"
+                  - balance: "27580.45995517"
                     address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-                    token: tCE8LfkCj9HJUZu3dtgERNFfquMVJVe4sh
-                  - balance: "4666893.11259768"
+                    token: tPXUEzDyZDrR8YzQ6LiAJWhVuAKB8RUjyt
+                    createdBlock: 2989306
+                    modifiedBlock: 3015545
+                  - balance: "362.628729020"
                     address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-                    token: tFCyMPURX9pVWXuXQqYY2hJmRcCrhmBPfY
+                    token: tCorSgPVt6pF5Q4gzcrZWDZ8f7ERVxhwAd
+                    createdBlock: 2989320
+                    modifiedBlock: 2991148
+                  - balance: "0.12026492"
+                    address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
+                    token: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
+                    createdBlock: 2989326
+                    modifiedBlock: 3009264
                   - balance: "1.00000000"
                     address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                     token: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
-                  - balance: "3626.28729020"
+                    createdBlock: 2989326
+                    modifiedBlock: 3003823
+                  - balance: "8.556538343928946001"
                     address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
-                    token: tCorSgPVt6pF5Q4gzcrZWDZ8f7ERVxhwAd
+                    token: tF83sdXXt2nTkL7UyEYDVFMK4jTuYMbmR3
+                    createdBlock: 2989330
+                    modifiedBlock: 2991127
                 paging: {}
         400:
           description: The request is not valid
@@ -9035,9 +9078,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/addressBalanceResponse"
               example:
-                balance: "0.19703287"
+                balance: "0.12026492"
                 address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                 token: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
+                createdBlock: 2989326
+                modifiedBlock: 3009264
         400:
           description: The request is not valid
           content:
@@ -9090,9 +9135,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/addressBalanceResponse"
               example:
-                balance: "0.19703287"
+                balance: "0.12026492"
                 address: tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm
                 token: tGSk2dVENuqAQ2rNXbui37XHuurFCTqadD
+                createdBlock: 2989326
+                modifiedBlock: 3009264
         400:
           description: The request is not valid
           content:
@@ -9184,6 +9231,8 @@ paths:
                     amount: "3.14831968"
                     miningPool: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
                     miningToken: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
+                    createdBlock: 2991138
+                    modifiedBlock: 2991446
                 paging: {}
         400:
           description: The request is not valid
@@ -9238,6 +9287,8 @@ paths:
                 amount: "3.14831968"
                 miningPool: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
                 miningToken: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
+                createdBlock: 2991138
+                modifiedBlock: 2991446
         400:
           description: The request is not valid
           content:
@@ -9333,6 +9384,8 @@ paths:
                     amount: "555.94827358"
                     liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                     stakingToken: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                    createdBlock: 3646922
+                    modifiedBlock: 3721001
                 paging: {}
         400:
           description: The request is not valid
@@ -9387,6 +9440,8 @@ paths:
                 amount: "555.94827358"
                 liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
                 stakingToken: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                createdBlock: 3646922
+                modifiedBlock: 3721001
         400:
           description: The request is not valid
           content:

--- a/src/Opdex.Platform.Application.Abstractions/Models/Addresses/AddressBalanceDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Addresses/AddressBalanceDto.cs
@@ -9,4 +9,6 @@ public class AddressBalanceDto
     public Address Address { get; set; }
 
     public Address Token { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Addresses/MiningPositionDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Addresses/MiningPositionDto.cs
@@ -8,4 +8,6 @@ public class MiningPositionDto
     public FixedDecimal Amount { get; set; }
     public Address MiningPool { get; set; }
     public Address MiningToken { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Addresses/StakingPositionDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Addresses/StakingPositionDto.cs
@@ -8,4 +8,6 @@ public class StakingPositionDto
     public FixedDecimal Amount { get; set; }
     public Address LiquidityPool { get; set; }
     public Address StakingToken { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
@@ -10,6 +10,8 @@ public class LiquidityPoolDto
     public string Name { get; set; }
     public Address Address { get; set; }
     public decimal TransactionFee { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
     public Address Market { get; set; }
     public MarketTokenDto SrcToken { get; set; }
     public MarketTokenDto LpToken { get; set; }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSummaryDto.cs
@@ -7,6 +7,5 @@ public class LiquidityPoolSummaryDto
     public ReservesDto Reserves { get; set; }
     public CostDto Cost { get; set; }
     public StakingDto Staking { get; set; }
-    public ulong CreatedBlock { get; set; }
     public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolSummaryDto.cs
@@ -7,4 +7,6 @@ public class LiquidityPoolSummaryDto
     public ReservesDto Reserves { get; set; }
     public CostDto Cost { get; set; }
     public StakingDto Staking { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketDto.cs
@@ -16,5 +16,7 @@ public class MarketDto
     public bool AuthTraders { get; set; }
     public decimal TransactionFeePercent { get; set; }
     public bool MarketFeeEnabled { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
     public MarketSummaryDto Summary { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketSummaryDto.cs
@@ -11,4 +11,6 @@ public class MarketSummaryDto
     public decimal VolumeUsd { get; set; }
     public MarketStakingDto Staking { get; set; }
     public RewardsDto Rewards { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketSummaryDto.cs
@@ -11,6 +11,5 @@ public class MarketSummaryDto
     public decimal VolumeUsd { get; set; }
     public MarketStakingDto Staking { get; set; }
     public RewardsDto Rewards { get; set; }
-    public ulong CreatedBlock { get; set; }
     public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/MiningGovernances/MiningGovernanceDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/MiningGovernances/MiningGovernanceDto.cs
@@ -12,4 +12,6 @@ public class MiningGovernanceDto
     public FixedDecimal MiningPoolRewardPerPeriod { get; set; }
     public FixedDecimal TotalRewardsPerPeriod { get; set; }
     public Address MinedToken { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/MiningPools/MiningPoolDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/MiningPools/MiningPoolDto.cs
@@ -12,4 +12,6 @@ public class MiningPoolDto
     public UInt256 RewardPerLpt { get; set; }
     public UInt256 TokensMining { get; set; }
     public bool IsActive { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenDto.cs
@@ -14,5 +14,7 @@ public class TokenDto
     public ulong Sats { get; set; }
     public FixedDecimal TotalSupply { get; set; }
     public IEnumerable<TokenAttributeType> Attributes { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
     public TokenSummaryDto Summary { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenSummaryDto.cs
@@ -4,6 +4,5 @@ public class TokenSummaryDto
 {
     public decimal PriceUsd { get; set; }
     public decimal DailyPriceChangePercent { get; set; }
-    public ulong CreatedBlock { get; set; }
     public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Tokens/TokenSummaryDto.cs
@@ -4,5 +4,6 @@ public class TokenSummaryDto
 {
     public decimal PriceUsd { get; set; }
     public decimal DailyPriceChangePercent { get; set; }
+    public ulong CreatedBlock { get; set; }
     public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultCertificateDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultCertificateDto.cs
@@ -11,5 +11,7 @@ public class VaultCertificateDto
     public ulong VestingEndBlock { get; set; }
     public bool Redeemed { get; set; }
     public bool Revoked { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
     public IEnumerable<ulong> Proposals { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultDto.cs
@@ -12,4 +12,6 @@ public class VaultDto
     public FixedDecimal TotalPledgeMinimum { get; set; }
     public FixedDecimal TotalVoteMinimum { get; set; }
     public ulong VestingDuration { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultProposalDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultProposalDto.cs
@@ -19,5 +19,7 @@ public class VaultProposalDto
     public FixedDecimal NoAmount { get; set; }
     public FixedDecimal PledgeAmount { get; set; }
     public bool Approved { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
     public VaultCertificateDto Certificate { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultProposalPledgeDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultProposalPledgeDto.cs
@@ -9,4 +9,6 @@ public class VaultProposalPledgeDto
     public Address Pledger { get; set; }
     public FixedDecimal Pledge { get; set; }
     public FixedDecimal Balance { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultProposalVoteDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Vaults/VaultProposalVoteDto.cs
@@ -10,4 +10,6 @@ public class VaultProposalVoteDto
     public FixedDecimal Vote { get; set; }
     public FixedDecimal Balance { get; set; }
     public bool InFavor { get; set; }
+    public ulong CreatedBlock { get; set; }
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
@@ -87,7 +87,6 @@ public class LiquidityPoolDtoAssembler : IModelAssembler<LiquidityPool, Liquidit
                 ProviderDailyUsd = providerUsd,
                 MarketDailyUsd = marketUsd
             },
-            CreatedBlock = summary.CreatedBlock,
             ModifiedBlock = summary.ModifiedBlock
         };
 

--- a/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
@@ -86,7 +86,9 @@ public class LiquidityPoolDtoAssembler : IModelAssembler<LiquidityPool, Liquidit
             {
                 ProviderDailyUsd = providerUsd,
                 MarketDailyUsd = marketUsd
-            }
+            },
+            CreatedBlock = summary.CreatedBlock,
+            ModifiedBlock = summary.ModifiedBlock
         };
 
         if (!stakingEnabled) return poolDto;

--- a/src/Opdex.Platform.Application/Assemblers/MiningPoolDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/MiningPoolDtoAssembler.cs
@@ -34,7 +34,9 @@ public class MiningPoolDtoAssembler : IModelAssembler<MiningPool, MiningPoolDto>
             RewardPerBlock = miningPool.RewardPerBlock,
             RewardPerLpt = miningPool.RewardPerLpt,
             TokensMining = tokensMining?.Balance ?? UInt256.Zero,
-            IsActive = miningPool.MiningPeriodEndBlock > latestBlock.Height
+            IsActive = miningPool.MiningPeriodEndBlock > latestBlock.Height,
+            CreatedBlock = miningPool.CreatedBlock,
+            ModifiedBlock = miningPool.ModifiedBlock
         };
     }
 }

--- a/src/Opdex.Platform.Application/Assemblers/MiningPositionDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/MiningPositionDtoAssembler.cs
@@ -30,7 +30,9 @@ public class MiningPositionDtoAssembler : IModelAssembler<AddressMining, MiningP
             Address = source.Owner,
             Amount = source.Balance.ToDecimal(token.Decimals),
             MiningPool = miningPool.Address,
-            MiningToken = token.Address
+            MiningToken = token.Address,
+            CreatedBlock = source.CreatedBlock,
+            ModifiedBlock = source.ModifiedBlock
         };
     }
 }

--- a/src/Opdex.Platform.Application/Assemblers/StakingPositionDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/StakingPositionDtoAssembler.cs
@@ -30,7 +30,9 @@ public class StakingPositionDtoAssembler : IModelAssembler<AddressStaking, Staki
             Address = source.Owner,
             Amount = source.Weight.ToDecimal(token.Decimals),
             LiquidityPool = liquidityPool.Address,
-            StakingToken = token.Address
+            StakingToken = token.Address,
+            CreatedBlock = source.CreatedBlock,
+            ModifiedBlock = source.ModifiedBlock
         };
     }
 }

--- a/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
@@ -79,6 +79,8 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.AuthTraders, opt => opt.MapFrom(src => src.AuthTraders))
             .ForMember(dest => dest.MarketFeeEnabled, opt => opt.MapFrom(src => src.MarketFeeEnabled))
             .ForMember(dest => dest.TransactionFeePercent, opt => opt.MapFrom(src => src.TransactionFee == 0 ? 0 : Math.Round((decimal)src.TransactionFee / 10, 1)))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<MarketSummary, MarketSummaryDto>()
@@ -89,6 +91,8 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.VolumeUsd, opt => opt.MapFrom(src => src.VolumeUsd))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<MarketSummary, MarketStakingDto>()
@@ -106,6 +110,7 @@ public class PlatformApplicationMapperProfile : Profile
         CreateMap<TokenSummary, TokenSummaryDto>()
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.DailyPriceChangePercent, opt => opt.MapFrom(src => src.DailyPriceChangePercent))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -117,6 +122,8 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Decimals, opt => opt.MapFrom(src => src.Decimals))
             .ForMember(dest => dest.Sats, opt => opt.MapFrom(src => src.Sats))
             .ForMember(dest => dest.TotalSupply, opt => opt.MapFrom(src => src.TotalSupply.ToDecimal(src.Decimals)))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -128,6 +135,8 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Decimals, opt => opt.MapFrom(src => src.Decimals))
             .ForMember(dest => dest.Sats, opt => opt.MapFrom(src => src.Sats))
             .ForMember(dest => dest.TotalSupply, opt => opt.MapFrom(src => src.TotalSupply.ToDecimal(src.Decimals)))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Market, opt => opt.MapFrom(src => src.Market.Address))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForAllOtherMembers(opt => opt.Ignore());
@@ -136,6 +145,8 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<Block, BlockDto>()
@@ -189,18 +200,21 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Spender, opt => opt.MapFrom(src => src.Spender))
             .ForAllOtherMembers(opt => opt.Ignore());
 
-        // Todo: Can be wiped when the original Vault is removed, new vault will use assembler
         CreateMap<VaultCertificate, VaultCertificateDto>()
             .ForMember(dest => dest.Owner, opt => opt.MapFrom(src => src.Owner))
             .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount.ToDecimal(TokenConstants.Opdex.Decimals)))
             .ForMember(dest => dest.VestingStartBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.VestingEndBlock, opt => opt.MapFrom(src => src.VestedBlock))
             .ForMember(dest => dest.Redeemed, opt => opt.MapFrom(src => src.Redeemed))
-            .ForMember(dest => dest.Revoked, opt => opt.MapFrom(src => src.Revoked));
+            .ForMember(dest => dest.Revoked, opt => opt.MapFrom(src => src.Revoked))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<Vault, VaultDto>()
             .ForMember(dest => dest.Vault, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.VestingDuration, opt => opt.MapFrom(src => src.VestingDuration))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<VaultProposal, VaultProposalDto>()
@@ -212,19 +226,27 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
             .ForMember(dest => dest.Expiration, opt => opt.MapFrom(src => src.Expiration))
             .ForMember(dest => dest.Approved, opt => opt.MapFrom(src => src.Approved))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<VaultProposalPledge, VaultProposalPledgeDto>()
             .ForMember(dest => dest.Pledger, opt => opt.MapFrom(src => src.Pledger))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<VaultProposalVote, VaultProposalVoteDto>()
             .ForMember(dest => dest.Voter, opt => opt.MapFrom(src => src.Voter))
             .ForMember(dest => dest.InFavor, opt => opt.MapFrom(src => src.InFavor))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<AddressBalance, AddressBalanceDto>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Owner))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         // Transactions and Transaction Events

--- a/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
@@ -91,7 +91,6 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.VolumeUsd, opt => opt.MapFrom(src => src.VolumeUsd))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src))
-            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -110,7 +109,6 @@ public class PlatformApplicationMapperProfile : Profile
         CreateMap<TokenSummary, TokenSummaryDto>()
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.DailyPriceChangePercent, opt => opt.MapFrom(src => src.DailyPriceChangePercent))
-            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/SelectAddressBalanceByTokenIdAndOwnerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Balances/SelectAddressBalanceByTokenIdAndOwnerQueryHandler.cs
@@ -46,7 +46,7 @@ public class SelectAddressBalanceByOwnerAndTokenIdQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"Balance not found.");
+            throw new NotFoundException("Balance not found.");
         }
 
         return result == null ? null : _mapper.Map<AddressBalance>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Mining/SelectAddressMiningByMiningPoolIdAndOwnerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Mining/SelectAddressMiningByMiningPoolIdAndOwnerQueryHandler.cs
@@ -48,7 +48,7 @@ public class SelectAddressMiningByMiningPoolIdAndOwnerQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"Mining position not found.");
+            throw new NotFoundException("Mining position not found.");
         }
 
         return result == null ? null : _mapper.Map<AddressMining>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Staking/SelectAddressStakingByLiquidityPoolIdAndOwnerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Addresses/Staking/SelectAddressStakingByLiquidityPoolIdAndOwnerQueryHandler.cs
@@ -49,7 +49,7 @@ public class SelectAddressStakingByLiquidityPoolIdAndOwnerQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"Staking position not found.");
+            throw new NotFoundException("Staking position not found.");
         }
 
         return result == null ? null : _mapper.Map<AddressStaking>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/SelectIndexerLockQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Indexer/SelectIndexerLockQueryHandler.cs
@@ -38,7 +38,7 @@ public class SelectIndexerLockQueryHandler : IRequestHandler<SelectIndexerLockQu
 
         if (result == null)
         {
-            throw new NotFoundException($"Index lock not found.");
+            throw new NotFoundException("Index lock not found.");
         }
 
         return new IndexLock(result.Available, result.Locked, result.InstanceId, result.Reason, result.ModifiedDate);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByAddressQueryHandler.cs
@@ -46,7 +46,7 @@ public class SelectLiquidityPoolByAddressQueryHandler : IRequestHandler<SelectLi
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"Liquidity pool not found.");
+            throw new NotFoundException("Liquidity pool not found.");
         }
 
         return result == null ? null : _mapper.Map<LiquidityPool>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolByIdQueryHandler.cs
@@ -46,7 +46,7 @@ public class SelectLiquidityPoolByIdQueryHandler : IRequestHandler<SelectLiquidi
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(LiquidityPool)} not found.");
+            throw new NotFoundException("Liquidity pool not found.");
         }
 
         return result == null ? null : _mapper.Map<LiquidityPool>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler.cs
@@ -47,7 +47,7 @@ public class SelectLiquidityPoolBySrcTokenIdAndMarketIdQueryHandler : IRequestHa
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(LiquidityPool)} not found.");
+            throw new NotFoundException("Liquidity pool not found.");
         }
 
         return result == null ? null : _mapper.Map<LiquidityPool>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Summaries/SelectLiquidityPoolSummaryByLiquidityPoolIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/LiquidityPools/Summaries/SelectLiquidityPoolSummaryByLiquidityPoolIdQueryHandler.cs
@@ -50,7 +50,7 @@ public class SelectLiquidityPoolSummaryByLiquidityPoolIdQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(LiquidityPoolSummary)} not found.");
+            throw new NotFoundException("Liquidity pool summary not found.");
         }
 
         return result == null ? null : _mapper.Map<LiquidityPoolSummary>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/SelectMarketPermissionQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Permissions/SelectMarketPermissionQueryHandler.cs
@@ -49,7 +49,7 @@ public class SelectMarketPermissionQueryHandler : IRequestHandler<SelectMarketPe
 
         if (request.FindOrThrow && result is null)
         {
-            throw new NotFoundException($"{nameof(MarketPermission)} not found.");
+            throw new NotFoundException("Market permission not found.");
         }
 
         return result is null ? null : _mapper.Map<MarketPermission>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandler.cs
@@ -52,7 +52,7 @@ public class SelectMarketSummaryByMarketIdQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(MarketSummary)} not found.");
+            throw new NotFoundException("Market summary not found.");
         }
 
         return result == null ? null : _mapper.Map<MarketSummary>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/SelectMiningGovernanceNominationByLiquidityAndMiningPoolIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/Nominations/SelectMiningGovernanceNominationByLiquidityAndMiningPoolIdQueryHandler.cs
@@ -48,7 +48,7 @@ public class SelectMiningGovernanceNominationByLiquidityAndMiningPoolIdQueryHand
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"Mining governance nomination not found.");
+            throw new NotFoundException("Mining governance nomination not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningGovernanceNomination>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/SelectMiningGovernanceByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/SelectMiningGovernanceByAddressQueryHandler.cs
@@ -46,7 +46,7 @@ public class SelectMiningGovernanceByAddressQueryHandler : IRequestHandler<Selec
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(MiningGovernance)} not found.");
+            throw new NotFoundException("Mining governance not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningGovernance>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/SelectMiningGovernanceByTokenIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningGovernances/SelectMiningGovernanceByTokenIdQueryHandler.cs
@@ -45,7 +45,7 @@ public class SelectMiningGovernanceByTokenIdQueryHandler : IRequestHandler<Selec
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(MiningGovernance)} not found.");
+            throw new NotFoundException("Mining governance not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningGovernance>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByAddressQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByAddressQueryHandler.cs
@@ -46,7 +46,7 @@ public class SelectMiningPoolByAddressQueryHandler : IRequestHandler<SelectMinin
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"Mining pool not found.");
+            throw new NotFoundException("Mining pool not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningPool>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByIdQueryHandler.cs
@@ -44,7 +44,7 @@ public class SelectMiningPoolByIdQueryHandler : IRequestHandler<SelectMiningPool
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(MiningPool)} not found.");
+            throw new NotFoundException("Mining pool not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningPool>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByLiquidityPoolIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/MiningPools/SelectMiningPoolByLiquidityPoolIdQueryHandler.cs
@@ -45,7 +45,7 @@ public class SelectMiningPoolByLiquidityPoolIdQueryHandler : IRequestHandler<Sel
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(MiningPool)} not found.");
+            throw new NotFoundException("Mining pool not found.");
         }
 
         return result == null ? null : _mapper.Map<MiningPool>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Distribution/SelectLatestTokenDistributionByTokenIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Distribution/SelectLatestTokenDistributionByTokenIdQueryHandler.cs
@@ -47,7 +47,7 @@ public class SelectLatestTokenDistributionByTokenIdQueryHandler : IRequestHandle
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(TokenDistribution)} not found.");
+            throw new NotFoundException("Token distribution not found.");
         }
 
         return result == null ? null : _mapper.Map<TokenDistribution>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Summaries/SelectTokenSummaryByMarketAndTokenIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Tokens/Summaries/SelectTokenSummaryByMarketAndTokenIdQueryHandler.cs
@@ -45,7 +45,7 @@ public class SelectTokenSummaryByMarketAndTokenIdQueryHandler : IRequestHandler<
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(TokenSummary)} not found.");
+            throw new NotFoundException("Token summary not found.");
         }
 
         return result == null ? null : _mapper.Map<TokenSummary>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Certificates/SelectVaultCertificateByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Certificates/SelectVaultCertificateByIdQueryHandler.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Opdex.Platform.Infrastructure.Data.Handlers.Vaults.Certificates;
 
-public class SelectVaultCertificateByIdQueryHandler: IRequestHandler<SelectVaultCertificateByIdQuery, VaultCertificate>
+public class SelectVaultCertificateByIdQueryHandler : IRequestHandler<SelectVaultCertificateByIdQuery, VaultCertificate>
 {
     private static readonly string SqlQuery =
         @$"SELECT
@@ -46,7 +46,7 @@ public class SelectVaultCertificateByIdQueryHandler: IRequestHandler<SelectVault
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(VaultCertificate)} not found.");
+            throw new NotFoundException("Vault certificate not found.");
         }
 
         return result == null ? null : _mapper.Map<VaultCertificate>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Pledges/SelectVaultProposalPledgeByVaultIdAndProposalIdAndPledgerQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Pledges/SelectVaultProposalPledgeByVaultIdAndProposalIdAndPledgerQueryHandler.cs
@@ -49,7 +49,7 @@ public class SelectVaultProposalPledgeByVaultIdAndProposalIdAndPledgerQueryHandl
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(VaultProposalPledge)} not found.");
+            throw new NotFoundException("Proposal pledge not found.");
         }
 
         return result == null ? null : _mapper.Map<VaultProposalPledge>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/ProposalCertificates/SelectVaultProposalCertificateByProposalIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/ProposalCertificates/SelectVaultProposalCertificateByProposalIdQueryHandler.cs
@@ -43,7 +43,7 @@ public class SelectVaultProposalCertificateByProposalIdQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(VaultProposalCertificate)} not found.");
+            throw new NotFoundException("Certificate not found.");
         }
 
         return result == null ? null : _mapper.Map<VaultProposalCertificate>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Proposals/SelectVaultProposalByIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Proposals/SelectVaultProposalByIdQueryHandler.cs
@@ -53,7 +53,7 @@ public class SelectVaultProposalByIdQueryHandler : IRequestHandler<SelectVaultPr
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(VaultProposal)} not found.");
+            throw new NotFoundException("Proposal not found.");
         }
 
         return result == null ? null : _mapper.Map<VaultProposal>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Proposals/SelectVaultProposalByVaultIdAndPublicIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Proposals/SelectVaultProposalByVaultIdAndPublicIdQueryHandler.cs
@@ -55,7 +55,7 @@ public class SelectVaultProposalByVaultIdAndPublicIdQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(VaultProposal)} not found.");
+            throw new NotFoundException("Proposal not found.");
         }
 
         return result == null ? null : _mapper.Map<VaultProposal>(result);

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Votes/SelectVaultProposalVoteByVaultIdAndProposalIdAndVoterQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Vaults/Votes/SelectVaultProposalVoteByVaultIdAndProposalIdAndVoterQueryHandler.cs
@@ -50,7 +50,7 @@ public class SelectVaultProposalVoteByVaultIdAndProposalIdAndVoterQueryHandler
 
         if (request.FindOrThrow && result == null)
         {
-            throw new NotFoundException($"{nameof(VaultProposalVote)} not found.");
+            throw new NotFoundException("Proposal vote not found.");
         }
 
         return result == null ? null : _mapper.Map<VaultProposalVote>(result);

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -102,7 +102,6 @@ public class PlatformWebApiMapperProfile : Profile
         CreateMap<TokenSummaryDto, TokenSummaryResponseModel>()
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.DailyPriceChangePercent, opt => opt.MapFrom(src => src.DailyPriceChangePercent))
-            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -145,7 +144,6 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
             .ForMember(dest => dest.Volume, opt => opt.MapFrom(src => src.Volume))
             .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
-            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -287,7 +285,6 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.VolumeUsd, opt => opt.MapFrom(src => src.VolumeUsd))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src.Rewards))
-            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -66,6 +66,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Sats, opt => opt.MapFrom(src => src.Sats))
             .ForMember(dest => dest.TotalSupply, opt => opt.MapFrom(src => src.TotalSupply))
             .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.Attributes))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -100,6 +102,7 @@ public class PlatformWebApiMapperProfile : Profile
         CreateMap<TokenSummaryDto, TokenSummaryResponseModel>()
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.DailyPriceChangePercent, opt => opt.MapFrom(src => src.DailyPriceChangePercent))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -117,6 +120,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
             .ForMember(dest => dest.TransactionFeePercent, opt => opt.MapFrom(src => src.TransactionFee))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Market, opt => opt.MapFrom(src => src.Market))
             .ForMember(dest => dest.Tokens, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.MiningPool, opt => opt.MapFrom(src => src.MiningPool))
@@ -140,6 +145,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
             .ForMember(dest => dest.Volume, opt => opt.MapFrom(src => src.Volume))
             .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<LiquidityPoolSnapshotDto, LiquidityPoolSnapshotResponseModel>()
@@ -223,6 +230,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.RewardPerLpt, opt => opt.MapFrom(src => src.RewardPerLpt.ToDecimal(TokenConstants.Opdex.Decimals)))
             .ForMember(dest => dest.TokensMining, opt => opt.MapFrom(src => src.TokensMining.ToDecimal(TokenConstants.LiquidityPoolToken.Decimals)))
             .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<MiningPoolsDto, MiningPoolsResponseModel>()
@@ -262,6 +271,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.AuthTraders, opt => opt.MapFrom(src => src.AuthTraders))
             .ForMember(dest => dest.MarketFeeEnabled, opt => opt.MapFrom(src => src.MarketFeeEnabled))
             .ForMember(dest => dest.TransactionFeePercent, opt => opt.MapFrom(src => src.TransactionFeePercent))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForAllOtherMembers(opt => opt.Ignore());
 
@@ -276,6 +287,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.VolumeUsd, opt => opt.MapFrom(src => src.VolumeUsd))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src.Rewards))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<MarketStakingDto, MarketStakingResponseModel>()
@@ -299,7 +312,9 @@ public class PlatformWebApiMapperProfile : Profile
         CreateMap<AddressBalanceDto, AddressBalanceResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance))
-            .ForMember(dest => dest.Token, opt => opt.MapFrom(src => src.Token));
+            .ForMember(dest => dest.Token, opt => opt.MapFrom(src => src.Token))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<AddressBalancesDto, AddressBalancesResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Balances))
@@ -310,7 +325,9 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount))
             .ForMember(dest => dest.StakingToken, opt => opt.MapFrom(src => src.StakingToken))
-            .ForMember(dest => dest.LiquidityPool, opt => opt.MapFrom(src => src.LiquidityPool));
+            .ForMember(dest => dest.LiquidityPool, opt => opt.MapFrom(src => src.LiquidityPool))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<StakingPositionsDto, StakingPositionsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Positions))
@@ -320,7 +337,9 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount))
             .ForMember(dest => dest.MiningToken, opt => opt.MapFrom(src => src.MiningToken))
-            .ForMember(dest => dest.MiningPool, opt => opt.MapFrom(src => src.MiningPool));
+            .ForMember(dest => dest.MiningPool, opt => opt.MapFrom(src => src.MiningPool))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<MiningPositionsDto, MiningPositionsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Positions))
@@ -335,6 +354,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.MiningPoolRewardPerPeriod, opt => opt.MapFrom(src => src.MiningPoolRewardPerPeriod))
             .ForMember(dest => dest.PeriodsUntilRewardReset, opt => opt.MapFrom(src => src.PeriodsUntilRewardReset))
             .ForMember(dest => dest.TotalRewardsPerPeriod, opt => opt.MapFrom(src => src.TotalRewardsPerPeriod))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<MiningGovernancesDto, MiningGovernancesResponseModel>()
@@ -373,6 +394,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.VestingEndBlock, opt => opt.MapFrom(src => src.VestingEndBlock))
             .ForMember(dest => dest.Redeemed, opt => opt.MapFrom(src => src.Redeemed))
             .ForMember(dest => dest.Revoked, opt => opt.MapFrom(src => src.Revoked))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Proposals, opt => opt.MapFrom(src => src.Proposals));
 
         CreateMap<VaultCertificatesDto, VaultCertificatesResponseModel>()
@@ -387,7 +410,9 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.TokensLocked, opt => opt.MapFrom(src => src.TokensLocked))
             .ForMember(dest => dest.TotalPledgeMinimum, opt => opt.MapFrom(src => src.TotalPledgeMinimum))
             .ForMember(dest => dest.TotalVoteMinimum, opt => opt.MapFrom(src => src.TotalVoteMinimum))
-            .ForMember(dest => dest.VestingDuration, opt => opt.MapFrom(src => src.VestingDuration));
+            .ForMember(dest => dest.VestingDuration, opt => opt.MapFrom(src => src.VestingDuration))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<VaultsDto, VaultsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Vaults))
@@ -408,6 +433,8 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.NoAmount, opt => opt.MapFrom(src => src.NoAmount))
             .ForMember(dest => dest.PledgeAmount, opt => opt.MapFrom(src => src.PledgeAmount))
             .ForMember(dest => dest.Approved, opt => opt.MapFrom(src => src.Approved))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Certificate, opt => opt.MapFrom(src => src.Certificate));
 
         CreateMap<VaultProposalsDto, VaultProposalsResponseModel>()
@@ -419,7 +446,9 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.ProposalId, opt => opt.MapFrom(src => src.ProposalId))
             .ForMember(dest => dest.Pledger, opt => opt.MapFrom(src => src.Pledger))
             .ForMember(dest => dest.Pledge, opt => opt.MapFrom(src => src.Pledge))
-            .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance));
+            .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<VaultProposalPledgesDto, VaultProposalPledgesResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Pledges))
@@ -430,7 +459,9 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.ProposalId, opt => opt.MapFrom(src => src.ProposalId))
             .ForMember(dest => dest.Voter, opt => opt.MapFrom(src => src.Voter))
             .ForMember(dest => dest.Vote, opt => opt.MapFrom(src => src.Vote))
-            .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance));
+            .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance))
+            .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
+            .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<VaultProposalVotesDto, VaultProposalVotesResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Votes))

--- a/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
+++ b/src/Opdex.Platform.WebApi/Models/Requests/LiquidityPools/LiquidityPoolFilterParameters.cs
@@ -30,7 +30,7 @@ public class LiquidityPoolFilterParameters : FilterParameters<LiquidityPoolsCurs
     /// <summary>
     /// Liquidity pools to specifically filter for.
     /// </summary>
-    /// <example>[ "tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L", "tLrMcU1csbN7RxGjBMEnJeLoae3PxmQ9cr" ]</example>
+    /// <example>[ "tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L", "tFCyMPURX9pVWXuXQqYY2hJmRcCrhmBPfY" ]</example>
     public IEnumerable<Address> LiquidityPools { get; set; }
 
     /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/LiquidityPoolResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/LiquidityPoolResponseModel.cs
@@ -40,6 +40,18 @@ public class LiquidityPoolResponseModel
     public LiquidityPoolTokenGroupResponseModel Tokens { get; set; }
 
     /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
+
+    /// <summary>
     /// The governance mining pool associated with the liquidity pool in a staking market.
     /// </summary>
     public MiningPoolResponseModel MiningPool { get; set; }

--- a/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/Summary/LiquidityPoolSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/Summary/LiquidityPoolSummaryResponseModel.cs
@@ -29,4 +29,16 @@ public class LiquidityPoolSummaryResponseModel
     /// Staking details based on the pool's current status.
     /// </summary>
     public StakingResponseModel Staking { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/Summary/LiquidityPoolSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/Summary/LiquidityPoolSummaryResponseModel.cs
@@ -31,12 +31,6 @@ public class LiquidityPoolSummaryResponseModel
     public StakingResponseModel Staking { get; set; }
 
     /// <summary>
-    /// Block number at which the entity was created.
-    /// </summary>
-    /// <example>2500000</example>
-    public ulong CreatedBlock { get; set; }
-
-    /// <summary>
     /// Block number at which the entity state was last modified.
     /// </summary>
     /// <example>3000000</example>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketResponseModel.cs
@@ -68,6 +68,18 @@ public class MarketResponseModel
     public decimal TransactionFeePercent { get; set; }
 
     /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
+
+    /// <summary>
     /// Summary of market statistics include liquidity, volume, rewards etc.
     /// </summary>
     public MarketSummaryResponseModel Summary { get; set; }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketSummaryResponseModel.cs
@@ -31,4 +31,16 @@ public class MarketSummaryResponseModel
     /// Summary of daily rewards the market and volume have generated.
     /// </summary>
     public RewardsResponseModel Rewards { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketSummaryResponseModel.cs
@@ -33,12 +33,6 @@ public class MarketSummaryResponseModel
     public RewardsResponseModel Rewards { get; set; }
 
     /// <summary>
-    /// Block number at which the entity was created.
-    /// </summary>
-    /// <example>2500000</example>
-    public ulong CreatedBlock { get; set; }
-
-    /// <summary>
     /// Block number at which the entity state was last modified.
     /// </summary>
     /// <example>3000000</example>

--- a/src/Opdex.Platform.WebApi/Models/Responses/MiningGovernances/MiningGovernanceResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/MiningGovernances/MiningGovernanceResponseModel.cs
@@ -55,4 +55,16 @@ public class MiningGovernanceResponseModel
     /// </summary>
     /// <example>tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c</example>
     public Address MinedToken { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/MiningPools/MiningPoolResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/MiningPools/MiningPoolResponseModel.cs
@@ -48,4 +48,16 @@ public class MiningPoolResponseModel
     /// </summary>
     /// <example>true</example>
     public bool IsActive { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenResponseModel.cs
@@ -53,6 +53,18 @@ public class TokenResponseModel
     public IEnumerable<TokenAttributeType> Attributes { get; set; }
 
     /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
+
+    /// <summary>
     /// A summary including the USD price of the token and daily price change percentage if exists. Market tokens receive
     /// pricing specific to that market.
     /// </summary>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenSummaryResponseModel.cs
@@ -18,8 +18,14 @@ public class TokenSummaryResponseModel
     public decimal DailyPriceChangePercent { get; set; }
 
     /// <summary>
-    /// The block which the token was last updated.
+    /// Block number at which the entity was created.
     /// </summary>
-    /// <example>500000</example>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
     public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Tokens/TokenSummaryResponseModel.cs
@@ -18,12 +18,6 @@ public class TokenSummaryResponseModel
     public decimal DailyPriceChangePercent { get; set; }
 
     /// <summary>
-    /// Block number at which the entity was created.
-    /// </summary>
-    /// <example>2500000</example>
-    public ulong CreatedBlock { get; set; }
-
-    /// <summary>
     /// Block number at which the entity state was last modified.
     /// </summary>
     /// <example>3000000</example>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionEvents/Markets/CreateLiquidityPoolEvent.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionEvents/Markets/CreateLiquidityPoolEvent.cs
@@ -16,6 +16,6 @@ public class CreateLiquidityPoolEvent : TransactionEvent
     /// <summary>
     /// Address of the created liquidity pool.
     /// </summary>
-    /// <example>tLrMcU1csbN7RxGjBMEnJeLoae3PxmQ9cr</example>
+    /// <example>tFCyMPURX9pVWXuXQqYY2hJmRcCrhmBPfY</example>
     public Address LiquidityPool { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionEvents/TransactionEvent.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Transactions/TransactionEvents/TransactionEvent.cs
@@ -17,7 +17,7 @@ public abstract class TransactionEvent
     /// <summary>
     /// Address of the contract that logged the event.
     /// </summary>
-    /// <example>tLrMcU1csbN7RxGjBMEnJeLoae3PxmQ9cr</example>
+    /// <example>tFCyMPURX9pVWXuXQqYY2hJmRcCrhmBPfY</example>
     public Address Contract { get; set; }
 
     /// <summary>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultCertificateResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultCertificateResponseModel.cs
@@ -45,6 +45,18 @@ public class VaultCertificateResponseModel
     public bool Revoked { get; set; }
 
     /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
+
+    /// <summary>
     /// A list of proposal Id's affecting the certificate, consisting of create or revoke certificate proposals.
     /// </summary>
     /// <example>[12, 14, 23]</example>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultProposalPledgeResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultProposalPledgeResponseModel.cs
@@ -36,4 +36,16 @@ public class VaultProposalPledgeResponseModel
     /// </summary>
     /// <example>"0.00000000"</example>
     public FixedDecimal Balance { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultProposalResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultProposalResponseModel.cs
@@ -95,6 +95,18 @@ public class VaultProposalResponseModel
     public bool Approved { get; set; }
 
     /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
+
+    /// <summary>
     /// A vault certificate either created or revoked by the proposal if exists.
     /// </summary>
     public VaultCertificateResponseModel Certificate { get; set; }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultProposalVoteResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultProposalVoteResponseModel.cs
@@ -42,4 +42,16 @@ public class VaultProposalVoteResponseModel
     /// </summary>
     /// <example>true</example>
     public bool InFavor { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Vaults/VaultResponseModel.cs
@@ -54,4 +54,16 @@ public class VaultResponseModel
     /// </summary>
     /// <example>250000</example>
     public ulong VestingDuration { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Wallet/AddressBalanceResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Wallet/AddressBalanceResponseModel.cs
@@ -24,4 +24,16 @@ public class AddressBalanceResponseModel
     /// </summary>
     /// <example>t8WntmWKiLs1BdzoqPGXmPAYzUTpPb3DBw</example>
     public Address Token { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Wallet/MiningPositionResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Wallet/MiningPositionResponseModel.cs
@@ -30,4 +30,16 @@ public class MiningPositionResponseModel
     /// </summary>
     /// <example>tMdZ2UfwJorAyErDvqNdVU8kmiLaykuE5L</example>
     public Address MiningToken { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/Wallet/StakingPositionResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Wallet/StakingPositionResponseModel.cs
@@ -30,4 +30,16 @@ public class StakingPositionResponseModel
     /// </summary>
     /// <example>tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c</example>
     public Address StakingToken { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity was created.
+    /// </summary>
+    /// <example>2500000</example>
+    public ulong CreatedBlock { get; set; }
+
+    /// <summary>
+    /// Block number at which the entity state was last modified.
+    /// </summary>
+    /// <example>3000000</example>
+    public ulong ModifiedBlock { get; set; }
 }

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Markets.Summaries;
 
 public class SelectMarketSummaryByMarketIdQueryHandlerTests
 {
-     private readonly Mock<IDbContext> _dbContext;
+    private readonly Mock<IDbContext> _dbContext;
     private readonly SelectMarketSummaryByMarketIdQueryHandler _handler;
 
     public SelectMarketSummaryByMarketIdQueryHandlerTests()
@@ -83,7 +83,7 @@ public class SelectMarketSummaryByMarketIdQueryHandlerTests
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(MarketSummary)} not found.");
+            .WithMessage("Market summary not found.");
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningGovernances/SelectMiningGovernanceByAddressQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningGovernances/SelectMiningGovernanceByAddressQueryHandlerTests.cs
@@ -71,7 +71,7 @@ public class SelectMiningGovernanceByAddressQueryHandlerTests
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(MiningGovernance)} not found.");
+            .WithMessage("Mining governance not found.");
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningGovernances/SelectMiningGovernanceByTokenIdQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningGovernances/SelectMiningGovernanceByTokenIdQueryHandlerTests.cs
@@ -68,7 +68,7 @@ public class SelectMiningGovernanceByTokenIdQueryHandlerTests
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(MiningGovernance)} not found.");
+            .WithMessage("Mining governance not found.");
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningPools/SelectMiningPoolByAddressQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningPools/SelectMiningPoolByAddressQueryHandlerTests.cs
@@ -74,7 +74,7 @@ public class SelectMiningPoolByAddressQueryHandlerTests
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(MiningPool)} not found.");
+            .WithMessage("Mining pool not found.");
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningPools/SelectMiningPoolByLiquidityPoolIdQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/MiningPools/SelectMiningPoolByLiquidityPoolIdQueryHandlerTests.cs
@@ -73,7 +73,7 @@ public class SelectMiningPoolByLiquidityPoolIdQueryHandlerTests
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(MiningPool)} not found.");
+            .WithMessage("Mining pool not found.");
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Vaults/Pledges/SelectVaultProposalPledgeByVaultIdAndProposalIdAndPledgerQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Vaults/Pledges/SelectVaultProposalPledgeByVaultIdAndProposalIdAndPledgerQueryHandlerTests.cs
@@ -78,7 +78,7 @@ public class SelectVaultProposalPledgeByVaultIdAndProposalIdAndPledgerQueryHandl
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(VaultProposalPledge)} not found.");
+            .WithMessage("Proposal pledge not found.");
     }
 
     [Fact]

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Vaults/Proposals/SelectVaultProposalByIdQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Vaults/Proposals/SelectVaultProposalByIdQueryHandlerTests.cs
@@ -89,7 +89,7 @@ public class SelectVaultProposalByIdQueryHandlerTests
         _handler.Invoking(h => h.Handle(command, CancellationToken.None))
             .Should()
             .ThrowAsync<NotFoundException>()
-            .WithMessage($"{nameof(VaultProposal)} not found.");
+            .WithMessage("Proposal not found.");
     }
 
     [Fact]


### PR DESCRIPTION
Includes Created + Modified block in:
* Market response
* Liquidity Pool response
* Mining Pool response
* (Market)Token response
* MiningGovernance response
* Vault response
* Certificate response
* Proposal response
* Pledge response
* Vote response
* Address balance response
* Mining position response
* Staking position response

Includes Modified block in:
* Market summary response
* Liquidity pool summary response
* Token summary response

\+ changed some of the not found exception messages so they're more readable, as they are returned in 404 responses