### PR TITLE
[PAPI-387] Upgrade AutoMapper to v11

### DIFF
--- a/src/Opdex.Platform.Application/Assemblers/VaultCertificateDtoAssembler.cs
+++ b/src/Opdex.Platform.Application/Assemblers/VaultCertificateDtoAssembler.cs
@@ -1,10 +1,14 @@
 using AutoMapper;
 using MediatR;
 using Opdex.Platform.Application.Abstractions.Models.Vaults;
+using Opdex.Platform.Application.Abstractions.Queries.Tokens;
+using Opdex.Platform.Application.Abstractions.Queries.Vaults;
 using Opdex.Platform.Application.Abstractions.Queries.Vaults.ProposalCertificates;
 using Opdex.Platform.Application.Abstractions.Queries.Vaults.Proposals;
+using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Domain.Models.Vaults;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Opdex.Platform.Application.Assemblers;
@@ -23,6 +27,10 @@ public class VaultCertificateDtoAssembler: IModelAssembler<VaultCertificate, Vau
     public async Task<VaultCertificateDto> Assemble(VaultCertificate certificate)
     {
         var certificateDto = _mapper.Map<VaultCertificateDto>(certificate);
+
+        var vault = await _mediator.Send(new RetrieveVaultByIdQuery(certificate.VaultId), CancellationToken.None);
+        var governanceToken = await _mediator.Send(new RetrieveTokenByIdQuery(vault.TokenId), CancellationToken.None);
+        certificateDto.Amount = certificate.Amount.ToDecimal(governanceToken.Decimals);
 
         var proposalCertificates = await _mediator.Send(new RetrieveVaultProposalCertificatesByCertificateIdQuery(certificate.Id));
 

--- a/src/Opdex.Platform.Application/Opdex.Platform.Application.csproj
+++ b/src/Opdex.Platform.Application/Opdex.Platform.Application.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AutoMapper" Version="10.1.1" />
+      <PackageReference Include="AutoMapper" Version="11.0.1" />
       <PackageReference Include="MediatR" Version="9.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />

--- a/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
@@ -53,14 +53,14 @@ public class PlatformApplicationMapperProfile : Profile
         CreateMap<Admin, AdminDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Block, BlockDto>()
             .ForMember(dest => dest.Height, opt => opt.MapFrom(src => src.Height))
             .ForMember(dest => dest.Hash, opt => opt.MapFrom(src => src.Hash))
             .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.Time))
             .ForMember(dest => dest.MedianTime, opt => opt.MapFrom(src => src.MedianTime))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<IndexLock, IndexerStatusDto>()
             .ForMember(dest => dest.Available, opt => opt.MapFrom(src => src.Available))
@@ -68,7 +68,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.InstanceId, opt => opt.MapFrom(src => src.InstanceId))
             .ForMember(dest => dest.Reason, opt => opt.MapFrom(src => src.Reason))
             .ForMember(dest => dest.ModifiedDate, opt => opt.MapFrom(src => src.ModifiedDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Market, MarketDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -82,7 +82,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.TransactionFeePercent, opt => opt.MapFrom(src => src.TransactionFee == 0 ? 0 : Math.Round((decimal)src.TransactionFee / 10, 1)))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSummary, MarketSummaryDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -94,26 +94,26 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSummary, MarketStakingDto>()
             .ForMember(dest => dest.StakingWeight, opt => opt.MapFrom(src => src.StakingWeight.ToDecimal(TokenConstants.Opdex.Decimals)))
             .ForMember(dest => dest.DailyStakingWeightChangePercent, opt => opt.MapFrom(src => src.DailyStakingWeightChangePercent))
             .ForMember(dest => dest.StakingUsd, opt => opt.MapFrom(src => src.StakingUsd))
             .ForMember(dest => dest.DailyStakingUsdChangePercent, opt => opt.MapFrom(src => src.DailyStakingUsdChangePercent))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSummary, RewardsDto>()
             .ForMember(dest => dest.ProviderDailyUsd, opt => opt.MapFrom(src => src.ProviderRewardsDailyUsd))
             .ForMember(dest => dest.MarketDailyUsd, opt => opt.MapFrom(src => src.MarketRewardsDailyUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSummary, TokenSummaryDto>()
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.DailyPriceChangePercent, opt => opt.MapFrom(src => src.DailyPriceChangePercent))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Token, TokenDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -126,7 +126,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketToken, MarketTokenDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -140,7 +140,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Market, opt => opt.MapFrom(src => src.Market.Address))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenWrapped, WrappedTokenDetailsDto>()
             .ForMember(dest => dest.Custodian, opt => opt.MapFrom(src => src.Owner))
@@ -149,7 +149,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Validated, opt => opt.MapFrom(src => src.Validated))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPool, LiquidityPoolDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -157,26 +157,26 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Block, BlockDto>()
             .ForMember(dest => dest.Height, opt => opt.MapFrom(src => src.Height))
             .ForMember(dest => dest.Hash, opt => opt.MapFrom(src => src.Hash))
             .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.Time))
             .ForMember(dest => dest.MedianTime, opt => opt.MapFrom(src => src.MedianTime))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Ohlc<decimal>, OhlcDto<decimal>>()
             .ForMember(dest => dest.Open, opt => opt.MapFrom(src => src.Open))
             .ForMember(dest => dest.High, opt => opt.MapFrom(src => src.High))
             .ForMember(dest => dest.Low, opt => opt.MapFrom(src => src.Low))
             .ForMember(dest => dest.Close, opt => opt.MapFrom(src => src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSnapshot, TokenSnapshotDto>()
             .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.Price))
             .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.StartDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSnapshot, MarketSnapshotDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -187,7 +187,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src.Rewards))
             .ForMember(dest => dest.SnapshotType, opt => opt.MapFrom(src => src.SnapshotType))
             .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.StartDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<StakingSnapshot, StakingSnapshotDto>()
             .ForMember(dest => dest.Weight, opt => opt.MapFrom((src, ctx) => new OhlcDto<FixedDecimal>
@@ -198,21 +198,24 @@ public class PlatformApplicationMapperProfile : Profile
                 Close = src.Weight.Close.ToDecimal(TokenConstants.Opdex.Decimals)
             }))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<RewardsSnapshot, RewardsSnapshotDto>()
             .ForMember(dest => dest.ProviderUsd, opt => opt.MapFrom(src => src.ProviderUsd))
             .ForMember(dest => dest.MarketUsd, opt => opt.MapFrom(src => src.MarketUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressAllowance, AddressAllowanceDto>()
             .ForMember(dest => dest.Owner, opt => opt.MapFrom(src => src.Owner))
             .ForMember(dest => dest.Spender, opt => opt.MapFrom(src => src.Spender))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ForMember(dest => dest.Allowance, opt => opt.Ignore())
+            .ForMember(dest => dest.Token, opt => opt.Ignore())
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultCertificate, VaultCertificateDto>()
+            .ForMember(dest => dest.Amount, opt => opt.Ignore())
+            .ForMember(dest => dest.Proposals, opt => opt.Ignore())
             .ForMember(dest => dest.Owner, opt => opt.MapFrom(src => src.Owner))
-            .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount.ToDecimal(TokenConstants.Opdex.Decimals)))
             .ForMember(dest => dest.VestingStartBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.VestingEndBlock, opt => opt.MapFrom(src => src.VestedBlock))
             .ForMember(dest => dest.Redeemed, opt => opt.MapFrom(src => src.Redeemed))
@@ -221,14 +224,26 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock));
 
         CreateMap<Vault, VaultDto>()
+            .ForMember(dest => dest.Token, opt => opt.Ignore())
+            .ForMember(dest => dest.TokensLocked, opt => opt.Ignore())
+            .ForMember(dest => dest.TokensProposed, opt => opt.Ignore())
+            .ForMember(dest => dest.TokensUnassigned, opt => opt.Ignore())
+            .ForMember(dest => dest.TotalPledgeMinimum, opt => opt.MapFrom(src => src.TotalPledgeMinimum.ToDecimal(TokenConstants.Cirrus.Decimals)))
+            .ForMember(dest => dest.TotalVoteMinimum, opt => opt.MapFrom(src => src.TotalVoteMinimum.ToDecimal(TokenConstants.Cirrus.Decimals)))
             .ForMember(dest => dest.Vault, opt => opt.MapFrom(src => src.Address))
             .ForMember(dest => dest.VestingDuration, opt => opt.MapFrom(src => src.VestingDuration))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposal, VaultProposalDto>()
             .ForMember(dest => dest.ProposalId, opt => opt.MapFrom(src => src.PublicId))
+            .ForMember(dest => dest.Amount, opt => opt.Ignore())
+            .ForMember(dest => dest.YesAmount, opt => opt.Ignore())
+            .ForMember(dest => dest.NoAmount, opt => opt.Ignore())
+            .ForMember(dest => dest.PledgeAmount, opt => opt.Ignore())
+            .ForMember(dest => dest.Token, opt => opt.Ignore())
+            .ForMember(dest => dest.Vault, opt => opt.Ignore())
             .ForMember(dest => dest.Creator, opt => opt.MapFrom(src => src.Creator))
             .ForMember(dest => dest.Wallet, opt => opt.MapFrom(src => src.Wallet))
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
@@ -238,26 +253,36 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Approved, opt => opt.MapFrom(src => src.Approved))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalPledge, VaultProposalPledgeDto>()
+            .ForMember(dest => dest.ProposalId, opt => opt.Ignore())
+            .ForMember(dest => dest.Balance, opt => opt.Ignore())
+            .ForMember(dest => dest.Pledge, opt => opt.Ignore())
+            .ForMember(dest => dest.Vault, opt => opt.Ignore())
             .ForMember(dest => dest.Pledger, opt => opt.MapFrom(src => src.Pledger))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalVote, VaultProposalVoteDto>()
+            .ForMember(dest => dest.ProposalId, opt => opt.Ignore())
+            .ForMember(dest => dest.Balance, opt => opt.Ignore())
+            .ForMember(dest => dest.Vote, opt => opt.Ignore())
+            .ForMember(dest => dest.Vault, opt => opt.Ignore())
             .ForMember(dest => dest.Voter, opt => opt.MapFrom(src => src.Voter))
             .ForMember(dest => dest.InFavor, opt => opt.MapFrom(src => src.InFavor))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressBalance, AddressBalanceDto>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Owner))
+            .ForMember(dest => dest.Balance, opt => opt.Ignore())
+            .ForMember(dest => dest.Token, opt => opt.Ignore())
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         // Transactions and Transaction Events
 
@@ -269,7 +294,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.NewContractAddress, opt => opt.MapFrom(src => src.NewContractAddress))
             .ForMember(dest => dest.Success, opt => opt.MapFrom(src => src.Success))
             .ForMember(dest => dest.Error, opt => opt.MapFrom(src => src.Error))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionLog, TransactionEventDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -471,7 +496,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Error, opt => opt.MapFrom(src => src.Error))
             .ForMember(dest => dest.GasUsed, opt => opt.MapFrom(src => src.GasUsed))
             .ForMember(dest => dest.Request, opt => opt.MapFrom(src => src.Request))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionQuoteRequest, TransactionQuoteRequestDto>()
             .ForMember(dest => dest.Sender, opt => opt.MapFrom(src => src.Sender))
@@ -480,12 +505,12 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.Method, opt => opt.MapFrom(src => src.Method))
             .ForMember(dest => dest.Parameters, opt => opt.MapFrom(src => src.Parameters))
             .ForMember(dest => dest.Callback, opt => opt.MapFrom(src => src.Callback))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionQuoteRequestParameter, TransactionQuoteRequestParameterDto>()
             .ForMember(dest => dest.Label, opt => opt.MapFrom(src => src.Label))
             .ForMember(dest => dest.Value, opt => opt.MapFrom(src => src.Value.Serialize()))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionQuoteRequestDto, TransactionQuoteRequest>()
             .ConstructUsing((src, ctx) =>
@@ -493,10 +518,10 @@ public class PlatformApplicationMapperProfile : Profile
                 var parameters = src.Parameters.Select(p => ctx.Mapper.Map<TransactionQuoteRequestParameter>(p)).ToList();
                 return new TransactionQuoteRequest(src.Sender, src.To, src.Amount, src.Method, src.Callback, parameters);
             })
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionQuoteRequestParameterDto, TransactionQuoteRequestParameter>()
             .ConstructUsing(src => new TransactionQuoteRequestParameter(src.Label, SmartContractMethodParameter.Deserialize(src.Value)))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
     }
 }

--- a/src/Opdex.Platform.Infrastructure/Opdex.Platform.Infrastructure.csproj
+++ b/src/Opdex.Platform.Infrastructure/Opdex.Platform.Infrastructure.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AutoMapper" Version="10.1.1" />
+      <PackageReference Include="AutoMapper" Version="11.0.1" />
       <PackageReference Include="CoinGeckoAsyncApi" Version="1.5.5" />
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="MediatR" Version="9.0.0" />

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
@@ -47,180 +47,180 @@ public class PlatformInfrastructureMapperProfile : Profile
     {
         CreateMap<AuthSuccessEntity, AuthSuccess>()
             .ConstructUsing(src => new AuthSuccess(src.ConnectionId, src.Signer, src.Expiry))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AdminEntity, Admin>()
             .ConstructUsing(src => new Admin(src.Id, src.Address))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionEntity, Transaction>()
             .ConstructUsing(src => new Transaction(src.Id, src.Hash, src.Block, src.GasUsed, src.From, src.To, src.Success, src.Error, src.NewContractAddress))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenEntity, Token>()
             .ConstructUsing((src, ctx) => new Token(src.Id, src.Address, src.Name, src.Symbol, src.Decimals, src.Sats, src.TotalSupply, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenWrappedEntity, TokenWrapped>()
             .ConstructUsing(src => new TokenWrapped(src.Id, src.TokenId, src.Owner, (ExternalChainType)src.NativeChainTypeId, src.NativeAddress, src.Validated, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSummaryEntity, TokenSummary>()
             .ConstructUsing(src => new TokenSummary(src.Id, src.MarketId, src.TokenId, src.DailyPriceChangePercent, src.PriceUsd, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSnapshotEntity, TokenSnapshot>()
             .ConstructUsing((src, ctx) => new TokenSnapshot(src.Id, src.TokenId, src.MarketId, ctx.Mapper.Map<Ohlc<decimal>>(src.Price),
                                                             (SnapshotType)src.SnapshotTypeId, src.StartDate, src.EndDate, src.ModifiedDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenDistributionEntity, TokenDistribution>()
             .ConstructUsing(src => new TokenDistribution(src.Id, src.TokenId, src.VaultDistribution, src.MiningGovernanceDistribution, src.PeriodIndex,
                                                          src.DistributionBlock, src.NextDistributionBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenAttributeEntity, TokenAttribute>()
             .ConstructUsing(src => new TokenAttribute(src.Id, src.TokenId, (TokenAttributeType)src.AttributeTypeId))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<BlockEntity, Block>()
             .ConstructUsing(src => new Block(src.Height, src.Hash, src.Time, src.MedianTime))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolEntity, LiquidityPool>()
             .ConstructUsing(src => new LiquidityPool(src.Id, src.Address, src.Name, src.SrcTokenId, src.LpTokenId, src.MarketId, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSummaryEntity, LiquidityPoolSummary>()
             .ConstructUsing(src => new LiquidityPoolSummary(src.Id, src.LiquidityPoolId, src.LiquidityUsd, src.DailyLiquidityUsdChangePercent,
                                                             src.VolumeUsd, src.StakingWeight, src.DailyStakingWeightChangePercent, src.LockedCrs,
                                                             src.LockedSrc, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSnapshotEntity, LiquidityPoolSnapshot>()
             .ConstructUsing((src, ctx) => new LiquidityPoolSnapshot(src.Id, src.LiquidityPoolId, src.TransactionCount, ctx.Mapper.Map<ReservesSnapshot>(src.Reserves),
                                                                     ctx.Mapper.Map<RewardsSnapshot>(src.Rewards), ctx.Mapper.Map<StakingSnapshot>(src.Staking), ctx.Mapper.Map<VolumeSnapshot>(src.Volume),
                                                                     ctx.Mapper.Map<CostSnapshot>(src.Cost), (SnapshotType)src.SnapshotTypeId, src.StartDate, src.EndDate, src.ModifiedDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<SnapshotReservesEntity, ReservesSnapshot>()
             .ConstructUsing((src, ctx) => new ReservesSnapshot(ctx.Mapper.Map<Ohlc<ulong>>(src.Crs), ctx.Mapper.Map<Ohlc<UInt256>>(src.Src), ctx.Mapper.Map<Ohlc<decimal>>(src.Usd)))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<SnapshotRewardsEntity, RewardsSnapshot>()
             .ConstructUsing(src => new RewardsSnapshot(src.ProviderUsd, src.MarketUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<SnapshotStakingEntity, StakingSnapshot>()
             .ConstructUsing((src, ctx) => new StakingSnapshot(ctx.Mapper.Map<Ohlc<UInt256>>(src.Weight), ctx.Mapper.Map<Ohlc<decimal>>(src.Usd)))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<SnapshotVolumeEntity, VolumeSnapshot>()
             .ConstructUsing(src => new VolumeSnapshot(src.Crs, src.Src, src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<SnapshotCostEntity, CostSnapshot>()
             .ConstructUsing((src, ctx) => new CostSnapshot(ctx.Mapper.Map<Ohlc<UInt256>>(src.CrsPerSrc), ctx.Mapper.Map<Ohlc<UInt256>>(src.SrcPerCrs)))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<OhlcEntity<UInt256>, Ohlc<UInt256>>()
             .ConstructUsing(src => new Ohlc<UInt256>(src.Open, src.High, src.Low, src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<OhlcEntity<decimal>, Ohlc<decimal>>()
             .ConstructUsing(src => new Ohlc<decimal>(src.Open, src.High, src.Low, src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<OhlcEntity<ulong>, Ohlc<ulong>>()
             .ConstructUsing(src => new Ohlc<ulong>(src.Open, src.High, src.Low, src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningPoolEntity, MiningPool>()
             .ConstructUsing(src => new MiningPool(src.Id, src.LiquidityPoolId, src.Address, src.RewardPerBlock, src.RewardPerLpt, src.MiningPeriodEndBlock,
                                                   src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketEntity, Market>()
             .ConstructUsing(src => new Market(src.Id, src.Address, src.DeployerId, src.StakingTokenId, src.PendingOwner, src.Owner, src.AuthPoolCreators,
                                               src.AuthProviders, src.AuthTraders, src.TransactionFee, src.MarketFeeEnabled, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSummaryEntity, MarketSummary>()
             .ConstructUsing(src => new MarketSummary(src.Id, src.MarketId, src.LiquidityUsd, src.DailyLiquidityUsdChangePercent, src.VolumeUsd, src.StakingWeight,
                                 src.DailyStakingWeightChangePercent, src.StakingUsd, src.DailyStakingUsdChangePercent, src.ProviderRewardsDailyUsd, src.MarketRewardsDailyUsd,
                                 src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketPermissionEntity, MarketPermission>()
             .ConstructUsing(src => new MarketPermission(src.Id, src.MarketId, src.User, (MarketPermissionType)src.Permission, src.IsAuthorized, src.Blame,
                                                         src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketRouterEntity, MarketRouter>()
             .ConstructUsing(src => new MarketRouter(src.Id, src.Address, src.MarketId, src.IsActive, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningGovernanceEntity, MiningGovernance>()
             .ConstructUsing(src => new MiningGovernance(src.Id, src.Address, src.TokenId, src.NominationPeriodEnd, src.MiningDuration,
                                                         src.MiningPoolsFunded, src.MiningPoolReward, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningGovernanceNominationEntity, MiningGovernanceNomination>()
             .ConstructUsing(src => new MiningGovernanceNomination(src.Id, src.MiningGovernanceId, src.LiquidityPoolId, src.MiningPoolId, src.IsNominated, src.Weight, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<DeployerEntity, Deployer>()
             .ConstructUsing(src => new Deployer(src.Id, src.Address, src.PendingOwner, src.Owner, src.IsActive, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSnapshotEntity, MarketSnapshot>()
             .ConstructUsing((src, ctx) => new MarketSnapshot(src.Id, src.MarketId, ctx.Mapper.Map<Ohlc<decimal>>(src.LiquidityUsd), src.VolumeUsd,
                                                              ctx.Mapper.Map<StakingSnapshot>(src.Staking),
                                                              ctx.Mapper.Map<RewardsSnapshot>(src.Rewards),
                                                              (SnapshotType)src.SnapshotTypeId, src.StartDate, src.EndDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultCertificateEntity, VaultCertificate>()
             .ConstructUsing(src => new VaultCertificate(src.Id, src.VaultId, src.Owner, src.Amount, src.VestedBlock, src.Redeemed, src.Revoked,
                                                         src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalCertificateEntity, VaultProposalCertificate>()
             .ConstructUsing(src => new VaultProposalCertificate(src.Id, src.ProposalId, src.CertificateId))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressBalanceEntity, AddressBalance>()
             .ConstructUsing(src => new AddressBalance(src.Id, src.TokenId, src.Owner, src.Balance, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressMiningEntity, AddressMining>()
             .ConstructUsing(src => new AddressMining(src.Id, src.MiningPoolId, src.Owner, src.Balance, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressStakingEntity, AddressStaking>()
             .ConstructUsing(src => new AddressStaking(src.Id, src.LiquidityPoolId, src.Owner, src.Weight, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalEntity, VaultProposal>()
             .ConstructUsing(src => new VaultProposal(src.Id, src.PublicId, src.VaultId, src.Creator, src.Wallet, src.Amount, src.Description,
                                                      (VaultProposalType)src.ProposalTypeId, (VaultProposalStatus)src.ProposalStatusId, src.Expiration,
                                                      src.YesAmount, src.NoAmount, src.PledgeAmount, src.Approved, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalPledgeEntity, VaultProposalPledge>()
             .ConstructUsing(src => new VaultProposalPledge(src.Id, src.VaultId, src.ProposalId, src.Pledger, src.Pledge, src.Balance,
                                                            src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalVoteEntity, VaultProposalVote>()
             .ConstructUsing(src => new VaultProposalVote(src.Id, src.VaultId, src.ProposalId, src.Voter, src.Vote, src.Balance, src.InFavor,
                                                          src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultEntity, Vault>()
             .ConstructUsing(src => new Vault(src.Id, src.Address, src.TokenId, src.UnassignedSupply, src.VestingDuration, src.ProposedSupply,
                                                        src.TotalPledgeMinimum, src.TotalVoteMinimum, src.CreatedBlock, src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionLogEntity, TransactionLog>()
             .ConstructUsing((src, ctx) =>
@@ -283,7 +283,7 @@ public class PlatformInfrastructureMapperProfile : Profile
                     _ => null
                 };
             })
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionLogSummaryDto, TransactionLog>()
             .ConstructUsing((src, ctx) =>
@@ -351,12 +351,12 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.ConnectionId, opt => opt.MapFrom(src => src.ConnectionId))
             .ForMember(dest => dest.Signer, opt => opt.MapFrom(src => src.Signer))
             .ForMember(dest => dest.Expiry, opt => opt.MapFrom(src => src.Expiry))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Admin, AdminEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Market, MarketEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -372,7 +372,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.MarketFeeEnabled, opt => opt.MapFrom(src => src.MarketFeeEnabled))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSummary, MarketSummaryEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -388,7 +388,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.MarketRewardsDailyUsd, opt => opt.MapFrom(src => src.MarketRewardsDailyUsd))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketPermission, MarketPermissionEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -399,7 +399,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Blame, opt => opt.MapFrom(src => src.Blame))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketRouter, MarketRouterEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -408,7 +408,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSnapshot, MarketSnapshotEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -420,7 +420,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.SnapshotTypeId, opt => opt.MapFrom(src => (int)src.SnapshotType))
             .ForMember(dest => dest.StartDate, opt => opt.MapFrom(src => src.StartDate))
             .ForMember(dest => dest.EndDate, opt => opt.MapFrom(src => src.EndDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Deployer, DeployerEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -430,7 +430,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningGovernance, MiningGovernanceEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -442,7 +442,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.MiningPoolReward, opt => opt.MapFrom(src => src.MiningPoolReward))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningGovernanceNomination, MiningGovernanceNominationEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -453,7 +453,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Weight, opt => opt.MapFrom(src => src.Weight))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Token, TokenEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -465,7 +465,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.TotalSupply, opt => opt.MapFrom(src => src.TotalSupply))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenWrapped, TokenWrappedEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -476,7 +476,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Validated, opt => opt.MapFrom(src => src.Validated))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSummary, TokenSummaryEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -486,7 +486,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSnapshot, TokenSnapshotEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -496,7 +496,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.SnapshotTypeId, opt => opt.MapFrom(src => (int)src.SnapshotType))
             .ForMember(dest => dest.StartDate, opt => opt.MapFrom(src => src.StartDate))
             .ForMember(dest => dest.EndDate, opt => opt.MapFrom(src => src.EndDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenDistribution, TokenDistributionEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -506,13 +506,13 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.NextDistributionBlock, opt => opt.MapFrom(src => src.NextDistributionBlock))
             .ForMember(dest => dest.DistributionBlock, opt => opt.MapFrom(src => src.DistributionBlock))
             .ForMember(dest => dest.PeriodIndex, opt => opt.MapFrom(src => src.PeriodIndex))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenAttribute, TokenAttributeEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.TokenId, opt => opt.MapFrom(src => src.TokenId))
             .ForMember(dest => dest.AttributeTypeId, opt => opt.MapFrom(src => (uint)src.AttributeType))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPool, LiquidityPoolEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -523,7 +523,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.MarketId, opt => opt.MapFrom(src => src.MarketId))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSummary, LiquidityPoolSummaryEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -537,7 +537,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.LockedCrs, opt => opt.MapFrom(src => src.LockedCrs))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSnapshot, LiquidityPoolSnapshotEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -552,55 +552,55 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.StartDate, opt => opt.MapFrom(src => src.StartDate))
             .ForMember(dest => dest.EndDate, opt => opt.MapFrom(src => src.EndDate))
             .ForMember(dest => dest.ModifiedDate, opt => opt.MapFrom(src => src.ModifiedDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<ReservesSnapshot, SnapshotReservesEntity>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.Crs))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.Src))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<StakingSnapshot, SnapshotStakingEntity>()
             .ForMember(dest => dest.Weight, opt => opt.MapFrom(src => src.Weight))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VolumeSnapshot, SnapshotVolumeEntity>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.Crs))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.Src))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<RewardsSnapshot, SnapshotRewardsEntity>()
             .ForMember(dest => dest.ProviderUsd, opt => opt.MapFrom(src => src.ProviderUsd))
             .ForMember(dest => dest.MarketUsd, opt => opt.MapFrom(src => src.MarketUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<CostSnapshot, SnapshotCostEntity>()
             .ForMember(dest => dest.CrsPerSrc, opt => opt.MapFrom(src => src.CrsPerSrc))
             .ForMember(dest => dest.SrcPerCrs, opt => opt.MapFrom(src => src.SrcPerCrs))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Ohlc<ulong>, OhlcEntity<ulong>>()
             .ForMember(dest => dest.Open, opt => opt.MapFrom(src => src.Open))
             .ForMember(dest => dest.High, opt => opt.MapFrom(src => src.High))
             .ForMember(dest => dest.Low, opt => opt.MapFrom(src => src.Low))
             .ForMember(dest => dest.Close, opt => opt.MapFrom(src => src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Ohlc<UInt256>, OhlcEntity<UInt256>>()
             .ForMember(dest => dest.Open, opt => opt.MapFrom(src => src.Open))
             .ForMember(dest => dest.High, opt => opt.MapFrom(src => src.High))
             .ForMember(dest => dest.Low, opt => opt.MapFrom(src => src.Low))
             .ForMember(dest => dest.Close, opt => opt.MapFrom(src => src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Ohlc<decimal>, OhlcEntity<decimal>>()
             .ForMember(dest => dest.Open, opt => opt.MapFrom(src => src.Open))
             .ForMember(dest => dest.High, opt => opt.MapFrom(src => src.High))
             .ForMember(dest => dest.Low, opt => opt.MapFrom(src => src.Low))
             .ForMember(dest => dest.Close, opt => opt.MapFrom(src => src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningPool, MiningPoolEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -611,14 +611,14 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.MiningPeriodEndBlock, opt => opt.MapFrom(src => src.MiningPeriodEndBlock))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Block, BlockEntity>()
             .ForMember(dest => dest.Height, opt => opt.MapFrom(src => src.Height))
             .ForMember(dest => dest.Hash, opt => opt.MapFrom(src => src.Hash))
             .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.Time))
             .ForMember(dest => dest.MedianTime, opt => opt.MapFrom(src => src.MedianTime))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Transaction, TransactionEntity>()
             .ForMember(dest => dest.Block, opt => opt.MapFrom(src => src.BlockHeight))
@@ -629,7 +629,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Success, opt => opt.MapFrom(src => src.Success))
             .ForMember(dest => dest.Error, opt => opt.MapFrom(src => src.Error))
             .ForMember(dest => dest.NewContractAddress, opt => opt.MapFrom(src => src.NewContractAddress))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionLog, TransactionLogEntity>()
             .ForMember(dest => dest.TransactionId, opt => opt.MapFrom(src => src.TransactionId))
@@ -637,13 +637,13 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Contract, opt => opt.MapFrom(src => src.Contract))
             .ForMember(dest => dest.Details, opt => opt.MapFrom(src => src.SerializeLogDetails()))
             .ForMember(dest => dest.LogTypeId, opt => opt.MapFrom(src => (int)src.LogType))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalCertificate, VaultProposalCertificateEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.ProposalId, opt => opt.MapFrom(src => src.ProposalId))
             .ForMember(dest => dest.CertificateId, opt => opt.MapFrom(src => src.CertificateId))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultCertificate, VaultCertificateEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -655,7 +655,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Revoked, opt => opt.MapFrom(src => src.Revoked))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressBalance, AddressBalanceEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -664,7 +664,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressMining, AddressMiningEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -673,7 +673,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressStaking, AddressStakingEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -682,7 +682,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Weight, opt => opt.MapFrom(src => src.Weight))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposal, VaultProposalEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -701,7 +701,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Approved, opt => opt.MapFrom(src => src.Approved))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalPledge, VaultProposalPledgeEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -712,7 +712,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.Balance, opt => opt.MapFrom(src => src.Balance))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultProposalVote, VaultProposalVoteEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -724,7 +724,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.InFavor, opt => opt.MapFrom(src => src.InFavor))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Vault, VaultEntity>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
@@ -737,7 +737,7 @@ public class PlatformInfrastructureMapperProfile : Profile
             .ForMember(dest => dest.TotalVoteMinimum, opt => opt.MapFrom(src => src.TotalVoteMinimum))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<Interval, SnapshotType>()
             .ConvertUsing((src, ctx) =>

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -65,20 +65,20 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .AfterMap<TrustedBridgeMappingAction>()
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MinedTokenDistributionScheduleDto, MinedTokenDistributionScheduleResponseModel>()
             .ForMember(dest => dest.Vault, opt => opt.MapFrom(src => src.Vault))
             .ForMember(dest => dest.MiningGovernance, opt => opt.MapFrom(src => src.MiningGovernance))
             .ForMember(dest => dest.NextDistributionBlock, opt => opt.MapFrom(src => src.NextDistributionBlock))
             .ForMember(dest => dest.History, opt => opt.MapFrom(src => src.History))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MinedTokenDistributionItemDto, MinedTokenDistributionItemResponseModel>()
             .ForMember(dest => dest.Vault, opt => opt.MapFrom(src => src.Vault))
             .ForMember(dest => dest.MiningGovernance, opt => opt.MapFrom(src => src.MiningGovernance))
             .ForMember(dest => dest.Block, opt => opt.MapFrom(src => src.Block))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenDto, TokenResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
@@ -93,12 +93,12 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokensDto, TokensResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Tokens))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketTokenDto, MarketTokenResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
@@ -113,34 +113,34 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
             .ForMember(dest => dest.LiquidityPool, opt => opt.MapFrom(src => src.LiquidityPool))
             .ForMember(dest => dest.Market, opt => opt.MapFrom(src => src.Market))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketTokensDto, MarketTokensResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Tokens))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketTokenSnapshotsDto, MarketTokenSnapshotsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Snapshots))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSummaryDto, TokenSummaryResponseModel>()
             .ForMember(dest => dest.PriceUsd, opt => opt.MapFrom(src => src.PriceUsd))
             .ForMember(dest => dest.DailyPriceChangePercent, opt => opt.MapFrom(src => src.DailyPriceChangePercent))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSnapshotDto, TokenSnapshotResponseModel>()
             .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.Price))
             .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.Timestamp))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TokenSnapshotsDto, TokenSnapshotsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Snapshots))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolDto, LiquidityPoolResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
@@ -152,19 +152,19 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Tokens, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.MiningPool, opt => opt.MapFrom(src => src.MiningPool))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolDto, LiquidityPoolTokenGroupResponseModel>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.CrsToken))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.SrcToken))
             .ForMember(dest => dest.Lp, opt => opt.MapFrom(src => src.LpToken))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.StakingToken))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolsDto, LiquidityPoolsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.LiquidityPools))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSummaryDto, LiquidityPoolSummaryResponseModel>()
             .ForMember(dest => dest.Reserves, opt => opt.MapFrom(src => src.Reserves))
@@ -174,7 +174,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSnapshotDto, LiquidityPoolSnapshotResponseModel>()
             .ForMember(dest => dest.TransactionCount, opt => opt.MapFrom(src => src.TransactionCount))
@@ -184,69 +184,69 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Volume, opt => opt.MapFrom(src => src.Volume))
             .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
             .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.Timestamp))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<ReservesDto, ReservesResponseModel>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.Crs))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.Src))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
             .ForMember(dest => dest.DailyUsdChangePercent, opt => opt.MapFrom(src => src.DailyUsdChangePercent))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<RewardsDto, RewardsResponseModel>()
             .ForMember(dest => dest.ProviderDailyUsd, opt => opt.MapFrom(src => src.ProviderDailyUsd))
             .ForMember(dest => dest.MarketDailyUsd, opt => opt.MapFrom(src => src.MarketDailyUsd))
             .ForMember(dest => dest.TotalDailyUsd, opt => opt.MapFrom(src => src.ProviderDailyUsd + src.MarketDailyUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VolumeDto, VolumeResponseModel>()
             .ForMember(dest => dest.DailyUsd, opt => opt.MapFrom(src => src.DailyUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<StakingDto, StakingResponseModel>()
             .ForMember(dest => dest.Weight, opt => opt.MapFrom(src => src.Weight))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
             .ForMember(dest => dest.DailyWeightChangePercent, opt => opt.MapFrom(src => src.DailyWeightChangePercent))
             .ForMember(dest => dest.Nominated, opt => opt.MapFrom(src => src.Nominated))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<CostDto, CostResponseModel>()
             .ForMember(dest => dest.CrsPerSrc, opt => opt.MapFrom(src => src.CrsPerSrc))
             .ForMember(dest => dest.SrcPerCrs, opt => opt.MapFrom(src => src.SrcPerCrs))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<ReservesSnapshotDto, ReservesSnapshotResponseModel>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.Crs))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.Src))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<RewardsSnapshotDto, RewardsSnapshotResponseModel>()
             .ForMember(dest => dest.ProviderUsd, opt => opt.MapFrom(src => src.ProviderUsd))
             .ForMember(dest => dest.MarketUsd, opt => opt.MapFrom(src => src.MarketUsd))
             .ForMember(dest => dest.TotalUsd, opt => opt.MapFrom(src => src.MarketUsd + src.ProviderUsd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VolumeSnapshotDto, VolumeSnapshotResponseModel>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.Crs))
             .ForMember(dest => dest.Src, opt => opt.MapFrom(src => src.Src))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<StakingSnapshotDto, StakingSnapshotResponseModel>()
             .ForMember(dest => dest.Weight, opt => opt.MapFrom(src => src.Weight))
             .ForMember(dest => dest.Usd, opt => opt.MapFrom(src => src.Usd))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<CostSnapshotDto, CostSnapshotResponseModel>()
             .ForMember(dest => dest.CrsPerSrc, opt => opt.MapFrom(src => src.CrsPerSrc))
             .ForMember(dest => dest.SrcPerCrs, opt => opt.MapFrom(src => src.SrcPerCrs))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<LiquidityPoolSnapshotsDto, LiquidityPoolSnapshotsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Snapshots))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningPoolDto, MiningPoolResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
@@ -258,7 +258,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningPoolsDto, MiningPoolsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.MiningPools))
@@ -269,14 +269,14 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.High, opt => opt.MapFrom(src => src.High))
             .ForMember(dest => dest.Low, opt => opt.MapFrom(src => src.Low))
             .ForMember(dest => dest.Close, opt => opt.MapFrom(src => src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<OhlcDto<decimal>, OhlcDecimalResponseModel>()
             .ForMember(dest => dest.Open, opt => opt.MapFrom(src => src.Open))
             .ForMember(dest => dest.High, opt => opt.MapFrom(src => src.High))
             .ForMember(dest => dest.Low, opt => opt.MapFrom(src => src.Low))
             .ForMember(dest => dest.Close, opt => opt.MapFrom(src => src.Close))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSnapshotDto, MarketSnapshotResponseModel>()
             .ForMember(dest => dest.LiquidityUsd, opt => opt.MapFrom(src => src.LiquidityUsd))
@@ -284,7 +284,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src.Rewards))
             .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => src.Timestamp))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketDto, MarketResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
@@ -299,17 +299,17 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ForMember(dest => dest.Summary, opt => opt.MapFrom(src => src.Summary))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketDto, MarketTokenGroupResponseModel>()
             .ForMember(dest => dest.Crs, opt => opt.MapFrom(src => src.CrsToken))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.StakingToken))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketsDto, MarketsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Markets))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSummaryDto, MarketSummaryResponseModel>()
             .ForMember(dest => dest.LiquidityUsd, opt => opt.MapFrom(src => src.LiquidityUsd))
@@ -319,19 +319,19 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src.Rewards))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketStakingDto, MarketStakingResponseModel>()
             .ForMember(dest => dest.StakingWeight, opt => opt.MapFrom(src => src.StakingWeight))
             .ForMember(dest => dest.DailyStakingWeightChangePercent, opt => opt.MapFrom(src => src.DailyStakingWeightChangePercent))
             .ForMember(dest => dest.StakingUsd, opt => opt.MapFrom(src => src.StakingUsd))
             .ForMember(dest => dest.DailyStakingUsdChangePercent, opt => opt.MapFrom(src => src.DailyStakingUsdChangePercent))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketSnapshotsDto, MarketSnapshotsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Snapshots))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<AddressAllowanceDto, ApprovedAllowanceResponseModel>()
             .ForMember(dest => dest.Allowance, opt => opt.MapFrom(src => src.Allowance))
@@ -349,7 +349,7 @@ public class PlatformWebApiMapperProfile : Profile
         CreateMap<AddressBalancesDto, AddressBalancesResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Balances))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<StakingPositionDto, StakingPositionResponseModel>()
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Address))
@@ -386,7 +386,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.TotalRewardsPerPeriod, opt => opt.MapFrom(src => src.TotalRewardsPerPeriod))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<MiningGovernancesDto, MiningGovernancesResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.MiningGovernances))
@@ -397,7 +397,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Hash, opt => opt.MapFrom(src => src.Hash))
             .ForMember(dest => dest.Time, opt => opt.MapFrom(src => src.Time))
             .ForMember(dest => dest.MedianTime, opt => opt.MapFrom(src => src.MedianTime))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<BlocksDto, BlocksResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Blocks))
@@ -410,12 +410,12 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.InstanceId, opt => opt.MapFrom(src => src.InstanceId))
             .ForMember(dest => dest.Reason, opt => opt.MapFrom(src => src.Reason.IsValid() ? src.Reason : (IndexLockReason?)null))
             .ForMember(dest => dest.ModifiedDate, opt => opt.MapFrom(src => src.ModifiedDate))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<CursorDto, CursorResponseModel>()
             .ForMember(dest => dest.Next, opt => opt.MapFrom(src => src.Next))
             .ForMember(dest => dest.Previous, opt => opt.MapFrom(src => src.Previous))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<VaultCertificateDto, VaultCertificateResponseModel>()
             .ForMember(dest => dest.Owner, opt => opt.MapFrom(src => src.Owner))
@@ -501,7 +501,7 @@ public class PlatformWebApiMapperProfile : Profile
         CreateMap<TransactionsDto, TransactionsResponseModel>()
             .ForMember(dest => dest.Results, opt => opt.MapFrom(src => src.Transactions))
             .ForMember(dest => dest.Paging, opt => opt.MapFrom(src => src.Cursor))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         // Transaction
         CreateMap<TransactionDto, TransactionResponseModel>()
@@ -514,7 +514,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.To, opt => opt.MapFrom(src => src.To))
             .ForMember(dest => dest.Events, opt => opt.MapFrom(src => src.Events))
             .AfterMap<TransactionErrorMappingAction>()
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         // Transaction Events
         CreateMap<TransactionEventDto, TransactionEvent>()
@@ -705,7 +705,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Events, opt => opt.MapFrom(src => src.Events))
             .ForMember(dest => dest.Request, opt => opt.MapFrom(src => src.Request))
             .AfterMap<TransactionErrorMappingAction>()
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionQuoteRequestDto, QuotedTransactionModel>()
             .ForMember(dest => dest.Sender, opt => opt.MapFrom(src => src.Sender))
@@ -714,12 +714,12 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.Method, opt => opt.MapFrom(src => src.Method))
             .ForMember(dest => dest.Parameters, opt => opt.MapFrom(src => src.Parameters))
             .ForMember(dest => dest.Callback, opt => opt.MapFrom(src => src.Callback))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         CreateMap<TransactionQuoteRequestParameterDto, TransactionParameterModel>()
             .ForMember(dest => dest.Label, opt => opt.MapFrom(src => src.Label))
             .ForMember(dest => dest.Value, opt => opt.MapFrom(src => src.Value))
-            .ForAllOtherMembers(opt => opt.Ignore());
+            .ValidateMemberList(MemberList.None);
 
         // Vaults
         CreateMap<CompleteVaultProposalEventDto, CompleteVaultProposalEvent>()

--- a/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj
+++ b/src/Opdex.Platform.WebApi/Opdex.Platform.WebApi.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="AutoMapper" Version="11.0.1" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.1" />
         <PackageReference Include="Azure.Identity" Version="1.5.0" />
         <PackageReference Include="CcAcca.ApplicationInsights.ProblemDetails" Version="1.1.0" />

--- a/test/Opdex.Platform.Application.Tests/Mappers/AddressesPlatformApplicationMapperProfileTests.cs
+++ b/test/Opdex.Platform.Application.Tests/Mappers/AddressesPlatformApplicationMapperProfileTests.cs
@@ -1,7 +1,23 @@
 using FluentAssertions;
 using Opdex.Platform.Application.Abstractions.Models.Addresses;
+using Opdex.Platform.Application.Abstractions.Models.LiquidityPools;
+using Opdex.Platform.Application.Abstractions.Models.Markets;
+using Opdex.Platform.Application.Abstractions.Models.MarketTokens;
+using Opdex.Platform.Application.Abstractions.Models.Tokens;
+using Opdex.Platform.Application.Abstractions.Models.Transactions;
+using Opdex.Platform.Application.Abstractions.Models.Vaults;
+using Opdex.Platform.Common.Constants;
+using Opdex.Platform.Common.Extensions;
+using Opdex.Platform.Common.Models;
 using Opdex.Platform.Common.Models.UInt;
 using Opdex.Platform.Domain.Models.Addresses;
+using Opdex.Platform.Domain.Models.LiquidityPools;
+using Opdex.Platform.Domain.Models.Markets;
+using Opdex.Platform.Domain.Models.Tokens;
+using Opdex.Platform.Domain.Models.Transactions;
+using Opdex.Platform.Domain.Models.Vaults;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Opdex.Platform.Application.Tests.Mappers;
@@ -20,5 +36,263 @@ public class AddressesPlatformApplicationMapperProfileTests : PlatformApplicatio
         // Assert
         dto.Owner.Should().Be(model.Owner);
         dto.Spender.Should().Be(model.Spender);
+    }
+
+    [Fact]
+    public void From_AddressBalance_To_AddressBalanceDto()
+    {
+        // Arrange
+        var model = new AddressBalance(5, 5, "PQFv8x66vXEQEjw7ZBi8kCavrz15S1ShcG", 500000000, 5, 50);
+
+        // Act
+        var dto = _mapper.Map<AddressBalanceDto>(model);
+
+        // Assert
+        dto.Address.Should().Be(model.Owner);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_LiquidityPool_To_LiquidityPoolDto()
+    {
+        // Arrange
+        var model = new LiquidityPool(10, "PX2J4s4UHLfwZbDRJSvPoskKD25xQBHWYi", "BTC-CRS", 5, 15, 25, 500, 505);
+
+        // Act
+        var dto = _mapper.Map<LiquidityPoolDto>(model);
+
+        // Assert
+        dto.Id.Should().Be(model.Id);
+        dto.Address.Should().Be(model.Address);
+        dto.Name.Should().Be(model.Name);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_Market_To_MarketDto()
+    {
+        // Arrange
+        var model = new Market(10, "t3eYNv5BL2FAC3iS1PEGC4VsovkDgib1MD", 1, 5, Address.Empty, new Address("t7hy4H51KzU6PPCL4QKCdgBGPLV9Jpmf9G"), false, false, false, 3, true, 20, 25);
+
+        // Act
+        var dto = _mapper.Map<MarketDto>(model);
+
+        // Assert
+        dto.Id.Should().Be(model.Id);
+        dto.Address.Should().Be(model.Address);
+        dto.PendingOwner.Should().Be(model.PendingOwner);
+        dto.Owner.Should().Be(model.Owner);
+        dto.AuthProviders.Should().Be(model.AuthProviders);
+        dto.AuthTraders.Should().Be(model.AuthTraders);
+        dto.AuthPoolCreators.Should().Be(model.AuthPoolCreators);
+        dto.MarketFeeEnabled.Should().Be(model.MarketFeeEnabled);
+        dto.TransactionFeePercent.Should().Be(model.TransactionFee / 10m);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_MarketToken_To_MarketTokenDto()
+    {
+        // Arrange
+        var token = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        var market = new Market(19, "PAcm38V7iYnkfGPPGgCkN2kwXwmu3wuF5f", 2, 3, null, "nkfGPPGgMkN2kwXwmu3wuFYmPBWQ38k7iY", true, true, true, 3, true, 9, 10);
+        var model = new MarketToken(market, token);
+        model.SetSummary(new TokenSummary(5, market.Id, token.Id, 5.00m, 43.59m, 500, 1000));
+
+        // Act
+        var dto = _mapper.Map<MarketTokenDto>(model);
+
+        // Assert
+        dto.Id.Should().Be(model.Id);
+        dto.Address.Should().Be(model.Address);
+        dto.Market.Should().Be(model.Market.Address);
+        dto.Decimals.Should().Be(model.Decimals);
+        dto.Name.Should().Be(model.Name);
+        dto.Sats.Should().Be(model.Sats);
+        dto.Symbol.Should().Be(model.Symbol);
+        dto.TotalSupply.Should().Be(model.TotalSupply.ToDecimal(model.Decimals));
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+        dto.Summary.DailyPriceChangePercent.Should().Be(model.Summary.DailyPriceChangePercent);
+        dto.Summary.PriceUsd.Should().Be(model.Summary.PriceUsd);
+        dto.Summary.CreatedBlock.Should().Be(model.Summary.CreatedBlock);
+        dto.Summary.ModifiedBlock.Should().Be(model.Summary.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_Token_To_TokenDto()
+    {
+        // Arrange
+        var model = new Token(1, "PBWQ38k7iYnkfGPPGgMkN2kwXwmu3wuFYm", "STRAX", "STRAX", 8, 100_000_000, new UInt256("10000000000000000"), 9, 10);
+        model.SetSummary(new TokenSummary(5, 0, model.Id, 5.00m, 43.59m, 500, 1000));
+
+        // Act
+        var dto = _mapper.Map<TokenDto>(model);
+
+        // Assert
+        dto.Id.Should().Be(model.Id);
+        dto.Address.Should().Be(model.Address);
+        dto.Decimals.Should().Be(model.Decimals);
+        dto.Name.Should().Be(model.Name);
+        dto.Sats.Should().Be(model.Sats);
+        dto.Symbol.Should().Be(model.Symbol);
+        dto.TotalSupply.Should().Be(model.TotalSupply.ToDecimal(model.Decimals));
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+        dto.Summary.DailyPriceChangePercent.Should().Be(model.Summary.DailyPriceChangePercent);
+        dto.Summary.PriceUsd.Should().Be(model.Summary.PriceUsd);
+        dto.Summary.CreatedBlock.Should().Be(model.Summary.CreatedBlock);
+        dto.Summary.ModifiedBlock.Should().Be(model.Summary.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_Transaction_To_TransactionDto()
+    {
+        // Arrange
+        var model = new Transaction(1, new Sha256(5340958239), 2, 3, "PFrSHgtz2khDuciJdLAZtR2uKwgyXryMjM", "PVwyqbwu5CazeACoAMRonaQSyRvTHZvAUh", true, null, "PNvzq4pxJ5v3pp9kDaZyifKNspGD79E4qM");
+
+        // Act
+        var dto = _mapper.Map<TransactionDto>(model);
+
+        // Assert
+        dto.From.Should().Be(model.From);
+        dto.To.Should().Be(model.To);
+        dto.NewContractAddress.Should().Be(model.NewContractAddress);
+        dto.GasUsed.Should().Be(model.GasUsed);
+        dto.Success.Should().Be(model.Success);
+        dto.Error.Should().Be(model.Error);
+        dto.Hash.Should().Be(model.Hash);
+    }
+
+    [Fact]
+    public void From_TransactionQuote_To_TransactionQuoteDto()
+    {
+        // Arrange
+        Address walletAddress = "PWcdTKU64jVFCDoHJgUKz633jsy1XTenAy";
+        Address miningPool = "PBSH3FTVne6gKiSgVBL4NRTJ31QmGShjMy";
+        FixedDecimal crsToSend = FixedDecimal.Zero;
+
+        var expectedParameters = new List<TransactionQuoteRequestParameter>
+        {
+            new("Amount", UInt256.Parse("100000000"))
+        };
+
+        var expectedRequest = new TransactionQuoteRequest(walletAddress, miningPool, crsToSend, "methodName", "callback", expectedParameters);
+
+        var model = new TransactionQuote("1000", null, 23800, null, expectedRequest);
+
+        // Act
+        var dto = _mapper.Map<TransactionQuoteDto>(model);
+
+        // Assert
+        dto.Result.Should().Be(model.Result);
+        dto.GasUsed.Should().Be(model.GasUsed);
+        dto.Error.Should().Be(model.Error);
+        dto.Request.To.Should().Be(model.Request.To);
+        dto.Request.Amount.Should().Be(model.Request.Amount);
+        dto.Request.Callback.Should().Be(model.Request.Callback);
+        dto.Request.Method.Should().Be(model.Request.Method);
+        dto.Request.Sender.Should().Be(model.Request.Sender);
+        var dtoParameters = dto.Request.Parameters.ToList();
+        var modelParameters = model.Request.Parameters.ToList();
+        for (int i = 0; i < dto.Request.Parameters.Count; i++)
+        {
+            dtoParameters[i].Label.Should().Be(modelParameters[i].Label);
+            dtoParameters[i].Value.Should().Be(modelParameters[i].Value.Serialize());
+        }
+    }
+
+    [Fact]
+    public void From_VaultCertificate_To_VaultCertificateDto()
+    {
+        // Arrange
+        var model = new VaultCertificate(10, 10, "PAVV2c9Muk9Eu4wi8Fqdmm55ffzhAFPffV", UInt256.Parse("1000000000"), 10500, false, false, 500, 505);
+
+        // Act
+        var dto = _mapper.Map<VaultCertificateDto>(model);
+
+        // Assert
+        dto.Owner.Should().Be(model.Owner);
+        dto.Redeemed.Should().Be(model.Redeemed);
+        dto.Revoked.Should().Be(model.Revoked);
+        dto.VestingStartBlock.Should().Be(model.CreatedBlock);
+        dto.VestingEndBlock.Should().Be(model.VestedBlock);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_Vault_To_VaultDto()
+    {
+        // Arrange
+        var model = new Vault(10, "PMU9EjmivLgqqARwmH1iT1GLsMroh6zXXN", 10, 10000000000, 100000, 50000000, 10000000, 1000000000, 50, 500);
+
+        // Act
+        var dto = _mapper.Map<VaultDto>(model);
+
+        // Assert
+        dto.Vault.Should().Be(model.Address);
+        dto.VestingDuration.Should().Be(model.VestingDuration);
+        dto.TotalPledgeMinimum.Should().Be(model.TotalPledgeMinimum.ToDecimal(TokenConstants.Cirrus.Decimals));
+        dto.TotalVoteMinimum.Should().Be(model.TotalVoteMinimum.ToDecimal(TokenConstants.Cirrus.Decimals));
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_VaultProposal_To_VaultProposalDto()
+    {
+        // Arrange
+        var model = new VaultProposal(2, 5, 5, "PMU9EjmivLgqqARwmH1iT1GLsMroh6zXXN", "PMU9EjmivLgqqARwmH1iT1GLsMroh6zXXN", 50000000,
+                                         "Proposal description", VaultProposalType.Revoke, VaultProposalStatus.Pledge, 100000,
+                                         125000000, 40000000, 230000, true, 50, 500);
+        // Act
+        var dto = _mapper.Map<VaultProposalDto>(model);
+
+        // Assert
+        dto.ProposalId.Should().Be(model.PublicId);
+        dto.Approved.Should().Be(model.Approved);
+        dto.Creator.Should().Be(model.Creator);
+        dto.Description.Should().Be(model.Description);
+        dto.Expiration.Should().Be(model.Expiration);
+        dto.Status.Should().Be(model.Status);
+        dto.Type.Should().Be(model.Type);
+        dto.Wallet.Should().Be(model.Wallet);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_VaultProposalPledge_To_VaultProposalPledgeDto()
+    {
+        // Arrange
+        var model = new VaultProposalPledge(10, 5, 5, "tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm", 500000000000, 100000, 50, 500);
+
+        // Act
+        var dto = _mapper.Map<VaultProposalPledgeDto>(model);
+
+        // Assert
+        dto.Pledger.Should().Be(model.Pledger);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
+    }
+
+    [Fact]
+    public void From_VaultProposalVote_To_VaultProposalVoteDto()
+    {
+        // Arrange
+        var model = new VaultProposalVote(5, 5, 5, "tQ9RukZsB6bBsenHnGSo1q69CJzWGnxohm", 500000000000, 100000, true, 50, 500);
+
+        // Act
+        var dto = _mapper.Map<VaultProposalVoteDto>(model);
+
+        // Assert
+        dto.Voter.Should().Be(model.Voter);
+        dto.InFavor.Should().Be(model.InFavor);
+        dto.CreatedBlock.Should().Be(model.CreatedBlock);
+        dto.ModifiedBlock.Should().Be(model.ModifiedBlock);
     }
 }

--- a/test/Opdex.Platform.Infrastructure.Tests/SignalRTests/PlatformHubTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/SignalRTests/PlatformHubTests.cs
@@ -188,7 +188,6 @@ public class PlatformHubTests
         // Arrange
         var unixTime10MinsFromNow = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeSeconds();
         var previousConnectionId = "QU5FWENSWVBURURDT05ORUNUSU9OSUQ";
-        var connectionId = "GO73rdOHET7W1FAuWp96Tw205af2011";
         var uid = "JztkuBy8zCCHSoPBmQ1D9YEUnNGYmRGE8j6EshsLRiSIF2aYLQiemjKsfHtqBFEJhxLjwtGRrzS3CZk6MDxa0A";
         var stratisId = $"sid:v1-dev-api.opdex.com/v1/auth/callback?uid={uid}&exp={unixTime10MinsFromNow}";
 


### PR DESCRIPTION
AutoMapper v11 has breaking changes. See [upgrade guide](https://docs.automapper.org/en/latest/11.0-Upgrade-Guide.html#forallothermembers-was-removed). It is currently the only dependency that we have with breaking changes.

We can no longer use `ForAllOtherMembers`, so instead I've opted to replace this with `ValidateMemberList(MemberList.None)`, to keep the behaviour where unspecified properties do not cause a runtime exception.

Going forward, I believe it will be best to aim to explicitly ignore unmapped properties. This is required for properties where we have two properties of the same name, but with different types (for example, where we have an assembler, the mapping fails for Amount -> FixedDecimal and must be ignored).