### PR TITLE
[PAPI-399] Reduce AKV reload interval

### DIFF
--- a/src/Opdex.Platform.WebApi/Program.cs
+++ b/src/Opdex.Platform.WebApi/Program.cs
@@ -35,24 +35,22 @@ public class Program
         Log.CloseAndFlush();
     }
 
-    public static IHostBuilder CreateHostBuilder(string[] args) =>
+    private static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureAppConfiguration((context, config) =>
             {
-                if (context.HostingEnvironment.IsProduction())
-                {
-                    var builtConfig = config.Build();
-                    var manager = new KeyVaultSecretManager();
-                    var secretClient = new SecretClient(
-                        new Uri($"https://{builtConfig["Azure:KeyVault:Name"]}.vault.azure.net/"),
-                        new DefaultAzureCredential());
+                if (!context.HostingEnvironment.IsProduction()) return;
 
-                    config.AddAzureKeyVault(secretClient, new AzureKeyVaultConfigurationOptions
-                    {
-                        Manager = new KeyVaultSecretManager(),
-                        ReloadInterval = TimeSpan.FromMinutes(10)
-                    });
-                }
+                var builtConfig = config.Build();
+                var secretClient = new SecretClient(
+                    new Uri($"https://{builtConfig["Azure:KeyVault:Name"]}.vault.azure.net/"),
+                    new DefaultAzureCredential());
+
+                config.AddAzureKeyVault(secretClient, new AzureKeyVaultConfigurationOptions
+                {
+                    Manager = new KeyVaultSecretManager(),
+                    ReloadInterval = TimeSpan.FromSeconds(16)
+                });
             })
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); })
             .UseSerilog((context, services, loggingConfiguration) =>


### PR DESCRIPTION
The long reload interval makes it difficult to diagnose key vault caching issues. Reducing it won't be a problem because it doesn't consume a lot of resources and won't even get close to any Azure limits. Every 16 seconds matches with block time, so config changes _should_ get propagated for the following block.