### PR TITLE
[PAPI-383] Retrieve transaction from Cirrus retries

### DIFF
--- a/src/Opdex.Platform.Application.Abstractions/Queries/Transactions/RetrieveCirrusTransactionByHashQuery.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Queries/Transactions/RetrieveCirrusTransactionByHashQuery.cs
@@ -6,6 +6,11 @@ namespace Opdex.Platform.Application.Abstractions.Queries.Transactions;
 
 public class RetrieveCirrusTransactionByHashQuery : IRequest<Transaction>
 {
+    /// <summary>
+    /// Creates a query to retrieve a Cirrus transaction by its hash
+    /// </summary>
+    /// <remarks>Expects to find the transaction, so will retry in the event of failure</remarks>
+    /// <param name="txHash">Hash of the transaction</param>
     public RetrieveCirrusTransactionByHashQuery(Sha256 txHash)
     {
         TxHash = txHash;

--- a/src/Opdex.Platform.Application/Handlers/Transactions/RetrieveCirrusTransactionByHashQueryHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/Transactions/RetrieveCirrusTransactionByHashQueryHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.SmartContracts;
 using Opdex.Platform.Application.Abstractions.Queries.Transactions;
 using Opdex.Platform.Domain.Models.Transactions;
@@ -14,21 +15,27 @@ namespace Opdex.Platform.Application.Handlers.Transactions;
 public class RetrieveCirrusTransactionByHashQueryHandler : IRequestHandler<RetrieveCirrusTransactionByHashQuery, Transaction>
 {
     private readonly IMediator _mediator;
+    private readonly ILogger<RetrieveCirrusTransactionByHashQueryHandler> _logger;
 
     private readonly AsyncRetryPolicy _retryPolicy = Policy
         .Handle<HttpRequestException>()
         .Or<TaskCanceledException>()
         .WaitAndRetryAsync(3, x => TimeSpan.FromSeconds(x));
 
-    public RetrieveCirrusTransactionByHashQueryHandler(IMediator mediator)
+    public RetrieveCirrusTransactionByHashQueryHandler(IMediator mediator, ILogger<RetrieveCirrusTransactionByHashQueryHandler> logger)
     {
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<Transaction> Handle(RetrieveCirrusTransactionByHashQuery request, CancellationToken cancellationToken)
     {
         var query = await _retryPolicy.ExecuteAndCaptureAsync(
             async () => await _mediator.Send(new CallCirrusGetTransactionByHashQuery(request.TxHash), cancellationToken));
-        return query.Result;
+
+        if (query.Outcome == OutcomeType.Successful) return query.Result;
+
+        _logger.LogError("Transaction could not be retrieved from Cirrus");
+        return null;
     }
 }

--- a/src/Opdex.Platform.Application/Opdex.Platform.Application.csproj
+++ b/src/Opdex.Platform.Application/Opdex.Platform.Application.csproj
@@ -10,6 +10,7 @@
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+      <PackageReference Include="Polly" Version="7.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/BlockStoreModule.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/BlockStoreModule.cs
@@ -18,7 +18,7 @@ public class BlockStoreModule : ApiClientBase, IBlockStoreModule
     {
     }
 
-    public Task<BlockReceiptDto> GetBlockAsync(Sha256 blockHash, CancellationToken cancellationToken)
+    public async Task<BlockReceiptDto> GetBlockAsync(Sha256 blockHash, CancellationToken cancellationToken)
     {
         const bool outputJson = true;
         const bool showTransactionDetails = true;
@@ -31,16 +31,16 @@ public class BlockStoreModule : ApiClientBase, IBlockStoreModule
 
         using (_logger.BeginScope(logDetails))
         {
-            return GetAsync<BlockReceiptDto>(uri, cancellationToken);
+            return await GetAsync<BlockReceiptDto>(uri, cancellationToken: cancellationToken);
         }
     }
 
-    public Task<Sha256> GetBestBlockAsync(CancellationToken cancellationToken)
+    public async Task<Sha256> GetBestBlockAsync(CancellationToken cancellationToken)
     {
-        return GetAsync<Sha256>(CirrusUriHelper.Consensus.GetBestBlockHash, cancellationToken);
+        return await GetAsync<Sha256>(CirrusUriHelper.Consensus.GetBestBlockHash, cancellationToken: cancellationToken);
     }
 
-    public Task<Sha256> GetBlockHashAsync(ulong height, CancellationToken cancellationToken)
+    public async Task<Sha256> GetBlockHashAsync(ulong height, CancellationToken cancellationToken)
     {
         var uri = string.Format(CirrusUriHelper.Consensus.GetBlockHash, height);
 
@@ -51,13 +51,13 @@ public class BlockStoreModule : ApiClientBase, IBlockStoreModule
 
         using (_logger.BeginScope(logDetails))
         {
-            return GetAsync<Sha256>(uri, cancellationToken);
+            return await GetAsync<Sha256>(uri, cancellationToken: cancellationToken);
         }
     }
 
     public async Task<AddressesBalancesDto> GetWalletAddressesBalances(IEnumerable<Address> addresses, CancellationToken cancellationToken)
     {
         var uri = string.Format(CirrusUriHelper.BlockStore.GetAddressesBalances, string.Join(',', addresses));
-        return await GetAsync<AddressesBalancesDto>(uri, cancellationToken);
+        return await GetAsync<AddressesBalancesDto>(uri, cancellationToken: cancellationToken);
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/NodeModule.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/NodeModule.cs
@@ -17,13 +17,13 @@ public class NodeModule : ApiClientBase, INodeModule
     {
     }
 
-    public Task<NodeStatusDto> GetNodeStatusAsync(CancellationToken cancellationToken)
+    public async Task<NodeStatusDto> GetNodeStatusAsync(CancellationToken cancellationToken)
     {
-        return GetAsync<NodeStatusDto>(CirrusUriHelper.Node.Status, cancellationToken);
+        return await GetAsync<NodeStatusDto>(CirrusUriHelper.Node.Status, cancellationToken: cancellationToken);
     }
 
     public async Task<RawTransactionDto> GetRawTransactionAsync(Sha256 transactionHash, CancellationToken cancellationToken)
     {
-        return await GetAsync<RawTransactionDto>(string.Format(CirrusUriHelper.Node.GetRawTransaction, transactionHash, true), cancellationToken);
+        return await GetAsync<RawTransactionDto>(string.Format(CirrusUriHelper.Node.GetRawTransaction, transactionHash, true), cancellationToken: cancellationToken);
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/SmartContractsModule.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/SmartContractsModule.cs
@@ -21,10 +21,10 @@ public class SmartContractsModule : ApiClientBase, ISmartContractsModule
     {
     }
 
-    public Task<ContractCodeDto> GetContractCodeAsync(Address address, CancellationToken cancellationToken)
+    public async Task<ContractCodeDto> GetContractCodeAsync(Address address, CancellationToken cancellationToken)
     {
         var uri = string.Format(CirrusUriHelper.SmartContracts.GetContractCode, address);
-        return GetAsync<ContractCodeDto>(uri, cancellationToken);
+        return await GetAsync<ContractCodeDto>(uri, cancellationToken: cancellationToken);
     }
 
     public async Task<string> GetContractStorageAsync(Address address, string storageKey, SmartContractParameterType dataType,
@@ -34,29 +34,29 @@ public class SmartContractsModule : ApiClientBase, ISmartContractsModule
 
         if (blockHeight > 0) uri += $"&BlockHeight={blockHeight}";
 
-        return await GetAsync<string>(uri, cancellationToken);
+        return await GetAsync<string>(uri, cancellationToken: cancellationToken);
     }
 
-    public Task<string> GetContractBalanceAsync(Address address, CancellationToken cancellationToken)
+    public async Task<string> GetContractBalanceAsync(Address address, CancellationToken cancellationToken)
     {
         var uri = string.Format(CirrusUriHelper.SmartContracts.GetContractBalance, address);
-        return GetAsync<string>(uri, cancellationToken);
+        return await GetAsync<string>(uri, cancellationToken: cancellationToken);
     }
 
-    public Task<TransactionReceiptDto> GetReceiptAsync(Sha256 txHash, CancellationToken cancellationToken)
+    public async Task<TransactionReceiptDto> GetReceiptAsync(Sha256 txHash, CancellationToken cancellationToken)
     {
         var uri = string.Format(CirrusUriHelper.SmartContracts.GetTransactionReceipt, txHash);
-        return GetAsync<TransactionReceiptDto>(uri, cancellationToken);
+        return await GetAsync<TransactionReceiptDto>(uri, cancellationToken: cancellationToken);
     }
 
-    public Task<IEnumerable<TransactionReceiptDto>> ReceiptSearchAsync(Address contractAddress, string logName, ulong fromBlock,
+    public async Task<IEnumerable<TransactionReceiptDto>> ReceiptSearchAsync(Address contractAddress, string logName, ulong fromBlock,
                                                                        ulong? toBlock, CancellationToken cancellationToken)
     {
         var uri = string.Format(CirrusUriHelper.SmartContracts.GetContractReceiptSearch, contractAddress, logName, fromBlock);
 
         if (toBlock.GetValueOrDefault() > 0) uri += $"&to={toBlock}";
 
-        return GetAsync<IEnumerable<TransactionReceiptDto>>(uri, cancellationToken);
+        return await GetAsync<IEnumerable<TransactionReceiptDto>>(uri, cancellationToken: cancellationToken);
     }
 
     public async Task<LocalCallResponseDto> LocalCallAsync(LocalCallRequestDto request, CancellationToken cancellationToken)
@@ -77,7 +77,7 @@ public class SmartContractsModule : ApiClientBase, ISmartContractsModule
 
         using (_logger.BeginScope(logDetails))
         {
-            return await PostAsync<LocalCallResponseDto>(uri, httpRequest.Content, cancellationToken);
+            return await PostAsync<LocalCallResponseDto>(uri, httpRequest.Content, cancellationToken: cancellationToken);
         }
     }
 
@@ -98,7 +98,7 @@ public class SmartContractsModule : ApiClientBase, ISmartContractsModule
 
         using (_logger.BeginScope(logDetails))
         {
-            var response = await PostAsync<SmartContractCallResponseDto>(uri, httpRequest.Content, cancellationToken);
+            var response = await PostAsync<SmartContractCallResponseDto>(uri, httpRequest.Content, cancellationToken: cancellationToken);
             return response.TransactionId;
         }
     }
@@ -119,7 +119,7 @@ public class SmartContractsModule : ApiClientBase, ISmartContractsModule
 
         using (_logger.BeginScope(logDetails))
         {
-            var transactionHash = await PostAsync<Sha256>(uri, httpRequest.Content, cancellationToken);
+            var transactionHash = await PostAsync<Sha256>(uri, httpRequest.Content, cancellationToken: cancellationToken);
             return transactionHash;
         }
     }

--- a/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/WalletModule.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CirrusFullNodeApi/Modules/WalletModule.cs
@@ -30,7 +30,7 @@ public class WalletModule : ApiClientBase, IWalletModule
 
         using (_logger.BeginScope(logDetails))
         {
-            return await PostAsync<bool>(CirrusUriHelper.Wallet.VerifyMessage, httpRequest.Content, cancellationToken);
+            return await PostAsync<bool>(CirrusUriHelper.Wallet.VerifyMessage, httpRequest.Content, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Clients/CoinMarketCapApi/Modules/QuotesModule.cs
+++ b/src/Opdex.Platform.Infrastructure/Clients/CoinMarketCapApi/Modules/QuotesModule.cs
@@ -17,15 +17,15 @@ public class QuotesModule : ApiClientBase, IQuotesModule
     {
     }
 
-    public Task<CmcLatestQuote> GetLatestQuoteAsync(int tokenId, CancellationToken cancellationToken)
+    public async Task<CmcLatestQuote> GetLatestQuoteAsync(int tokenId, CancellationToken cancellationToken)
     {
         var uri = string.Format(CmcUriHelper.Quotes.Latest, tokenId);
-        return GetAsync<CmcLatestQuote>(uri, cancellationToken);
+        return await GetAsync<CmcLatestQuote>(uri, false, cancellationToken);
     }
 
-    public Task<CmcHistoricalQuote> GetHistoricalQuoteAsync(int tokenId, DateTime dateTime, CancellationToken cancellationToken)
+    public async Task<CmcHistoricalQuote> GetHistoricalQuoteAsync(int tokenId, DateTime dateTime, CancellationToken cancellationToken)
     {
         var uri = string.Format(CmcUriHelper.Quotes.Historical, tokenId, dateTime);
-        return GetAsync<CmcHistoricalQuote>(uri, cancellationToken);
+        return await GetAsync<CmcHistoricalQuote>(uri, false, cancellationToken);
     }
 }


### PR DESCRIPTION
* Resiliency improvements to retry retrieval of transactions from Cirrus
* Update module classes to not elide async/await (following [these recommendations](https://blog.stephencleary.com/2016/12/eliding-async-await.html))