### PR TITLE
Allow for null 'to' address when trx failed

### DIFF
--- a/src/Opdex.Platform.Domain/Models/Transactions/Transaction.cs
+++ b/src/Opdex.Platform.Domain/Models/Transactions/Transaction.cs
@@ -26,7 +26,7 @@ public class Transaction
             throw new ArgumentNullException(nameof(from), "From address must be set.");
         }
 
-        if (to == Address.Empty && newContractAddress == Address.Empty)
+        if (success && to == Address.Empty && newContractAddress == Address.Empty)
         {
             throw new ArgumentNullException(nameof(to), "To address must be set.");
         }


### PR DESCRIPTION
Fixes issues retrieving transactions where the execution ran out of gas, or the call was invalid. For example, processing the following receipt:

```json
{
  "transactionHash": "ad5df977f416e28264e9eff94794eccb1442d58a8a21478268f95e5b67f6168c",
  "blockHash": "19dcdb7f2c289675ede3a9bbd40ae3c68d8aa33b98f8d3493a49e3f83d272437",
  "blockNumber": 3427148,
  "postState": "f2ae9aaeafd85eddb25f9512d59cc4bf6bba3a391510cda135a0efb9b1fad8a6",
  "gasUsed": 12000,
  "from": "tLvZdzinedNTM8QCFR5XaQdcSUaQXn7HSm",
  "to": null,
  "newContractAddress": null,
  "success": false,
  "returnValue": null,
  "bloom": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  "error": "Execution ran out of gas.",
  "logs": []
}
```