### PR TITLE
[PAPI-354] Market and liquidity pool response cleanup

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1890,6 +1890,8 @@ components:
           $ref: "#/components/schemas/tokenResponse"
         lp:
           $ref: "#/components/schemas/tokenResponse"
+        staking:
+          $ref: "#/components/schemas/tokenResponse"
     liquidityPoolSummary:
       type: object
       properties:
@@ -1944,8 +1946,6 @@ components:
     liquidityPoolStakingSummary:
       type: object
       properties:
-        token:
-          $ref: "#/components/schemas/marketTokenResponse"
         weight:
           $ref: "#/components/schemas/fixedDecimal"
           description: Total number of tokens staking
@@ -2065,12 +2065,9 @@ components:
         owner:
           $ref: "#/components/schemas/address"
           description: Address of the market owner
-        crsToken:
-          $ref: "#/components/schemas/tokenResponse"
-          description: Details of the CRS token
-        stakingToken:
-          $ref: "#/components/schemas/tokenResponse"
-          description: Details of the staking token
+        tokens:
+          $ref: "#/components/schemas/marketTokenBreakdown"
+          description: Details of tokens that are tied to a market
         authPoolCreators:
           type: boolean
           description: Whether the market owner authorizes liquidity pool creators
@@ -2101,6 +2098,16 @@ components:
         summary:
           $ref: "#/components/schemas/marketSummary"
           description: Financial summary for the market
+    marketTokenBreakdown:
+      type: object
+      description: Details of tokens that are tied to a market
+      properties:
+        crs:
+          $ref: "#/components/schemas/tokenResponse"
+          description: Details of the CRS token
+        staking:
+          $ref: "#/components/schemas/tokenResponse"
+          description: Details of the staking token
     marketSummary:
       type: object
       properties:
@@ -3451,6 +3458,22 @@ paths:
                           priceUsd: 323.92670749
                           dailyPriceChangePercent: 0.21000000
                           modifiedBlock: 3043250
+                      staking:
+                        address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                        name: Testnet Opdex Token
+                        symbol: TODX
+                        decimals: 8
+                        sats: 100000000
+                        totalSupply: "400000000.00000000"
+                        attributes:
+                          - NonProvisional
+                          - Staking
+                        createdBlock: 2988890
+                        modifiedBlock: 2989018
+                        summary:
+                          priceUsd: 0.00000000
+                          dailyPriceChangePercent: 0.00000000
+                          modifiedBlock: 3043278
                     miningPool:
                       address: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
                       liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
@@ -3477,24 +3500,6 @@ paths:
                         crsPerSrc: "31211.01244732"
                         srcPerCrs: "0.00003203"
                       staking:
-                        token:
-                          market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                          liquidityPool: tGS4ad4E1eNXcKxoke3t7v5zQtjMpeRQ3U
-                          address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
-                          name: Testnet Opdex Token
-                          symbol: TODX
-                          decimals: 8
-                          sats: 100000000
-                          totalSupply: "400000000.00000000"
-                          attributes:
-                            - NonProvisional
-                            - Staking
-                          createdBlock: 2988890
-                          modifiedBlock: 2989018
-                          summary:
-                            priceUsd: 0.00000000
-                            dailyPriceChangePercent: 0.00000000
-                            modifiedBlock: 3043278
                         weight: "0.00000000"
                         usd: 0.00000000
                         dailyWeightChangePercent: 0.00000000
@@ -3666,6 +3671,22 @@ paths:
                       priceUsd: 323.92670749
                       dailyPriceChangePercent: 0.21000000
                       modifiedBlock: 3043250
+                  staking:
+                    address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                    name: Testnet Opdex Token
+                    symbol: TODX
+                    decimals: 8
+                    sats: 100000000
+                    totalSupply: "400000000.00000000"
+                    attributes:
+                      - NonProvisional
+                      - Staking
+                    createdBlock: 2988890
+                    modifiedBlock: 2989018
+                    summary:
+                      priceUsd: 0.00000000
+                      dailyPriceChangePercent: 0.00000000
+                      modifiedBlock: 3043278
                 miningPool:
                   address: tRs6rXfHuLhKZhWuWpycLASzAyn4kXo6bT
                   liquidityPool: tVFhXcS3gVb49MSTsaDFoqkxLrAUiNEN7n
@@ -3692,24 +3713,6 @@ paths:
                     crsPerSrc: "31211.01244732"
                     srcPerCrs: "0.00003203"
                   staking:
-                    token:
-                      market: t7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb
-                      liquidityPool: tGS4ad4E1eNXcKxoke3t7v5zQtjMpeRQ3U
-                      address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
-                      name: Testnet Opdex Token
-                      symbol: TODX
-                      decimals: 8
-                      sats: 100000000
-                      totalSupply: "400000000.00000000"
-                      attributes:
-                        - NonProvisional
-                        - Staking
-                      createdBlock: 2988890
-                      modifiedBlock: 2989018
-                      summary:
-                        priceUsd: 0.00000000
-                        dailyPriceChangePercent: 0.00000000
-                        modifiedBlock: 3043278
                     weight: "0.00000000"
                     usd: 0.00000000
                     dailyWeightChangePercent: 0.00000000
@@ -4650,36 +4653,37 @@ paths:
                     authProviders: false
                     marketFeeEnabled: true
                     transactionFeePercent: 0.3
-                    crsToken:
-                      address: CRS
-                      name: Cirrus
-                      symbol: TCRS
-                      decimals: 8
-                      sats: 100000000
-                      totalSupply: "130000000.00000000"
-                      attributes: []
-                      createdBlock: 2988890
-                      modifiedBlock: 2988890
-                      summary:
-                        priceUsd: 0.95057037
-                        dailyPriceChangePercent: 0.63000000
-                        modifiedBlock: 3043278
-                    stakingToken:
-                      address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
-                      name: Testnet Opdex Token
-                      symbol: TODX
-                      decimals: 8
-                      sats: 100000000
-                      totalSupply: "40000000000000000.00000000"
-                      attributes:
-                        - NonProvisional
-                        - Staking
-                      createdBlock: 2988890
-                      modifiedBlock: 2989018
-                      summary:
-                        priceUsd: 0.00000000
-                        dailyPriceChangePercent: 0.00000000
-                        modifiedBlock: 3043278
+                    tokens:
+                      crs:
+                        address: CRS
+                        name: Cirrus
+                        symbol: TCRS
+                        decimals: 8
+                        sats: 100000000
+                        totalSupply: "130000000.00000000"
+                        attributes: []
+                        createdBlock: 2988890
+                        modifiedBlock: 2988890
+                        summary:
+                          priceUsd: 0.95057037
+                          dailyPriceChangePercent: 0.63000000
+                          modifiedBlock: 3043278
+                      staking:
+                        address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                        name: Testnet Opdex Token
+                        symbol: TODX
+                        decimals: 8
+                        sats: 100000000
+                        totalSupply: "40000000000000000.00000000"
+                        attributes:
+                          - NonProvisional
+                          - Staking
+                        createdBlock: 2988890
+                        modifiedBlock: 2989018
+                        summary:
+                          priceUsd: 0.00000000
+                          dailyPriceChangePercent: 0.00000000
+                          modifiedBlock: 3043278
                     createdBlock: 2988898
                     modifiedBlock: 2988898
                     summary:
@@ -4753,36 +4757,37 @@ paths:
                 authProviders: false
                 marketFeeEnabled: true
                 transactionFeePercent: 0.3
-                crsToken:
-                  address: CRS
-                  name: Cirrus
-                  symbol: TCRS
-                  decimals: 8
-                  sats: 100000000
-                  totalSupply: "130000000.00000000"
-                  attributes: []
-                  createdBlock: 2988890
-                  modifiedBlock: 2988890
-                  summary:
-                    priceUsd: 0.95057037
-                    dailyPriceChangePercent: 0.63000000
-                    modifiedBlock: 3043278
-                stakingToken:
-                  address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
-                  name: Testnet Opdex Token
-                  symbol: TODX
-                  decimals: 8
-                  sats: 100000000
-                  totalSupply: "40000000000000000.00000000"
-                  attributes:
-                    - NonProvisional
-                    - Staking
-                  createdBlock: 2988890
-                  modifiedBlock: 2989018
-                  summary:
-                    priceUsd: 0.00000000
-                    dailyPriceChangePercent: 0.00000000
-                    modifiedBlock: 3043278
+                tokens:
+                  crs:
+                    address: CRS
+                    name: Cirrus
+                    symbol: TCRS
+                    decimals: 8
+                    sats: 100000000
+                    totalSupply: "130000000.00000000"
+                    attributes: []
+                    createdBlock: 2988890
+                    modifiedBlock: 2988890
+                    summary:
+                      priceUsd: 0.95057037
+                      dailyPriceChangePercent: 0.63000000
+                      modifiedBlock: 3043278
+                  staking:
+                    address: tTTuKbCR2UnsEByXBp1ynBz91J2yz63h1c
+                    name: Testnet Opdex Token
+                    symbol: TODX
+                    decimals: 8
+                    sats: 100000000
+                    totalSupply: "40000000000000000.00000000"
+                    attributes:
+                      - NonProvisional
+                      - Staking
+                    createdBlock: 2988890
+                    modifiedBlock: 2989018
+                    summary:
+                      priceUsd: 0.00000000
+                      dailyPriceChangePercent: 0.00000000
+                      modifiedBlock: 3043278
                 createdBlock: 2988898
                 modifiedBlock: 2988898
                 summary:

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/LiquidityPoolDto.cs
@@ -16,6 +16,7 @@ public class LiquidityPoolDto
     public MarketTokenDto SrcToken { get; set; }
     public MarketTokenDto LpToken { get; set; }
     public TokenDto CrsToken { get; set; }
+    public MarketTokenDto StakingToken { get; set; }
     public MiningPoolDto MiningPool { get; set; }
     public LiquidityPoolSummaryDto Summary { get; set; }
 }

--- a/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/StakingDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/LiquidityPools/StakingDto.cs
@@ -5,7 +5,6 @@ namespace Opdex.Platform.Application.Abstractions.Models.LiquidityPools;
 
 public class StakingDto
 {
-    public MarketTokenDto Token { get; set; }
     public FixedDecimal Weight { get; set; }
     public decimal Usd { get; set; }
     public decimal DailyWeightChangePercent { get; set; }

--- a/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketDto.cs
@@ -7,7 +7,7 @@ public class MarketDto
 {
     public ulong Id { get; set; }
     public Address Address { get; set; }
-    public TokenDto StakingToken { get; set; }
+    public MarketTokenDto StakingToken { get; set; }
     public TokenDto CrsToken { get; set; }
     public Address PendingOwner { get; set; }
     public Address Owner { get; set; }

--- a/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/LiquidityPoolDtoAssembler.cs
@@ -53,8 +53,12 @@ public class LiquidityPoolDtoAssembler : IModelAssembler<LiquidityPool, Liquidit
         poolDto.CrsToken = await AssembleToken(Address.Cirrus);
         poolDto.SrcToken = await AssembleMarketToken(pool.SrcTokenId, market);
         poolDto.LpToken = await AssembleMarketToken(pool.LpTokenId, market);
-        var stakingToken = market.IsStakingMarket && pool.SrcTokenId != market.StakingTokenId ? await AssembleMarketToken(market.StakingTokenId, market) : null;
-        var stakingEnabled = stakingToken != null;
+        var stakingToken = market.IsStakingMarket && pool.SrcTokenId != market.StakingTokenId
+            ? await AssembleMarketToken(market.StakingTokenId, market)
+            : null;
+        poolDto.StakingToken = stakingToken;
+
+        var stakingEnabled = stakingToken is not null;
 
         // Calc rewards
         (decimal providerUsd, decimal marketUsd) = MathExtensions.VolumeBasedRewards(summary.VolumeUsd, summary.StakingWeight, stakingEnabled,
@@ -99,7 +103,6 @@ public class LiquidityPoolDtoAssembler : IModelAssembler<LiquidityPool, Liquidit
         poolDto.MiningPool = await _miningPoolAssembler.Assemble(miningPool);
         poolDto.Summary.Staking = new StakingDto
         {
-            Token = stakingToken,
             Weight = summary.StakingWeight.ToDecimal(stakingToken.Decimals),
             Usd = MathExtensions.TotalFiat(summary.StakingWeight, stakingToken.Summary.PriceUsd, stakingToken.Sats),
             DailyWeightChangePercent = summary.DailyStakingWeightChangePercent,

--- a/src/Opdex.Platform.Application/Assemblers/MarketDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/MarketDtoAssembler.cs
@@ -34,7 +34,12 @@ public class MarketDtoAssembler : IModelAssembler<Market, MarketDto>
         var marketDto = _mapper.Map<MarketDto>(market);
 
         var summary = await _mediator.Send(new RetrieveMarketSummaryByMarketIdQuery(market.Id, findOrThrow: false), CancellationToken.None);
-        if (summary is not null) marketDto.Summary = _mapper.Map<MarketSummaryDto>(summary);
+        if (summary is not null)
+        {
+            marketDto.Summary = _mapper.Map<MarketSummaryDto>(summary);
+            // remove staking summary from standard markets
+            if (!market.IsStakingMarket) marketDto.Summary.Staking = null;
+        }
 
         marketDto.CrsToken = await AssembleToken(Address.Cirrus);
 

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -141,6 +141,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.CrsToken))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.SrcToken))
             .ForMember(dest => dest.Lp, opt => opt.MapFrom(src => src.LpToken))
+            .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.StakingToken))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<LiquidityPoolsDto, LiquidityPoolsResponseModel>()
@@ -185,7 +186,6 @@ public class PlatformWebApiMapperProfile : Profile
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<StakingDto, StakingResponseModel>()
-            .ForMember(dest => dest.Token, opt => opt.MapFrom(src => src.Token))
             .ForMember(dest => dest.Weight, opt => opt.MapFrom(src => src.Weight))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
             .ForMember(dest => dest.DailyWeightChangePercent, opt => opt.MapFrom(src => src.DailyWeightChangePercent))
@@ -272,8 +272,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.PendingOwner, opt => opt.MapFrom(src => src.PendingOwner))
             .ForMember(dest => dest.Owner, opt => opt.MapFrom(src => src.Owner))
-            .ForMember(dest => dest.StakingToken, opt => opt.MapFrom(src => src.StakingToken))
-            .ForMember(dest => dest.CrsToken, opt => opt.MapFrom(src => src.CrsToken))
+            .ForMember(dest => dest.Tokens, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.AuthPoolCreators, opt => opt.MapFrom(src => src.AuthPoolCreators))
             .ForMember(dest => dest.AuthProviders, opt => opt.MapFrom(src => src.AuthProviders))
             .ForMember(dest => dest.AuthTraders, opt => opt.MapFrom(src => src.AuthTraders))
@@ -282,6 +281,11 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
+            .ForAllOtherMembers(opt => opt.Ignore());
+
+        CreateMap<MarketDto, MarketTokenGroupResponseModel>()
+            .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.CrsToken))
+            .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.StakingToken))
             .ForAllOtherMembers(opt => opt.Ignore());
 
         CreateMap<MarketsDto, MarketsResponseModel>()

--- a/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/LiquidityPoolTokenGroupResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/LiquidityPoolTokenGroupResponseModel.cs
@@ -21,4 +21,9 @@ public class LiquidityPoolTokenGroupResponseModel
     /// Pairing liquidity pool token details and pricing.
     /// </summary>
     public TokenResponseModel Lp { get; set; }
+
+    /// <summary>
+    /// Staking token details and pricing.
+    /// </summary>
+    public TokenResponseModel Staking { get; set; }
 }

--- a/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/Summary/StakingResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/LiquidityPools/Summary/StakingResponseModel.cs
@@ -10,11 +10,6 @@ namespace Opdex.Platform.WebApi.Models.Responses.LiquidityPools.Summary;
 public class StakingResponseModel
 {
     /// <summary>
-    /// The governance token used for staking.
-    /// </summary>
-    public MarketTokenResponseModel Token { get; set; }
-
-    /// <summary>
     /// Total number of tokens staking.
     /// </summary>
     /// <example>100000.0000000</example>

--- a/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketResponseModel.cs
@@ -27,14 +27,9 @@ public class MarketResponseModel
     public Address Owner { get; set; }
 
     /// <summary>
-    /// Token details about the markets staking token if exists.
+    /// Tokens involved in the market.
     /// </summary>
-    public TokenResponseModel StakingToken { get; set; }
-
-    /// <summary>
-    /// Token details of CRS.
-    /// </summary>
-    public TokenResponseModel CrsToken { get; set; }
+    public MarketTokenGroupResponseModel Tokens { get; set; }
 
     /// <summary>
     /// Flag determining if the market has a whitelist of addresses with create liquidity pool permissions.

--- a/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketTokenGroupResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketTokenGroupResponseModel.cs
@@ -1,0 +1,16 @@
+using Opdex.Platform.WebApi.Models.Responses.Tokens;
+
+namespace Opdex.Platform.WebApi.Models.Responses.Markets;
+
+public class MarketTokenGroupResponseModel
+{
+    /// <summary>
+    /// CRS token details and pricing.
+    /// </summary>
+    public TokenResponseModel Crs { get; set; }
+
+    /// <summary>
+    /// Staking token details and pricing.
+    /// </summary>
+    public TokenResponseModel Staking { get; set; }
+}

--- a/test/Opdex.Platform.Application.Tests/EntryHandlers/Markets/GetMarketsWithFilterQueryHandlerTests.cs
+++ b/test/Opdex.Platform.Application.Tests/EntryHandlers/Markets/GetMarketsWithFilterQueryHandlerTests.cs
@@ -353,7 +353,7 @@ public class GetMarketsWithFilterQueryHandlerTests
             MarketFeeEnabled = market.MarketFeeEnabled,
             Summary = new MarketSummaryDto(),
             CrsToken = new TokenDto(),
-            StakingToken = new TokenDto()
+            StakingToken = new MarketTokenDto()
         };
         return marketDto;
     }


### PR DESCRIPTION
Cleans up the market and liquidity pool responses so that they are structured in the same way. Makes it easier to consume data and store only what is cared for.

Also includes a fix so that no staking summary is returned for standard markets.