### PR TITLE
[PAPI-348] Allow cursor alongside filters

### DIFF
--- a/src/Opdex.Platform.WebApi/Validation/AbstractCursorValidator.cs
+++ b/src/Opdex.Platform.WebApi/Validation/AbstractCursorValidator.cs
@@ -1,41 +1,17 @@
 using FluentValidation;
-using FluentValidation.AspNetCore;
-using FluentValidation.Results;
-using Microsoft.AspNetCore.Mvc;
 using Opdex.Platform.Common.Extensions;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Queries;
 using Opdex.Platform.WebApi.Models.Requests;
 
 namespace Opdex.Platform.WebApi.Validation;
 
-public abstract class AbstractCursorValidator<T, TCursor> : AbstractValidator<T>, IValidatorInterceptor where T : FilterParameters<TCursor>
+public abstract class AbstractCursorValidator<T, TCursor> : AbstractValidator<T>
+    where T : FilterParameters<TCursor>
     where TCursor : Cursor
 {
     protected AbstractCursorValidator()
     {
         When(filter => filter.EncodedCursor.HasValue(),
              () => RuleFor(filter => filter.EncodedCursor).Must((filter, cursor) => filter.ValidateWellFormed()).WithMessage("Cursor not formed correctly."));
-    }
-
-    public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
-    {
-        return result;
-    }
-
-    public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
-    {
-        var queryParams = actionContext.HttpContext.Request.Query;
-        if (!queryParams.ContainsKey("cursor") || queryParams.Count == 1)
-        {
-            return commonContext;
-        }
-
-        foreach (var queryParam in queryParams.Keys)
-        {
-            if (queryParam.EqualsIgnoreCase("cursor")) continue;
-            actionContext.ModelState.AddModelError(queryParam, "Filters cannot be provided alongside cursor.");
-        }
-
-        return commonContext;
     }
 }


### PR DESCRIPTION
Removes validation for filter being provided alongside cursors. This makes it easier for certain clients to make paginated requests