### PR TITLE
[PAPI-394] Market liquidity pool count

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2199,6 +2199,11 @@ components:
         rewards:
           $ref: "#/components/schemas/rewardSummary"
           description: Rewards summary
+        liquidityPoolCount:
+          type: integer
+          format: uint32
+          minimum: 0
+          description: Number of liquidity pools in the market
         createdBlock:
           type: integer
           format: uint64
@@ -4867,6 +4872,7 @@ paths:
                         providerDailyUsd: "1205.00639582"
                         marketDailyUsd: "241.00127916"
                         totalDailyUsd: "1446.00767498"
+                      liquidityPoolCount: 8
                       createdBlock: 2988898
                       modifiedBlock: 3042951
                 paging: {}
@@ -4982,6 +4988,7 @@ paths:
                     providerDailyUsd: "1205.00639582"
                     marketDailyUsd: "241.00127916"
                     totalDailyUsd: "1446.00767498"
+                  liquidityPoolCount: 8
                   createdBlock: 2988898
                   modifiedBlock: 3042951
           headers:

--- a/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketSummaryDto.cs
+++ b/src/Opdex.Platform.Application.Abstractions/Models/Markets/MarketSummaryDto.cs
@@ -11,6 +11,7 @@ public class MarketSummaryDto
     public decimal VolumeUsd { get; set; }
     public MarketStakingDto Staking { get; set; }
     public RewardsDto Rewards { get; set; }
+    public uint LiquidityPoolCount { get; set; }
     public ulong CreatedBlock { get; set; }
     public ulong ModifiedBlock { get; set; }
 }

--- a/src/Opdex.Platform.Application/Handlers/LiquidityPools/MakeLiquidityPoolCommandHandler.cs
+++ b/src/Opdex.Platform.Application/Handlers/LiquidityPools/MakeLiquidityPoolCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Opdex.Platform.Application.Abstractions.Commands.LiquidityPools;
 using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.LiquidityPools;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,8 +17,10 @@ public class MakeLiquidityPoolCommandHandler : IRequestHandler<MakeLiquidityPool
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
-    public Task<ulong> Handle(MakeLiquidityPoolCommand request, CancellationToken cancellationToken)
+    public async Task<ulong> Handle(MakeLiquidityPoolCommand request, CancellationToken cancellationToken)
     {
-        return _mediator.Send(new PersistLiquidityPoolCommand(request.LiquidityPool));
+        var poolId = await _mediator.Send(new PersistLiquidityPoolCommand(request.LiquidityPool), CancellationToken.None);
+        await _mediator.Send(new ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(request.LiquidityPool.MarketId, request.LiquidityPool.CreatedBlock), CancellationToken.None);
+        return poolId;
     }
 }

--- a/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
+++ b/src/Opdex.Platform.Application/PlatformApplicationMapperProfile.cs
@@ -92,6 +92,7 @@ public class PlatformApplicationMapperProfile : Profile
             .ForMember(dest => dest.VolumeUsd, opt => opt.MapFrom(src => src.VolumeUsd))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src))
+            .ForMember(dest => dest.LiquidityPoolCount, opt => opt.MapFrom(src => src.LiquidityPoolCount))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ValidateMemberList(MemberList.None);

--- a/src/Opdex.Platform.Domain/Models/Markets/MarketSummary.cs
+++ b/src/Opdex.Platform.Domain/Models/Markets/MarketSummary.cs
@@ -14,7 +14,7 @@ public class MarketSummary : BlockAudit
 
     public MarketSummary(ulong id, ulong marketId, decimal liquidityUsd, decimal dailyLiquidityUsdChangePercent, decimal volumeUsd, ulong stakingWeight,
                          decimal dailyStakingWeightChangePercent, decimal stakingUsd, decimal dailyStakingUsdChangePercent, decimal providerRewardsDailyUsd,
-                         decimal marketRewardsDailyUsd, ulong liquidityPoolCount, ulong createdBlock, ulong modifiedBlock) : base(createdBlock, modifiedBlock)
+                         decimal marketRewardsDailyUsd, uint liquidityPoolCount, ulong createdBlock, ulong modifiedBlock) : base(createdBlock, modifiedBlock)
     {
         Id = id;
         MarketId = marketId;
@@ -41,7 +41,7 @@ public class MarketSummary : BlockAudit
     public decimal DailyStakingUsdChangePercent { get; private set; }
     public decimal ProviderRewardsDailyUsd { get; private set; }
     public decimal MarketRewardsDailyUsd { get; private set; }
-    public ulong LiquidityPoolCount { get; }
+    public uint LiquidityPoolCount { get; }
 
     public void Update(MarketSnapshot snapshot, ulong blockHeight)
     {

--- a/src/Opdex.Platform.Domain/Models/Markets/MarketSummary.cs
+++ b/src/Opdex.Platform.Domain/Models/Markets/MarketSummary.cs
@@ -14,7 +14,7 @@ public class MarketSummary : BlockAudit
 
     public MarketSummary(ulong id, ulong marketId, decimal liquidityUsd, decimal dailyLiquidityUsdChangePercent, decimal volumeUsd, ulong stakingWeight,
                          decimal dailyStakingWeightChangePercent, decimal stakingUsd, decimal dailyStakingUsdChangePercent, decimal providerRewardsDailyUsd,
-                         decimal marketRewardsDailyUsd, ulong createdBlock, ulong modifiedBlock) : base(createdBlock, modifiedBlock)
+                         decimal marketRewardsDailyUsd, ulong liquidityPoolCount, ulong createdBlock, ulong modifiedBlock) : base(createdBlock, modifiedBlock)
     {
         Id = id;
         MarketId = marketId;
@@ -27,6 +27,7 @@ public class MarketSummary : BlockAudit
         DailyStakingUsdChangePercent = dailyStakingUsdChangePercent;
         ProviderRewardsDailyUsd = providerRewardsDailyUsd;
         MarketRewardsDailyUsd = marketRewardsDailyUsd;
+        LiquidityPoolCount = liquidityPoolCount;
     }
 
     public ulong Id { get; }
@@ -40,6 +41,7 @@ public class MarketSummary : BlockAudit
     public decimal DailyStakingUsdChangePercent { get; private set; }
     public decimal ProviderRewardsDailyUsd { get; private set; }
     public decimal MarketRewardsDailyUsd { get; private set; }
+    public ulong LiquidityPoolCount { get; }
 
     public void Update(MarketSnapshot snapshot, ulong blockHeight)
     {

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Commands/Markets/ExecuteUpdateMarketSummaryLiquidityPoolCountCommand.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Commands/Markets/ExecuteUpdateMarketSummaryLiquidityPoolCountCommand.cs
@@ -1,0 +1,19 @@
+using MediatR;
+using System;
+
+namespace Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+
+public class ExecuteUpdateMarketSummaryLiquidityPoolCountCommand : IRequest<bool>
+{
+    public ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(ulong marketId, ulong blockHeight)
+    {
+        // a market id of 0 is valid for the procedure, but we never should use it
+        if (marketId == 0) throw new ArgumentOutOfRangeException(nameof(marketId), "Market id must be greater than 0");
+        if (blockHeight == 0) throw new ArgumentOutOfRangeException(nameof(blockHeight), "Block height must be greater than 0");
+        MarketId = marketId;
+        BlockHeight = blockHeight;
+    }
+
+    public ulong MarketId { get; }
+    public ulong BlockHeight { get; }
+}

--- a/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/Markets/MarketSummaryEntity.cs
+++ b/src/Opdex.Platform.Infrastructure.Abstractions/Data/Models/Markets/MarketSummaryEntity.cs
@@ -13,4 +13,5 @@ public class MarketSummaryEntity : AuditEntity
     public decimal DailyStakingUsdChangePercent { get; set; }
     public decimal ProviderRewardsDailyUsd { get; set; }
     public decimal MarketRewardsDailyUsd { get; set; }
+    public uint LiquidityPoolCount { get; set; }
 }

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler.cs
@@ -1,0 +1,49 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Opdex.Platform.Infrastructure.Data.Handlers.Markets.Summaries;
+
+public class ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler : IRequestHandler<ExecuteUpdateMarketSummaryLiquidityPoolCountCommand, bool>
+{
+    private const string SqlCommand = "UpdateMarketSummaryLiquidityPoolCount";
+
+    private readonly IDbContext _context;
+    private readonly ILogger _logger;
+
+    public ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler(IDbContext context, ILogger<ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> Handle(ExecuteUpdateMarketSummaryLiquidityPoolCountCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var command = DatabaseQuery.Create(SqlCommand, CommandType.StoredProcedure,new { marketId = request.MarketId, blockHeight = request.BlockHeight }, cancellationToken);
+
+            await _context.ExecuteCommandAsync(command);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            using (_logger.BeginScope(new Dictionary<string, object>
+            {
+               { nameof(request.MarketId), request.MarketId },
+               { nameof(request.BlockHeight), request.BlockHeight }
+            }))
+            {
+                _logger.LogError(ex, "Failed to update market summary liquidity pool count");
+                return false;
+            }
+        }
+    }
+}

--- a/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandler.cs
+++ b/src/Opdex.Platform.Infrastructure/Data/Handlers/Markets/Summaries/SelectMarketSummaryByMarketIdQueryHandler.cs
@@ -28,6 +28,7 @@ public class SelectMarketSummaryByMarketIdQueryHandler
                 {nameof(MarketSummaryEntity.DailyStakingUsdChangePercent)},
                 {nameof(MarketSummaryEntity.ProviderRewardsDailyUsd)},
                 {nameof(MarketSummaryEntity.MarketRewardsDailyUsd)},
+                {nameof(MarketSummaryEntity.LiquidityPoolCount)},
                 {nameof(MarketSummaryEntity.CreatedBlock)},
                 {nameof(MarketSummaryEntity.ModifiedBlock)}
             FROM market_summary

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureMapperProfile.cs
@@ -148,7 +148,7 @@ public class PlatformInfrastructureMapperProfile : Profile
         CreateMap<MarketSummaryEntity, MarketSummary>()
             .ConstructUsing(src => new MarketSummary(src.Id, src.MarketId, src.LiquidityUsd, src.DailyLiquidityUsdChangePercent, src.VolumeUsd, src.StakingWeight,
                                 src.DailyStakingWeightChangePercent, src.StakingUsd, src.DailyStakingUsdChangePercent, src.ProviderRewardsDailyUsd, src.MarketRewardsDailyUsd,
-                                src.CreatedBlock, src.ModifiedBlock))
+                                src.LiquidityPoolCount, src.CreatedBlock, src.ModifiedBlock))
             .ValidateMemberList(MemberList.None);
 
         CreateMap<MarketPermissionEntity, MarketPermission>()

--- a/src/Opdex.Platform.Infrastructure/PlatformInfrastructureServiceCollectionExtensions.cs
+++ b/src/Opdex.Platform.Infrastructure/PlatformInfrastructureServiceCollectionExtensions.cs
@@ -195,6 +195,7 @@ public static class PlatformInfrastructureServiceCollectionExtensions
         services.AddTransient<IRequestHandler<PersistLiquidityPoolCommand, ulong>, PersistLiquidityPoolCommandHandler>();
         services.AddTransient<IRequestHandler<PersistLiquidityPoolSnapshotCommand, bool>, PersistLiquidityPoolSnapshotCommandHandler>();
         services.AddTransient<IRequestHandler<PersistLiquidityPoolSummaryCommand, ulong>, PersistLiquidityPoolSummaryCommandHandler>();
+        services.AddTransient<IRequestHandler<ExecuteUpdateMarketSummaryLiquidityPoolCountCommand, bool>, ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler>();
 
         // Mining Pools
         services.AddTransient<IRequestHandler<PersistMiningPoolCommand, ulong>, PersistMiningPoolCommandHandler>();

--- a/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
+++ b/src/Opdex.Platform.WebApi/Mappers/PlatformWebApiMapperProfile.cs
@@ -317,6 +317,7 @@ public class PlatformWebApiMapperProfile : Profile
             .ForMember(dest => dest.VolumeUsd, opt => opt.MapFrom(src => src.VolumeUsd))
             .ForMember(dest => dest.Staking, opt => opt.MapFrom(src => src.Staking))
             .ForMember(dest => dest.Rewards, opt => opt.MapFrom(src => src.Rewards))
+            .ForMember(dest => dest.LiquidityPoolCount, opt => opt.MapFrom(src => src.LiquidityPoolCount))
             .ForMember(dest => dest.CreatedBlock, opt => opt.MapFrom(src => src.CreatedBlock))
             .ForMember(dest => dest.ModifiedBlock, opt => opt.MapFrom(src => src.ModifiedBlock))
             .ValidateMemberList(MemberList.None);

--- a/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketSummaryResponseModel.cs
+++ b/src/Opdex.Platform.WebApi/Models/Responses/Markets/MarketSummaryResponseModel.cs
@@ -33,6 +33,11 @@ public class MarketSummaryResponseModel
     public RewardsResponseModel Rewards { get; set; }
 
     /// <summary>
+    /// Number of liquidity pools in the market
+    /// </summary>
+    public uint LiquidityPoolCount { get; set; }
+
+    /// <summary>
     /// Block number at which the entity state was created.
     /// </summary>
     /// <example>2500000</example>

--- a/test/Opdex.Platform.Domain.Tests/Models/Markets/MarketSummaryTests.cs
+++ b/test/Opdex.Platform.Domain.Tests/Models/Markets/MarketSummaryTests.cs
@@ -19,7 +19,7 @@ public class MarketSummaryTests
         const ulong createdBlock = 7;
 
         // Act
-        void Act() => new MarketSummary(marketId, createdBlock);
+        void Act() => _ = new MarketSummary(marketId, createdBlock);
 
         // Assert
         Assert.Throws<ArgumentOutOfRangeException>(Act).Message.Should().Contain("MarketId must be greater than zero.");
@@ -42,10 +42,11 @@ public class MarketSummaryTests
         const decimal marketRewardsDailyUsd = 0.22m;
         const ulong createdBlock = 7;
         const ulong modifiedBlock = 8;
+        const int liquidityPoolCount = 50;
 
         // Act
         var result = new MarketSummary(id, marketId, liquidity, dailyLiquidityChange, volume, stakingWeight, dailyStakingChange, stakingUsd,
-                                       dailyStakingUsdChange, providerRewardsDailyUsd, marketRewardsDailyUsd, createdBlock, modifiedBlock);
+                                       dailyStakingUsdChange, providerRewardsDailyUsd, marketRewardsDailyUsd, liquidityPoolCount, createdBlock, modifiedBlock);
 
         // Assert
         result.Id.Should().Be(id);
@@ -58,6 +59,7 @@ public class MarketSummaryTests
         result.DailyStakingUsdChangePercent.Should().Be(dailyStakingUsdChange);
         result.ProviderRewardsDailyUsd.Should().Be(providerRewardsDailyUsd);
         result.MarketRewardsDailyUsd.Should().Be(marketRewardsDailyUsd);
+        result.LiquidityPoolCount.Should().Be(liquidityPoolCount);
         result.CreatedBlock.Should().Be(createdBlock);
         result.ModifiedBlock.Should().Be(modifiedBlock);
     }

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Markets/Summaries/ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Markets/Summaries/ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandlerTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Opdex.Platform.Infrastructure.Abstractions.Data;
+using Opdex.Platform.Infrastructure.Abstractions.Data.Commands.Markets;
+using Opdex.Platform.Infrastructure.Data.Handlers.Markets.Summaries;
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opdex.Platform.Infrastructure.Tests.Data.Handlers.Markets.Summaries;
+
+public class ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandlerTests
+{
+    private readonly Mock<IDbContext> _dbContext;
+    private readonly ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler _handler;
+
+    public ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandlerTests()
+    {
+        var logger = new NullLogger<ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler>();
+
+        _dbContext = new Mock<IDbContext>();
+        _handler = new ExecuteUpdateMarketSummaryLiquidityPoolCountCommandHandler(_dbContext.Object, logger);
+    }
+
+    [Fact]
+    public void ExecuteUpdateMarketSummaryLiquidityPoolCountCommand_MarketIdZero_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        // Act
+        static void Act() => _ = new ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(0, 5);
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(Act).ParamName.Should().Be("marketId");
+    }
+
+    [Fact]
+    public void ExecuteUpdateMarketSummaryLiquidityPoolCountCommand_BlockHeightZero_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        // Act
+        static void Act() => _ = new ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(5, 0);
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(Act).ParamName.Should().Be("blockHeight");
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateMarketSummaryLiquidityPoolCountCommand_Executes_StoredProcedure()
+    {
+        // Arrange
+        var command = new ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(5, 10);
+
+        // Act
+        try
+        {
+            await _handler.Handle(command, CancellationToken.None);
+        }
+        catch
+        {
+            // ignored
+        }
+
+        // Assert
+        _dbContext.Verify(callTo => callTo.ExecuteCommandAsync(It.Is<DatabaseQuery>(q => q.Parameters != null &&
+                                                                                         q.Type == CommandType.StoredProcedure &&
+                                                                                         q.Sql == "UpdateMarketSummaryLiquidityPoolCount")), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateMarketSummaryLiquidityPoolCountCommand_Success()
+    {
+        // Arrange
+        var command = new ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(5 , 10);
+
+        _dbContext.Setup(db => db.ExecuteCommandAsync(It.IsAny<DatabaseQuery>())).ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateMarketSummaryLiquidityPoolCountCommand_Fail()
+    {
+        // Arrange
+        var command = new ExecuteUpdateMarketSummaryLiquidityPoolCountCommand(5, 10);
+
+        _dbContext.Setup(db => db.ExecuteCommandAsync(It.IsAny<DatabaseQuery>())).ThrowsAsync(new Exception("Something went wrong"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Markets/Summaries/PersistMarketSummaryCommandHandlerTests.cs
+++ b/test/Opdex.Platform.Infrastructure.Tests/Data/Handlers/Markets/Summaries/PersistMarketSummaryCommandHandlerTests.cs
@@ -47,7 +47,7 @@ public class PersistMarketSummaryCommandHandlerTests
     public async Task Update_MarketSummary_SendsSqlCommand()
     {
         const ulong expectedId = 10ul;
-        var model = new MarketSummary(expectedId, 1, 2.00m, 4.5m, 3.00m, 4, 6.5m, 5, 7, 8, 9, 10, 11);
+        var model = new MarketSummary(expectedId, 1, 2.00m, 4.5m, 3.00m, 4, 6.5m, 5, 7, 8, 9, 50, 10, 11);
         var command = new PersistMarketSummaryCommand(model);
 
         try
@@ -79,7 +79,7 @@ public class PersistMarketSummaryCommandHandlerTests
     public async Task Update_MarketSummary_Returns()
     {
         const ulong expectedId = 10ul;
-        var model = new MarketSummary(expectedId, 1, 2.00m, 4.5m, 3.00m, 4, 6.5m, 5, 7, 8, 9, 10, 11);
+        var model = new MarketSummary(expectedId, 1, 2.00m, 4.5m, 3.00m, 4, 6.5m, 5, 7, 8, 9, 50, 10, 11);
         var command = new PersistMarketSummaryCommand(model);
 
         _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))
@@ -94,7 +94,7 @@ public class PersistMarketSummaryCommandHandlerTests
     public async Task PersistsMarketSummary_Fail()
     {
         const ulong expectedId = 0;
-        var model = new MarketSummary(expectedId, 1, 2.00m, 4.5m, 3.00m, 4, 6.5m, 5, 7, 8, 9, 10, 11);
+        var model = new MarketSummary(expectedId, 1, 2.00m, 4.5m, 3.00m, 4, 6.5m, 5, 7, 8, 9, 50, 10, 11);
         var command = new PersistMarketSummaryCommand(model);
 
         _dbContext.Setup(db => db.ExecuteScalarAsync<ulong>(It.IsAny<DatabaseQuery>()))


### PR DESCRIPTION
Returns the count of liquidity pools in a market as part of the market summary.
Depends on https://github.com/Opdex/opdex-v1-db/pull/41