### PR TITLE
[PAPI-398] Update CoinGecko client

### DIFF
--- a/src/Opdex.Platform.Infrastructure/Opdex.Platform.Infrastructure.csproj
+++ b/src/Opdex.Platform.Infrastructure/Opdex.Platform.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="AutoMapper" Version="11.0.1" />
-      <PackageReference Include="CoinGeckoAsyncApi" Version="1.5.5" />
+      <PackageReference Include="CoinGeckoAsyncApi" Version="1.6.0" />
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="MediatR" Version="10.0.1" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />


### PR DESCRIPTION
Resolves bug where price data was failing to deserialise if CoinGecko was used as pricing feed