### PR TITLE
[PAPI-390] Maintenance lock 

### DIFF
--- a/src/Opdex.Platform.WebApi/Exceptions/MaintenanceLockException.cs
+++ b/src/Opdex.Platform.WebApi/Exceptions/MaintenanceLockException.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Opdex.Platform.WebApi.Exceptions;
+
+public class MaintenanceLockException : Exception
+{
+}

--- a/src/Opdex.Platform.WebApi/MaintenanceConfiguration.cs
+++ b/src/Opdex.Platform.WebApi/MaintenanceConfiguration.cs
@@ -1,0 +1,6 @@
+namespace Opdex.Platform.WebApi;
+
+public class MaintenanceConfiguration
+{
+    public bool Locked { get; set; }
+}

--- a/src/Opdex.Platform.WebApi/Middleware/MaintenanceLockMiddleware.cs
+++ b/src/Opdex.Platform.WebApi/Middleware/MaintenanceLockMiddleware.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System;
+using System.Threading.Tasks;
+
+namespace Opdex.Platform.WebApi.Middleware;
+
+public class MaintenanceLockMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public MaintenanceLockMiddleware(RequestDelegate next)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));;
+    }
+
+    public async Task Invoke(HttpContext httpContext, IOptionsSnapshot<MaintenanceConfiguration> config)
+    {
+        if (!config.Value.Locked)
+        {
+            await _next(httpContext);
+            return;
+        }
+
+        httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+        await httpContext.Response.CompleteAsync();
+    }
+}

--- a/src/Opdex.Platform.WebApi/Middleware/MaintenanceLockMiddleware.cs
+++ b/src/Opdex.Platform.WebApi/Middleware/MaintenanceLockMiddleware.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Opdex.Platform.WebApi.Exceptions;
 using System;
 using System.Threading.Tasks;
 
@@ -16,13 +17,8 @@ public class MaintenanceLockMiddleware
 
     public async Task Invoke(HttpContext httpContext, IOptionsSnapshot<MaintenanceConfiguration> config)
     {
-        if (!config.Value.Locked)
-        {
-            await _next(httpContext);
-            return;
-        }
+        if (config.Value.Locked) throw new MaintenanceLockException();
 
-        httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-        await httpContext.Response.CompleteAsync();
+        await _next(httpContext);
     }
 }

--- a/src/Opdex.Platform.WebApi/Startup.cs
+++ b/src/Opdex.Platform.WebApi/Startup.cs
@@ -95,8 +95,9 @@ public class Startup
             });
             options.MapToStatusCode<NotImplementedException>(StatusCodes.Status501NotImplemented);
             options.Map<IndexingAlreadyRunningException>(e => new StatusCodeProblemDetails(StatusCodes.Status503ServiceUnavailable) { Detail = e.Message });
+            options.Map<MaintenanceLockException>(_ => new StatusCodeProblemDetails(StatusCodes.Status503ServiceUnavailable) { Detail = "Currently undergoing maintenance" });
             options.MapToStatusCode<Exception>(StatusCodes.Status500InternalServerError);
-            options.IncludeExceptionDetails = (context, ex) =>
+            options.IncludeExceptionDetails = (context, _) =>
             {
                 var environment = context.RequestServices.GetRequiredService<IHostEnvironment>();
                 return environment.IsDevelopment();

--- a/src/Opdex.Platform.WebApi/Startup.cs
+++ b/src/Opdex.Platform.WebApi/Startup.cs
@@ -189,6 +189,9 @@ public class Startup
 
         services.Configure<IndexerConfiguration>(Configuration.GetSection(nameof(IndexerConfiguration)));
 
+        // Maintenance Configurations
+        services.Configure<MaintenanceConfiguration>(Configuration.GetSection(nameof(MaintenanceConfiguration)));
+
         // Register project module services
         services.AddPlatformApplicationServices();
         services.AddPlatformInfrastructureServices(cirrusConfig.Get<CirrusConfiguration>(),
@@ -277,6 +280,7 @@ public class Startup
         app.UseSerilogRequestLogging();
         app.UseProblemDetails();
         app.UseMiddleware<RedirectToResourceMiddleware>();
+        app.UseMiddleware<MaintenanceLockMiddleware>();
         app.UseCors(options => options
                         .SetIsOriginAllowed(host => true)
                         .AllowAnyHeader()

--- a/src/Opdex.Platform.WebApi/appsettings.json
+++ b/src/Opdex.Platform.WebApi/appsettings.json
@@ -54,6 +54,9 @@
   "InterfluxConfiguration": {
     "MultiSigContractAddress": ""
   },
+  "MaintenanceConfiguration": {
+    "Locked": false
+  },
   "Azure": {
     "SignalR": {
       "ConnectionString": ""

--- a/test/Opdex.Platform.WebApi.Tests/Middleware/MaintenanceLockMiddlewareTests.cs
+++ b/test/Opdex.Platform.WebApi.Tests/Middleware/MaintenanceLockMiddlewareTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Moq;
+using Opdex.Platform.WebApi.Middleware;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.WebApi.Tests.Middleware;
+
+public class MaintenanceLockMiddlewareTests
+{
+    [Fact]
+    public async Task Invoke_MaintenanceLockFalse_ProcessRequest()
+    {
+        // Arrange
+        using var host = await CreateHost(maintenanceLock: false);
+
+        // Act
+        var response = await host.GetTestClient().GetAsync("/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Invoke_MaintenanceLockTrue_Return503ServiceUnavailable()
+    {
+        // Arrange
+        using var host = await CreateHost(maintenanceLock: true);
+
+        // Act
+        var response = await host.GetTestClient().GetAsync("/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    private static async Task<IHost> CreateHost(bool maintenanceLock)
+    {
+        var optionsSnapshotMock = new Mock<IOptionsSnapshot<MaintenanceConfiguration>>();
+        optionsSnapshotMock.Setup(callTo => callTo.Value)
+            .Returns(new MaintenanceConfiguration {Locked = maintenanceLock});
+
+        return await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        // registering configuration options like normal doesn't work, so mocking instead
+                        services.AddScoped(_ => optionsSnapshotMock.Object);
+                        services.AddRouting();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseMiddleware<MaintenanceLockMiddleware>();
+                        app.UseRouting();
+                        app.UseEndpoints(builder =>
+                        {
+                            builder.MapGet("/", async context =>
+                            {
+                                context.Response.StatusCode = StatusCodes.Status204NoContent;
+                                await context.Response.CompleteAsync();
+                            });
+                        });
+
+                    });
+            })
+            .StartAsync();
+    }
+}


### PR DESCRIPTION
Adds the ability to make the API unavailable through configuration, for precautionary measure