### PR TITLE
[PAPI-397] Persist Attributes

### DIFF
--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateTokenCommandHandler.cs
@@ -8,6 +8,7 @@ using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Infrastructure.Abstractions.Clients.CirrusFullNodeApi.Queries.Tokens;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,7 +54,14 @@ public class CreateTokenCommandHandler : IRequestHandler<CreateTokenCommand, ulo
 
         if (tokenId == 0)
         {
-            _logger.LogError("Something went wrong indexing the token");
+            using (_logger.BeginScope(new Dictionary<string, object>
+                   {
+                       ["Address"] = request.Token
+                   }))
+            {
+                _logger.LogError("Something went wrong indexing the token");
+            }
+
             return tokenId;
         }
 

--- a/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateTokenCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Tokens/CreateTokenCommandHandler.cs
@@ -31,23 +31,25 @@ public class CreateTokenCommandHandler : IRequestHandler<CreateTokenCommand, ulo
         var token = await _mediator.Send(new RetrieveTokenByAddressQuery(request.Token, findOrThrow: false), CancellationToken.None);
         var tokenId = token?.Id ?? 0ul;
 
-        if (token is null)
+        if (token is not null)
         {
-            var summary = await _mediator.Send(new CallCirrusGetStandardTokenContractSummaryQuery(request.Token,
-                                                                                                  request.BlockHeight,
-                                                                                                  includeBaseProperties: true,
-                                                                                                  includeTotalSupply: true));
-
-            token = new Token(request.Token,
-                              summary.Name,
-                              summary.Symbol,
-                              (int)summary.Decimals.GetValueOrDefault(),
-                              summary.Sats.GetValueOrDefault(),
-                              summary.TotalSupply.GetValueOrDefault(),
-                              request.BlockHeight);
-
-            tokenId = await _mediator.Send(new MakeTokenCommand(token, request.BlockHeight), CancellationToken.None);
+            return tokenId;
         }
+
+        var summary = await _mediator.Send(new CallCirrusGetStandardTokenContractSummaryQuery(request.Token,
+                                                                                              request.BlockHeight,
+                                                                                              includeBaseProperties: true,
+                                                                                              includeTotalSupply: true));
+
+        token = new Token(request.Token,
+                          summary.Name,
+                          summary.Symbol,
+                          (int)summary.Decimals.GetValueOrDefault(),
+                          summary.Sats.GetValueOrDefault(),
+                          summary.TotalSupply.GetValueOrDefault(),
+                          request.BlockHeight);
+
+        tokenId = await _mediator.Send(new MakeTokenCommand(token, request.BlockHeight), CancellationToken.None);
 
         if (tokenId == 0)
         {

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/ProcessGovernanceDeploymentTransactionCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/ProcessGovernanceDeploymentTransactionCommandHandler.cs
@@ -33,7 +33,7 @@ public class ProcessGovernanceDeploymentTransactionCommandHandler : IRequestHand
     {
         try
         {
-            var transaction = await _mediator.Send(new RetrieveCirrusTransactionByHashQuery(request.TxHash), CancellationToken.None) ??
+            var transaction = await _mediator.Send(new RetrieveTransactionByHashQuery(request.TxHash, findOrThrow: false), CancellationToken.None) ??
                               await _mediator.Send(new RetrieveCirrusTransactionByHashQuery(request.TxHash), CancellationToken.None);
 
             if (transaction == null || transaction.Id > 0) return Unit.Value;
@@ -53,8 +53,8 @@ public class ProcessGovernanceDeploymentTransactionCommandHandler : IRequestHand
             await _mediator.Send(new CreateCrsTokenSnapshotsCommand(hashBlock.MedianTime, transaction.BlockHeight), CancellationToken.None);
 
             // Insert Staking Token
-            var stakingAttributes = new[] { TokenAttributeType.Staking };
-            var stakingTokenId = await _mediator.Send(new CreateTokenCommand(transaction.NewContractAddress, stakingAttributes, transaction.BlockHeight));
+            var attributes = new[] { TokenAttributeType.Staking, TokenAttributeType.NonProvisional };
+            var stakingTokenId = await _mediator.Send(new CreateTokenCommand(transaction.NewContractAddress, attributes, transaction.BlockHeight));
 
             // Get token summary
             var stakingTokenSummary = await _mediator.Send(new RetrieveStakingTokenContractSummaryQuery(transaction.NewContractAddress,

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/MarketDeployers/ProcessCreateMarketLogCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/MarketDeployers/ProcessCreateMarketLogCommandHandler.cs
@@ -48,8 +48,8 @@ public class ProcessCreateMarketLogCommandHandler : IRequestHandler<ProcessCreat
             Token stakingToken = null;
             if (!request.Log.StakingToken.IsZero)
             {
-                var stakingAttributes = new[] { TokenAttributeType.Staking };
-                var tokenId = await _mediator.Send(new CreateTokenCommand(request.Log.StakingToken, stakingAttributes, request.BlockHeight));
+                var attributes = new[] { TokenAttributeType.Staking, TokenAttributeType.NonProvisional };
+                var tokenId = await _mediator.Send(new CreateTokenCommand(request.Log.StakingToken, attributes, request.BlockHeight));
                 if (tokenId == 0)
                 {
                     _logger.LogError("Unable to create market staking token");

--- a/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/MarketDeployers/ProcessCreateMarketLogCommandHandler.cs
+++ b/src/Opdex.Platform.Application/EntryHandlers/Transactions/TransactionLogs/MarketDeployers/ProcessCreateMarketLogCommandHandler.cs
@@ -16,6 +16,7 @@ using Opdex.Platform.Common.Enums;
 using Opdex.Platform.Domain.Models.Markets;
 using Opdex.Platform.Domain.Models.Tokens;
 using Opdex.Platform.Domain.Models.TransactionLogs.MarketDeployers;
+using System.Collections.Generic;
 
 namespace Opdex.Platform.Application.EntryHandlers.Transactions.TransactionLogs.MarketDeployers;
 
@@ -52,7 +53,14 @@ public class ProcessCreateMarketLogCommandHandler : IRequestHandler<ProcessCreat
                 var tokenId = await _mediator.Send(new CreateTokenCommand(request.Log.StakingToken, attributes, request.BlockHeight));
                 if (tokenId == 0)
                 {
-                    _logger.LogError("Unable to create market staking token");
+                    using (_logger.BeginScope(new Dictionary<string, object>
+                           {
+                               ["Address"] = request.Log.StakingToken
+                           }))
+                    {
+                        _logger.LogError("Unable to create market staking token");
+                    }
+
                     return false;
                 }
 


### PR DESCRIPTION
When a pool was created, most of the time, we'd already know about the token through our validation process. 

When creating the pool and attempting to persist the SRC token, if it already exists, try to persist additional attributes rather than returning out early.

`MakeTokenAttributeCommand` will only attempt to persist attributes that are not already applied to the given token. 

Hide whitespace for easier review. 